### PR TITLE
fix typo in examples/tests/nightwatch.js

### DIFF
--- a/examples/tests/nightwatch.js
+++ b/examples/tests/nightwatch.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'Demo test Google' : function (client) {
+  'Demo test NightwatchJS.org' : function (client) {
     client
       .url('http://nightwatchjs.org')
       .waitForElementVisible('body', 1000)


### PR DESCRIPTION
Test is hitting _nightwatchjs.org_ rather than _google.com_.
