### PR TITLE
always set a content length header

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -46,6 +46,8 @@ HttpRequest.prototype.createOptions = function(options) {
   if (this.data && this.data.length > 0) {
     reqOptions.headers['Content-Type']   = 'application/json';
     reqOptions.headers['Content-Length'] = this.data.length;
+  } else {
+    reqOptions.headers['Content-Length'] = 0;
   }
 
   if (Settings.credentials &&


### PR DESCRIPTION
Some servers (browserstack) require content length headers for all commands, this makes sure one is sent even when there's no data (for click and submitForm actions).
