### PR TITLE
Removing check if a command exists.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -294,12 +294,7 @@ Nightwatch.prototype.loadCustomAssertions = function(parent, abortOnFailure) {
 
 Nightwatch.prototype.addCommand = function(name, command, context, parent) {
   parent = parent || this;
-  if (parent[name]) {
-    this.results.errors++;
-    var error = new Error('The command "' + name + '" is already defined!');
-    this.errors.push(error.stack);
-    throw error;
-  }
+
   var self = this;
   parent[name] = (function(internalCommandName) {
     return function() {


### PR DESCRIPTION
This will allow us to override a command with our own custom behaviour, such as extending the url command to check for an element presence once a page is loaded without having to code an extra step in tests. This is particularly useful for us as we have a custom command that runs every time a page is loaded.
