### PR TITLE
Adding global setup/teardown

### DIFF
--- a/bin/runner.js
+++ b/bin/runner.js
@@ -136,6 +136,12 @@ function parseTestSettings(argv) {
   var test_settings = settings.test_settings[argv.e];
   test_settings.custom_commands_path = settings.custom_commands_path || '';
 
+  if (settings.global_setup_teardown) {
+    var globals = require(path.join(process.cwd(), settings.global_setup_teardown));
+    test_settings.setUp = globals.setUp;
+    test_settings.tearDown = globals.tearDown;
+  }
+
   if (argv.v) {
     test_settings.silent = false;
   }

--- a/bin/settings.json
+++ b/bin/settings.json
@@ -2,6 +2,7 @@
   "src_folders" : ["./examples/tests"],
   "output_folder" : "./examples/reports",
   "custom_commands_path" : "",
+  "global_setup_teardown" : "",
   
   "selenium" : {
     "start_process" : false,


### PR DESCRIPTION
I added a global setup/teardown that will, if configured, run once per entire test run. 

I added a new key to the settings.json file, global_setup_teardown. This will point to a file somewhere. 

``` json
...
"global_setup_teardown" : "./global_setup_teardown.js",
...
```

The global_setup_teardown.js would look like this:

``` javascript
module.exports = {
  setUp: function(client) {
    // do some global config stuff and such
  },
  tearDown: function(client) {
    // do some global teardown stuff
  }
};
```

You'll notice in the code that I extracted the Nightwatch.client(opts) call to the run method, so that there is only one Nightwatch instance for all tests during the run, rather than having one Nightwatch per module run. 
