### PR TITLE
update request.js - attempt to fix #32

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -19,7 +19,7 @@ var DO_NOT_LOG_ERRORS = [
    
 function HttpRequest(options) {
   events.EventEmitter.call(this);
-  this.data       = options.data && JSON.stringify(options.data) || '';
+  this.data       = options.data && JSON.stringify(options.data) || '{}';
   this.reqOptions = this.createOptions(options);
   this.request    = null;
 }


### PR DESCRIPTION
Change the default value of `request.data` property 
from _empty string_ `""` to _object_ `"{}"`.

This fixes issue #32 (at least) for me.

``` sh
$ npm test #=> passes
```

Maybe you can give it a try and could confirm this.

regards
~david
