### PR TITLE
Passing nightwatch through to the teardown method

### DIFF
--- a/runner/run.js
+++ b/runner/run.js
@@ -53,7 +53,7 @@ module.exports = new (function() {
 
     if (keys.indexOf('tearDown') > -1) {
       tearDown = function(clientFn) {
-        module.tearDown();
+        module.tearDown(module.client);
         clientFn();
       };
       keys.splice(keys.indexOf('tearDown'), 1);


### PR DESCRIPTION
Essentially the reasoning behind this PR is that it's compelling to have Nightwatch passed to the teardown in order to complete any module level cleanup tasks.

Say for instance you want to ensure that with each test in a module, you want to perform the following:
- Navigate to a particular URL (the same URL for all tests in the module)
- Do some individual tests in each test
- Close the browser (in order to isolate the tests and make them independently runnable)

Extracting the first and last steps into setup and teardown respectively would eliminate code duplication.

Example:

``` javascript
module.exports = {
  setUp: function(client) {
    client.url('http://some-site.com');
  },
  tearDown: function(client) {
    client.end();
  },
  'Footer is present on page': function(client) {
    client
        .verify.elementPresent('#x-footer');
  },

  'Footer contains newsletter signup': function(client) {
    client
        .verify.elementPresent('#x-footer')
        .verify.elementPresent('.x-newsletter')
        .verify.elementPresent('#x-newsletter_email')
        .verify.elementPresent('#newsletter_email')
        .verify.elementPresent('#newsletter_men_submit')
        .verify.elementPresent('#newsletter_women_submit');
  }
};
```

I realize that there may be a philosophy for requiring end to be called inside each test, but it still can be. This just gives the option of removing duplication for those that desire it.
