### PR TITLE
Adding handling for globals commonly used in all environments

### DIFF
--- a/bin/nightwatch.json
+++ b/bin/nightwatch.json
@@ -4,6 +4,7 @@
   "custom_commands_path" : "./examples/custom-commands",
   "custom_assertions_path" : "",
   "globals_path" : "./examples/globals.json",
+  "globals_common_env" : "common",
 
   "selenium" : {
     "start_process" : false,

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -1,7 +1,7 @@
 /**
- * Module dependenciesyxc
+ * Module dependencies
  */
-var fs = require('fs');ed
+var fs = require('fs');
 var path = require('path');
 var Logger = require('../lib/util/logger.js');
 var cli = require('./_cli.js');
@@ -149,6 +149,30 @@ function readExternalGlobals(file) {
 }
 
 /**
+ * Builds the globals object with respect to common values shared for all environments
+ * @param {Object} globals
+ * @returns {Object} globals
+ */
+ function addGlobals(globals, ext_globals, common, env){
+	if(!globals){
+		globals = new Object();
+	}
+	//add common vars to globals, overwrite if already existing
+	if(common in ext_globals){
+		for(var i in ext_globals[common]){
+			globals[i] = ext_globals[common][i];
+		}
+	}
+	//add env vars to globals, overwrite if already existing
+	if(env != common && env in ext_globals){
+		for(var i in ext_globals[env]){
+			globals[i] = ext_globals[env][i];
+		}
+	}
+	return globals;
+}
+
+/**
  *
  * @param {Object} argv
  */
@@ -177,7 +201,11 @@ function parseTestSettings(argv) {
   if (typeof settings.globals_path == 'string' && settings.globals_path) {
     var globals = readExternalGlobals(settings.globals_path);
     if (globals && globals.hasOwnProperty(argv.e)) {
-      test_settings.globals = globals[argv.e];
+      if(typeof settings.globals_common_env == 'string' && settings.globals_common_env){
+    	test_settings.globals = addGlobals(test_settings.globals, globals, settings.globals_common_env, argv.e);
+      } else {
+        test_settings.globals = globals[argv.e];
+      }
     }
   }
 

--- a/examples/globals.json
+++ b/examples/globals.json
@@ -1,4 +1,7 @@
 {
+  "common" : {
+    "commonGlobal" : "Everywhere"
+  },
   "default" : {
     "myGlobal" : 1
   },

--- a/examples/globalsModule.js
+++ b/examples/globalsModule.js
@@ -1,4 +1,8 @@
 module.exports = {
+  'common' : {
+	  commonGlobal : 'works on all environments'
+  },
+
   'default' : {
     myGlobal : function() {
       return 'I\'m a method';


### PR DESCRIPTION
Hi there,

since we have several environments that share many variables (e.g. for locators) but differ in other (e.g. base urls), we were searching for a solution to define common variables that are loaded regardless of the environment. Also you are required to specify all variables used in your testcases for each environment, there is no fallback/default. Any global value from the configuration gets replaced by the values from the globals file.

To solve these issues, I introduced a concept and handling for common variables to the runner.js and added a configuration parameter to control its use:
- new parameter: "globals_common_env" - its value is the name of the "environment" used for storing common parameters in the globals file, e.g. "common"; if you don't specify one, the old logic will be used.
- function "addGlobals" in runner.js handling the common variables

You can add any common variables you want to use for all environments to the "common" env config in the globals.json file then.

There exists an order for globals now, in which the values get overwritten:
1) global from configuration, i.e. nightwatch.json, gets overwritten by
2) global from "common" in globals.json, gets overwritten by
3) global from env in globals.json

I did not test with .js globals, though...

Also, I am a first time github user and first time javascript developer, so be kind your critics. ;-)

Cheers,
Thorsten
