### PR TITLE
Fixed #168 - 'java.lang.NullPointerException' selenium standalone server

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -355,8 +355,7 @@ Nightwatch.prototype.startSession = function () {
   var options = {
     path : '/session',
     data : {
-      desiredCapabilities : this.desiredCapabilities,
-      sessionId : null
+      desiredCapabilities : this.desiredCapabilities
     }
   };
 


### PR DESCRIPTION
Remove sessionId param with null value from the session start request. Tested with selenium 2.42.0 and 2.41.0.
