### PR TITLE
Replace deprecated util.print and util.puts with process.stdout.write and console.log

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -89,7 +89,7 @@ function Background() { return this; }
 
 var colors = new ConsoleColor();
 function logObject(obj) {
-  util.puts(util.inspect(obj, false, 3, true));
+  console.log(util.inspect(obj, false, 3, true));
 }
 
 function logTimestap() {
@@ -120,7 +120,7 @@ function logMessage(type, message, args) {
       break;
   }
 
-  util.print(messageStr);
+  process.stdout.write(messageStr);
 
   if (args.length > 0) {
     var inlineArgs = [];
@@ -136,12 +136,12 @@ function logMessage(type, message, args) {
       }
     });
     if (inlineArgs.length) {
-      util.print(' ');
+      process.stdout.write(' ');
       console.log.apply(console, inlineArgs);
       inlineArgs = [];
     }
   } else {
-    util.print('\n');
+    process.stdout.write('\n');
   }
 }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -114,10 +114,10 @@ module.exports = (function() {
         }
 
         if (errorMessage !== '') {
-          util.puts(Logger.colors.yellow('There was an error while executing the Selenium command') +
+          console.log(Logger.colors.yellow('There was an error while executing the Selenium command') +
             (!Logger.isEnabled() ? ' - enabling the --verbose option might offer more details.' : '')
           );
-          util.puts(errorMessage);
+          console.log(errorMessage);
         }
 
         var logMethod = response.statusCode.toString().indexOf('5') === 0 ? 'error' : 'info';


### PR DESCRIPTION
While running nightwatch with node v0.11.6 I got some annoying warnings telling me util.print and util.puts were deprecated, these changes fixed that for me.  
