### PR TITLE
Print uncaught exceptions to the console before exiting.

### DIFF
--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -229,13 +229,18 @@ module.exports = new (function() {
     }
   }
 
-  function processExitListener() {
+  function processListener() {
     process.on('exit', function (code) {
       if (globalResults.errors > 0 || globalResults.failed > 0) {
         process.exit(1);
       } else {
         process.exit(code);
       }
+    });
+    process.on('uncaughtException', function (err) {
+      console.log(Logger.colors.red('\nAn error occurred while running:'));
+      console.log(err.stack);
+      process.exit(2);
     });
   }
 
@@ -499,6 +504,6 @@ module.exports = new (function() {
       }, finishCallback);
     }, opts);
 
-    processExitListener();
+    processListener();
   };
 })();


### PR DESCRIPTION
Print uncaught exceptions to the console before exiting..  This will display errors from async code in tests and commands.

Here's an example of a test with an error in it:

``` javascript
module.exports = {
  "Error in test" : function (browser) {
    browser.url('http://www.google.com')
    .this_method_does_not_exist()
    .waitForElementVisible('body', 1000)
    .end();
  }
};
```

In the above example, the stack trace of the error is printed to the console (as expected.)

Here's an example of a test with an error in an async block:

``` javascript
module.exports = {
  "Error in test (async)" : function (browser) {
    setImmediate(function() {
      browser.this_method_does_not_exist();
    });
    browser.url('http://www.google.com')
    .waitForElementVisible('body', 1000)
    .end();
  }
};
```

In this second example, the stack trace of the error is not printed to the console, and the process silently exits without any message.

Obviously, the second error is just a toy example.  The case that I actually encountered is in an async block in a custom command.  If you make a mistake in an async block of a custom command, it's hard to debug because no message is printed to the console.

The pull request I created catches uncaught exceptions from async blocks and prints them to the console before exiting.  Thanks for considering it.

Joel Jirak
