### PR TITLE
Adding exit code for when server isn't started.

### DIFF
--- a/bin/runner.js
+++ b/bin/runner.js
@@ -244,6 +244,8 @@ try {
         } else {
           Logger.error('There was an error while running the test.');
         }
+
+        process.exit(1);
       }
     };
 
@@ -261,8 +263,8 @@ try {
           output_folder : output_folder,
           src_folders : settings.src_folders
         }, function(err) {
-          errorHandler(err);
           selenium.stopServer();
+          errorHandler(err);
         });
       });
     } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -151,7 +151,6 @@ Nightwatch.prototype.start = function() {
       .once('error', function(data, error) {
         console.error(Logger.colors.red('Connection refused!'),
           'Is selenium server started?');
-        process.exit(1);
       })
       .startSession();
     return this;


### PR DESCRIPTION
When the connection fails, it doesn't correctly bubble up an exit code to the process. This is needed for CI integration.

Status: **Opened for visibility**

Reviewers: @beatfactor
## Changes
- added exit code
## How to test-drive this PR
- checkout this branch
- don't start a selenium server
- run test
- ensure that exit code is correct
