### PR TITLE
fix Action.frame protocol, argument key is id instead of frameId

### DIFF
--- a/lib/selenium/protocol.js
+++ b/lib/selenium/protocol.js
@@ -260,7 +260,7 @@ Actions.frame = function(frameId, callback) {
   }
   
   return postRequest.call(this, "/frame", {
-    "frameId": frameId
+    "id": frameId
   }, callback);
 };
 

--- a/tests/src/testProtocolActions.js
+++ b/tests/src/testProtocolActions.js
@@ -281,7 +281,7 @@ module.exports = {
       });
       
       test.equal(command.request.method, "POST");
-      test.equal(command.data, '{"frameId":"testFrame"}');
+      test.equal(command.data, '{"id":"testFrame"}');
       test.equal(command.request.path, '/wd/hub/session/1352110219202/frame');
     });
   },


### PR DESCRIPTION
Hi,

Action.frame was calling the frame protocol with frameId keyword argument. At the docs it says the keyword is id.

https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/frame

Thanks
