### PR TITLE
Less verbose logging

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -104,8 +104,7 @@ HttpRequest.prototype.send = function() {
 
       if (errorMessage != '' && Logger.isEnabled()) {
         util.puts(Logger.colors.yellow('There was an error while executing the Selenium command') +
-          ' - enabling the --verbose option might offer more details.')
-        );
+          ' - enabling the --verbose option might offer more details.');
 
         util.puts(errorMessage);
       }


### PR DESCRIPTION
When using waitForElementPresent, if selenium doesn't find the element immediately, it spits an error out. This just changes the settings so that `silent:true` is honoured and the error only shows up if set to false. Sorry about the whitespace changes, but my editor strips them out automatically. 
