### PR TITLE
added -f option to filter filename formats. Uses minimatch module

### DIFF
--- a/bin/runner.js
+++ b/bin/runner.js
@@ -9,8 +9,8 @@ var cli = require('./_cli.js');
 
 // CLI definitions
 
-// $ nightwatch -c 
-// $ nightwatch --config 
+// $ nightwatch -c
+// $ nightwatch --config
 cli.command('config')
   .demand(true)
   .description('Path to configuration file')
@@ -36,19 +36,19 @@ cli.command('env')
 cli.command('verbose')
   .description('Turns on selenium command logging during the session.')
   .alias('v');
-    
+
 // $ nightwatch -t
 // $ nightwatch --test
 cli.command('test')
   .description('Runs a single test.')
   .alias('t');
-  
+
 // $ nightwatch -g
 // $ nightwatch --group
 cli.command('group')
   .description('Runs a group of tests (i.e. a folder)')
   .alias('g');
-  
+
 // $ nightwatch -s
 // $ nightwatch --skipgroup
 cli.command('skipgroup')
@@ -59,7 +59,13 @@ cli.command('skipgroup')
 // $ nightwatch --skipgroup
 cli.command('help')
   .description('Shows this help.')
-  .alias('h');  
+  .alias('h');
+
+// $ nightwatch -f
+// $ nightwatch --format
+cli.command('format')
+  .description('Specify a file name format.')
+  .alias('f');
 
 /**
  * Looks for pattern ${VAR_NAME} in settings
@@ -86,20 +92,20 @@ function replaceEnvVariables(target) {
  */
 function readSettings(argv) {
   var settings;
-  
+
   // use default settings.json file if we haven't received another value
   if (cli.command('config').isDefault(argv.c)) {
     var defaultValue = cli.command('config').defaults();
-    
+
     if (fs.existsSync(defaultValue)) {
-      argv.c = path.join(path.resolve('./'), argv.c);  
+      argv.c = path.join(path.resolve('./'), argv.c);
     } else {
       argv.c = path.join(__dirname, argv.c);
     }
   } else {
     argv.c = path.resolve(argv.c);
   }
-  
+
   // reading the settings file
   try {
     settings = require(argv.c);
@@ -108,12 +114,12 @@ function readSettings(argv) {
     Logger.error(ex);
     settings = {};
   }
-  
+
   return settings;
 };
 
 /**
- * 
+ *
  * @param {Object} argv
  */
 function parseTestSettings(argv) {
@@ -124,67 +130,71 @@ function parseTestSettings(argv) {
   if (!(argv.e in settings.test_settings)) {
     throw new Error('Invalid testing environment specified: ' + argv.e);
   }
-  
+
   // picking the environment specific test settings
   var test_settings = settings.test_settings[argv.e];
   test_settings.custom_commands_path = settings.custom_commands_path || '';
-  
+
   if (argv.v) {
     test_settings.silent = false;
   }
-  
+
   if (typeof argv.s == 'string') {
     test_settings.skipgroup = argv.s.split(',');
   }
-  
+
+  if (argv.f) {
+    test_settings.format = argv.f;
+  }
+
   return test_settings;
 }
-       
+
 try {
   var argv = cli.init();
-  
+
   if (argv.help) {
     cli.showHelp();
   } else {
-    
+
     process.chdir(process.cwd());
-    
+
     // the test runner
     var runner = require(__dirname + '/../runner/run.js');
-    
+
     var settings = readSettings(argv);
-    
+
     // setting the output folder
-    var output_folder = cli.command('output').isDefault(argv.o) && 
+    var output_folder = cli.command('output').isDefault(argv.o) &&
         settings.output_folder || argv.o;
-    
+
     var test_settings = parseTestSettings(argv);
-    
+
     // setting the source of the test(s)
     var testsource;
     if (typeof argv.t == 'string') {
-      testsource =  (argv.t.indexOf(process.cwd()) === -1) ? 
+      testsource =  (argv.t.indexOf(process.cwd()) === -1) ?
                       path.join(process.cwd(), argv.t) :
                       argv.t;
       testsource.substr(-3) === '.js' || (testsource += '.js');
-      fs.statSync(testsource);                      
+      fs.statSync(testsource);
     } else if (typeof argv.g == 'string') {
       testsource = [argv.g];
     } else {
       testsource = settings.src_folders;
     }
-  
+
     // running the tests
     if (settings.selenium && settings.selenium.start_process) {
       var selenium = require(__dirname + '/../runner/selenium.js');
-      
+
       selenium.startServer(settings, test_settings, function(error, child, error_out, exitcode) {
         if (error) {
           Logger.error('There was an error while starting the Selenium server:');
           console.log(error_out);
           process.exit(exitcode);
         }
-        
+
         runner.run(testsource, test_settings, {
           output_folder : output_folder,
           selenium : (settings.selenium || null)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "ejs": ">=0.8.3",
-    "optimist": ">=0.3.5"
+    "optimist": ">=0.3.5",
+    "minimatch": "~0.2.14"
   },
   "devDependencies": {
     "nodeunit": "latest"

--- a/runner/run.js
+++ b/runner/run.js
@@ -8,6 +8,7 @@ var child_process = require('child_process');
 var Nightwatch = require('../index.js');
 var Logger = require('../lib/logger.js');
 var Reporter = require('./reporters/junit.js');
+var minimatch = require('minimatch');
 
 module.exports = new (function() {
   var seleniumProcess = null;
@@ -20,12 +21,12 @@ module.exports = new (function() {
     errmessages : [],
     modules : {}
   };
-  
+
   function runModule(module, opts, moduleName, callback) {
     var client = Nightwatch.client(opts);
     var keys   = Object.keys(module);
     var tests  = [];
-    var setUp; 
+    var setUp;
     var tearDown;
     var testresults = {
       passed : 0,
@@ -35,9 +36,9 @@ module.exports = new (function() {
       tests : 0,
       steps : keys.slice(0)
     };
-    
+
     module.client = client;
-    
+
     if (keys.indexOf('setUp') > -1) {
       setUp = function(clientFn) {
         module.setUp(module.client);
@@ -48,7 +49,7 @@ module.exports = new (function() {
     } else {
       setUp = function(callback) {callback();}
     }
-    
+
     if (keys.indexOf('tearDown') > -1) {
       tearDown = function(clientFn) {
         module.tearDown();
@@ -56,11 +57,11 @@ module.exports = new (function() {
       };
       keys.splice(keys.indexOf('tearDown'), 1);
       testresults.steps.splice(testresults.steps.indexOf('tearDown'), 1);
-      
+
     } else {
       tearDown = function(callback) {callback();}
     }
-    
+
     function next() {
       if (keys.length) {
         var key = keys.shift();
@@ -68,7 +69,7 @@ module.exports = new (function() {
           next();
           return;
         }
-        
+
         console.log('\nRunning: ', Logger.colors.green(key));
         var test = wrapTest(setUp, tearDown, module[key], module, function onComplete(results, errors) {
           globalresults.modules[moduleName][key] = {
@@ -78,11 +79,11 @@ module.exports = new (function() {
             skipped : results.skipped,
             tests   : [].concat(results.tests)
           };
-          
+
           if (Array.isArray(errors) && errors.length) {
-            globalresults.errmessages = globalresults.errmessages.concat(errors);  
+            globalresults.errmessages = globalresults.errmessages.concat(errors);
           }
-          
+
           testresults.passed += results.passed;
           testresults.failed += results.failed;
           testresults.errors += results.errors;
@@ -91,13 +92,13 @@ module.exports = new (function() {
           if (this.client.terminated) {
             callback(testresults);
           } else {
-            setTimeout(next, 0);  
+            setTimeout(next, 0);
           }
         });
-        
+
         var error = false;
         try {
-          test(client);  
+          test(client);
         } catch (err) {
           globalresults.errmessages.push(err.message);
           console.log(Logger.colors.red('\nAn error occured while running the test:'));
@@ -106,19 +107,19 @@ module.exports = new (function() {
           client.terminate();
           error = true;
         }
-        
+
         if (!error) {
-          client.start();  
+          client.start();
         }
-          
+
       } else {
         callback(testresults);
-      } 
+      }
     }
-        
+
     setTimeout(next, 0);
   };
-  
+
   function printResults(testresults) {
     if (testresults.passed > 0 && testresults.errors == 0 && testresults.failed == 0) {
       console.log(Logger.colors.green('\nOK. ' + testresults.passed, Logger.colors.background.black), 'total assertions passed.');
@@ -127,11 +128,11 @@ module.exports = new (function() {
       if (testresults.skipped) {
         skipped = ' and ' + Logger.colors.blue(testresults.skipped) + ' skipped.';
       }
-      console.log(Logger.colors.light_red('\nTEST FAILURE:'), Logger.colors.red(testresults.errors + testresults.failed) + 
+      console.log(Logger.colors.light_red('\nTEST FAILURE:'), Logger.colors.red(testresults.errors + testresults.failed) +
       ' assertions failed, ' + Logger.colors.green(testresults.passed) + ' passed' + skipped);
     }
   };
-  
+
   function wrapTest(setUp, tearDown, fn, context, onComplete) {
     return function (client) {
       context.client = client;
@@ -139,17 +140,17 @@ module.exports = new (function() {
         client.once('queue:finished', function(results, errors) {
           tearDown.call(context, function() {
             onComplete.call(context, results, errors);
-          });  
+          });
         });
-        
+
         return fn.call(context, client);
       };
-      
+
       setUp.call(context, clientFn);
       return;
     };
   };
-  
+
   function ensureDir(path, callback) {
     var mkdir = child_process.spawn('mkdir', ['-p', path]);
     mkdir.on('error', function (err) {
@@ -161,34 +162,34 @@ module.exports = new (function() {
       else callback(new Error('mkdir exited with code: ' + code));
     });
   };
-  
+
   function runFiles(paths, cb, opts) {
     var extensionPattern = /\.js$/;
     if (paths.length == 1 && extensionPattern.test(paths[0])) {
       paths[0] = paths[0].replace(extensionPattern, '');
       return cb(null, paths);
     }
-    
+
     paths.forEach(function(p) {
       walk(p, function(err, list) {
         if (err) {
           return cb(err);
         }
         list.sort();
-        
+
         var modules = list.filter(function (filename) {
           return extensionPattern.exec(filename);
         });
-        
+
         modules = modules.map(function (filename) {
           return filename.replace(extensionPattern, '');
         });
-  
+
         cb(null, modules);
       }, opts);
     });
   };
-  
+
   function walk(dir, done, opts) {
     var results = [];
     fs.readdir(dir, function(err, list) {
@@ -196,14 +197,14 @@ module.exports = new (function() {
         return done(err);
       }
       var pending = list.length;
-      
+
       if (pending == 0) {
         return done(null, results);
       }
-      
+
       list.forEach(function(file) {
         file = [dir, file].join('/');
-        
+
         fs.stat(file, function(err, stat) {
           if (stat && stat.isDirectory()) {
             var dirname = file.split('/').slice(-1)[0];
@@ -216,11 +217,21 @@ module.exports = new (function() {
                 if (!pending) {
                   done(null, results);
                 }
-              }, opts);  
+              }, opts);
             }
           } else {
-            results.push(file);
+
+            if (opts.format) {
+              var filename = file.split('/').slice(-1)[0];
+
+              if (minimatch(filename, opts.format)) {
+                results.push(file);
+              }
+            } else {
+              results.push(file);
+            }
             pending = pending-1;
+
             if (!pending) {
               done(null, results);
             }
@@ -229,14 +240,14 @@ module.exports = new (function() {
       });
     });
   };
-  
+
   this.run = function runner(files, opts, aditional_opts, finishCallback) {
     var start = new Date().getTime();
     var modules = {}
     var curModule;
-    
+
     finishCallback = finishCallback || function() {};
-      
+
     if (typeof files == 'string') {
       var paths = [files];
     } else {
@@ -244,53 +255,53 @@ module.exports = new (function() {
         return path.join(process.cwd(), p);
       });
     }
-    
+
     if (paths.length == 0) {
       throw new Error('No tests to run.');
     }
-    
+
     runFiles(paths, function runTestModule(err, fullpaths) {
       if (!fullpaths || fullpaths.length == 0) {
         Logger.warn('No tests defined!');
         console.log('using source folder', paths)
         return;
       }
-      
+
       var modulePath = fullpaths.shift();
       var module     = require(modulePath);
       var moduleName = modulePath.split(path.sep).pop();
       globalresults.modules[moduleName] = [];
       console.log('\n' + Logger.colors.cyan('[ ' + moduleName + ' module ]'));
-            
+
       runModule(module, opts, moduleName, function(testresults) {
         globalresults.passed += testresults.passed;
         globalresults.failed += testresults.failed;
         globalresults.errors += testresults.errors;
         globalresults.skipped += testresults.skipped;
         globalresults.tests += testresults.tests;
-        
+
         if (fullpaths.length) {
           setTimeout(function() {
             runTestModule(err, fullpaths);
-          }, 0);  
+          }, 0);
         } else {
           if (testresults.tests != globalresults.tests || testresults.steps.length > 1) {
-            printResults(globalresults);  
+            printResults(globalresults);
           }
-          
+
           var output = aditional_opts.output_folder;
           if (output === false) {
-            finishCallback();  
+            finishCallback();
           } else {
             ensureDir(output, function() {
               Reporter.save(globalresults, output);
-              finishCallback();  
+              finishCallback();
             });
           }
         }
       })
-    }, opts);  
+    }, opts);
   };
-  
+
 })();
-    
+


### PR DESCRIPTION
If you use Javascript files to declare external variables/functions to be reusable in your tests, it is very convenient to have those files directly in your test folder.

For example, here is a test folders architecture:

```
tests/
    common.js
    /auth
        common.js
        tests_login_success.js
        tests_login_failure.js
        ...
   /books
       common.js
       tests_books_add.js
       tests_books_edit.js
       ...
```

Files named common.js could be included in specific tests using  `require`.

``` javascript
// File: tests_login_success.js
var common = require('./common.js');

module.exports = {
    // Write your nightwatch tests here
}
```

Option format (-f) enables to filter tests filenames. It can be combined with existing options

Usage example:

```
./nightwatch -g /tests -f tests*.js
```

It uses [minimatch](https://github.com/isaacs/minimatch) to deals with regex objects.

Original discussion was about [How to organize tests in real life?](https://github.com/beatfactor/nightwatch/issues/29)
