### PR TITLE
Fix `npm run-script coveralls`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "man": "",
   "scripts": {
     "jshint": "./node_modules/.bin/jshint --verbose --config .jshintrc lib/",
-    "coveralls": "jscoverage lib && NIGHTWATCH_COV=1 node ./tests/run_tests.js lcov | coveralls",
+    "coveralls": "jscoverage lib --exclude *.ejs,*.json && NIGHTWATCH_COV=1 node ./tests/run_tests.js lcov | coveralls",
     "test": "node ./tests/run_tests.js"
   }
 }


### PR DESCRIPTION
The coveralls script was throwing an error, due to **jscoverage** being unable to process non-javascript files contained within the nightwatch `lib` directory.

The fix was to simply add the `--exclude *.ejs,*.json` flag to the invocation of **jscoverage**.
