### PR TITLE
refactor(request): handle IEDriver messages

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -89,6 +89,22 @@ module.exports = (function() {
         }
       });
 
+      var needsFormattedErrorMessage = function(result) {
+        return !!(result.localizedMessage || result.message);
+      };
+
+      var isIEDriver = function(result) {
+        return !!result.localizedMessage;
+      };
+
+      var formatErrorMessage = function(info) {
+        var msg = isIEDriver(info) ? info.localizedMessage : info.message;
+        if (shouldLogErrorMessage(msg)) {
+          msg = msg.replace(/\n/g,'\n\t');
+        }
+        return msg;
+      };
+
       response.on('end', function () {
         var screenshotContent;
         var result, errorMessage = '';
@@ -105,8 +121,9 @@ module.exports = (function() {
               delete result.value.stackTrace;
             }
 
-            if (result.value.message && shouldLogErrorMessage(result.value.message)) {
-              errorMessage = result.value.message.replace(/\n/g,'\n\t');
+            if (needsFormattedErrorMessage(result)) {
+              errorMessage = formatErrorMessage(result.value);
+              delete result.value.localizedMessage;
               delete result.value.message;
             }
           }


### PR DESCRIPTION
Refactor lib/request.js to handle `localizedMessage` property from _IEDriver_.

Unfortunately i was not able to add a decent test.
@beatfactor Could you shed some light ?

Fixes #226
