### PR TITLE
Add 'noColors' option to provide uncoloured log output

### DIFF
--- a/bin/nightwatch.json
+++ b/bin/nightwatch.json
@@ -19,7 +19,7 @@
       "selenium_host" : "127.0.0.1",
       "selenium_port" : 4444,
       "silent" : true,
-      "noColors": false,
+      "disable_colors": false,
       "firefox_profile" : false,
       "chrome_driver" : "",
       "ie_driver" : "",

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,8 +96,8 @@ Nightwatch.prototype.setOptions = function(options) {
     Logger.enable();
   }
 
-  if (this.options.noColors) {
-    Logger.noColors();
+  if (this.options.disable_colors) {
+    Logger.disable_colors();
   }
 
   var seleniumPort = this.options.seleniumPort || this.options.selenium_port;

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -165,7 +165,7 @@ exports.error = function(message) {
   logMessage('ERROR', message, args);
 };
 
-exports.noColors = function () {
+exports.disable_colors = function () {
   Object.keys(ConsoleColor.prototype).forEach(function (color) {
     ConsoleColor.prototype[color] = function (text) {
       return text;


### PR DESCRIPTION
Add a new _boolean_ option `noColors` to the `testSettings`-section in `nightwatch.json`.
This is particularly useful when sending _plain-text_ build-reports from _CI_ systems.
