### PR TITLE
Setting output_folder to false disables output.

### DIFF
--- a/bin/_clirunner.js
+++ b/bin/_clirunner.js
@@ -126,7 +126,9 @@ CliRunner.prototype = {
    * @returns {CliRunner}
    */
   setOutputFolder : function() {
-    this.output_folder = this.cli.command('output').isDefault(this.argv.o) && this.settings.output_folder || this.argv.o;
+    this.output_folder = this.settings.output_folder === false ?
+          false : (this.cli.command('output').isDefault(this.argv.o)
+                   && this.settings.output_folder || this.argv.o);
     return this;
   },
 


### PR DESCRIPTION
This is a simple change to the cli runner so that if `output_folder` is false in the settings the runner will
not generate reports or the report folder.
