### PR TITLE
added <no such element> to array of DO_NOT_LOG_ERRORS

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -15,7 +15,8 @@ module.exports = (function() {
   };
 
   var DO_NOT_LOG_ERRORS = [
-    'Unable to locate element'
+    'Unable to locate element',
+    'no such element'
   ];
 
   function HttpRequest(options) {


### PR DESCRIPTION
This just adds 'no such element' to the DO_NOT_LOG_ERRORS list. This one has been causing us lots of grief with the elementPresent and waitForElementPresent commands. 

Thanks!

Keith
