### PR TITLE
The screenshot path in junit must be absolute

### DIFF
--- a/runner/reporters/junit.xml.ejs
+++ b/runner/reporters/junit.xml.ejs
@@ -16,7 +16,7 @@
         <% if (tests[i].screenshots && tests[i].screenshots.length > 0) { %>
           <system-out>
             <% for (var j = 0; j < tests[i].screenshots.length; j++) { %>
-              [[ATTACHMENT|<%= tests[i].screenshots[j] %>]]
+              [[ATTACHMENT|<%= require('path').resolve(tests[i].screenshots[j]) %>]]
             <% } %>
           </system-out>
         <% } %>


### PR DESCRIPTION
The path to the screenshot must be absolute, or the Jenkin JUnit Attachments Plugin won't find it.
