### PR TITLE
Fix single line comments in executeHandler

### DIFF
--- a/lib/selenium/protocol.js
+++ b/lib/selenium/protocol.js
@@ -494,7 +494,7 @@ module.exports = function(Nightwatch) {
 
     if (typeof script === 'function') {
       fn = 'var passedArgs = Array.prototype.slice.call(arguments,0); return ' +
-        script.toString().replace(/\n+/g, '') + '.apply(window, passedArgs);';
+        script.toString() + '.apply(window, passedArgs);';
     } else {
       fn = script;
     }


### PR DESCRIPTION
If you are using executeAsync and you use single line quotes you will receive cryptic errors during execution. This is because the new line characters are being stripped prevent from being parsed if the single line quote syntax is used. 

I do not understand the reason for stripping new lines so I have simply removed that. If it does server a purpose then I propose a more intelligent pre-processor that strips comments as well as removing the new lines.

Let me know what you think.

Thanks for maintaining a great project. 
