### PR TITLE
Update copyright year from 2013 to 2014

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013 Andrei Rusu <andrei.rusu@beatfactor.net>
+Copyright (c) 2014 Andrei Rusu <andrei.rusu@beatfactor.net>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
The copyright year was out of date (2013). Copyright notices must list the current year. This commit updates the listed year to 2014.
