### PR TITLE
Option to send nightwatch test name to remote selenium server

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -229,7 +229,6 @@ module.exports = (function() {
     try {
       result = JSON.parse(data);
     } catch (err) {
-      console.log(data);
       console.log(err.stack);
       result = {value: -1, error: err.message};
     }


### PR DESCRIPTION
This PR adds the ability to take the friendly name for each test (derived from the test's filename) and send it to the remote Selenium server.

This allows descriptive test names to show up in the Sauce Labs (and presumably others) dashboard.

Usage: (in `test_settings` in `nightwatch.json`):

```
      "syncTestNames": true,
```
