### PR TITLE
Integrate jshint linting into travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: node_js
 node_js:
   - "0.10"
+
+before_script:
+  - npm install -g grunt-cli
+  - npm install
+
+script:
+  - npm run-script jshint && npm test

--- a/package.json
+++ b/package.json
@@ -24,13 +24,15 @@
     "mkpath": ">=0.1.0"
   },
   "devDependencies": {
-    "nodeunit": "latest"
+    "nodeunit": "latest",
+    "jshint": "~2.4.4"
   },
   "bin": {
     "nightwatch": "./bin/nightwatch"
   },
   "man": "",
   "scripts": {
+    "jshint": "./node_modules/.bin/jshint --verbose --config .jshintrc lib/",
     "test": "node ./tests/run_tests.js"
   }
 }


### PR DESCRIPTION
This commit attempts to integrate linting via "jshint" into the "travis-ci" build process and introduces the following changes:
- add a "jshint" entry to the "scripts" section of the "package.json"
- update the ".travis.yml" to call "npm run-script jshint" before tests

Maybe you want to give it a try.. 

regards
~david
