### PR TITLE
fix an issue with the bin/nightwatch script and paths

### DIFF
--- a/bin/nightwatch
+++ b/bin/nightwatch
@@ -1,3 +1,7 @@
 #!/usr/bin/env node
-require('./runner.js');            
+
+var path = require('path');
+var fs = require('fs');
+var runner = path.join(path.dirname(fs.realpathSync(__filename)), 'runner.js');
+require(runner);            
 


### PR DESCRIPTION
As a part of my jenkins setup, I'd like to be able to run nightwatch via ./node_modules/.bin/nightwatch  With this change that I've used previously in my scripts, it seems to work fine for me.   
