### PR TITLE
added check for custom commands so that we can use the constructor forma...

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,10 @@ var util = require('util'),
     CommandQueue = require('./queue.js'),
     Logger = require('./logger.js');
 
+var AbstractCommand = function(client) {
+  this.client = client;
+}
+
 function Nightwatch(options) {
   events.EventEmitter.call(this);
   this.setMaxListeners(0);
@@ -196,10 +200,13 @@ Nightwatch.prototype.loadCustomCommands = function() {
       var name = path.basename(file, '.js');
       if (typeof command === 'function'){
         command = new command();
+        AbstractCommand.call(command, self);
+        self.addCommand(name, command.command, command, self);
+      } else {
+        self.addCommand(name, command.command, self, self);
       }
-      self.addCommand(name, command.command, self, self);
     }
-  })
+  });
 }
 
 Nightwatch.prototype.loadAssertions = function() {


### PR DESCRIPTION
This is a simple fix to allow the Constructor style commands to be loaded from the custom commands path. 
It just checks to see if the Command is an object or not and instantiates it if possible. 

Again, sorry for the white space. Actual changes are on line 197.

```
if (typeof command !== 'object'){
     command = new command();
}
```
