### PR TITLE
Hacking in the buttonDown/buttonUp protocols, thus enabling Dragand-Drop...

### DIFF
--- a/lib/selenium/protocol.js
+++ b/lib/selenium/protocol.js
@@ -25,6 +25,29 @@ Actions.elementIdClick = function(id, callback) {
   return postRequest.call(this, "/element/" + id + "/click", '', callback);
 };
 
+function buttonHandler(that, direction, id, button, callback) {
+    var bi;
+    if (typeof button == 'function') {
+        callback = button;
+        button = 0;
+    }
+    if (typeof button == 'string') {
+        bi = ['left', 'middle', 'right'].indexOf(button.toLowerCase());
+        if (bi !== -1) {
+            button = bi;
+        }
+    }
+    return postRequest.call(that, '/button' + direction, {button: button}, callback);
+};
+
+Actions.buttonDown = function(id, button, callback) {
+    return buttonHandler(this, 'down', id, button, callback);
+};
+
+Actions.buttonUp = function(id, button, callback) {
+    return buttonHandler(this, 'up', id, button, callback);
+};
+
 /**
  * http://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/css/:propertyName
  * 


### PR DESCRIPTION
Pretty much what it says on the box.  buttonUp/buttonDown protocol commands are pretty simple, and implementing them took very little rocket science.  I've successfully used this to implement drag-and-drop testing against the jquery.sortable plug-in.

The button can be (0, 1, 2) or ('left', 'middle', 'right').  It defaults to left mouse button, and if you don't pass in a button but do pass in a callback, it will handle it correctly.
