### PR TITLE
Option to disable screenshot data in logs

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -115,6 +115,16 @@ module.exports = (function() {
           result = {};
         }
 
+        // Clone the result object
+        var resultLog = {};
+        for (var key in result) {
+          resultLog[key] = result[key];
+        }
+        // Remove the screenshot base64 data according to settings
+        if (!Logger.settings.screenshot_data && self.reqOptions.path.indexOf('/screenshot') > -1) {
+          resultLog.value = '[removed by nightwatch due to settings]';
+        }
+
         if (errorMessage !== '') {
           console.log(Logger.colors.yellow('There was an error while executing the Selenium command') +
             (!Logger.isEnabled() ? ' - enabling the --verbose option might offer more details.' : '')
@@ -123,7 +133,7 @@ module.exports = (function() {
         }
 
         var logMethod = response.statusCode.toString().indexOf('5') === 0 ? 'error' : 'info';
-        Logger[logMethod]('Response ' + response.statusCode + ' ' + self.reqOptions.method + ' ' + self.reqOptions.path, result);
+        Logger[logMethod]('Response ' + response.statusCode + ' ' + self.reqOptions.method + ' ' + self.reqOptions.path, resultLog);
 
         if (response.statusCode.toString().indexOf('2') === 0 || redirected) {
           self.emit('success', result, response, redirected);

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,6 +101,9 @@ Nightwatch.prototype.setOptions = function(options) {
   } else {
     Logger.enable();
   }
+  if (typeof this.options.log_screenshot_data == 'boolean') {
+    Logger.settings.screenshot_data = this.options.log_screenshot_data;
+  }
 
   var seleniumPort = this.options.seleniumPort || this.options.selenium_port;
   var seleniumHost = this.options.seleniumHost || this.options.selenium_host;

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -1,6 +1,7 @@
 var util = require('util');
 var Settings = {
   log_timestamp : false,
+  screenshot_data: true,
   enabled : true
 };
 
@@ -188,3 +189,4 @@ exports.isEnabled = function() {
   return Settings.enabled;
 };
 exports.colors = colors;
+exports.settings = Settings;

--- a/tests/src/http/testRequest.js
+++ b/tests/src/http/testRequest.js
@@ -100,6 +100,80 @@ module.exports = {
 
   },
 
+  testScreenshotDataInLog : function(test) {
+    nock('http://localhost:4444')
+      .post('/wd/hub/123456/screenshot')
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: 'base64-data'
+      });
+
+    var options = {
+      path : '/:sessionId/screenshot',
+      method : 'POST',
+      sessionId : '123456'
+    };
+
+    var oldLoggerInfo = Logger.info;
+    var loggerInfoCalls = [];
+    Logger.info = function() {
+      loggerInfoCalls.push(arguments);
+    };
+
+    Logger.settings.screenshot_data = true;
+
+    var request = new HttpRequest(options);
+    request.on('success', function(result) {
+      var lastCall = loggerInfoCalls[loggerInfoCalls.length - 1];
+
+      test.ok(lastCall[1].value);
+      test.equal(lastCall[1].value, 'base64-data');
+      test.ok(result.value);
+      test.equal(result.value, 'base64-data');
+
+      Logger.info = oldLoggerInfo;
+      test.done();
+    }).send();
+  },
+
+  testScreenshotDataNotInLog : function(test) {
+    nock('http://localhost:4444')
+      .post('/wd/hub/123456/screenshot')
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: 'base64-data'
+      });
+
+    var options = {
+      path : '/:sessionId/screenshot',
+      method : 'POST',
+      sessionId : '123456'
+    };
+
+    var oldLoggerInfo = Logger.info;
+    var loggerInfoCalls = [];
+    Logger.info = function() {
+      loggerInfoCalls.push(arguments);
+    };
+
+    Logger.settings.screenshot_data = false;
+
+    var request = new HttpRequest(options);
+    request.on('success', function(result) {
+      var lastCall = loggerInfoCalls[loggerInfoCalls.length - 1];
+
+      test.ok(lastCall[1].value);
+      test.equal(lastCall[1].value, '[removed by nightwatch due to settings]');
+      test.ok(result.value);
+      test.equal(result.value, 'base64-data');
+
+      Logger.info = oldLoggerInfo;
+      test.done();
+    }).send();
+  },
+
   testGetRequest : function(test) {
     nock('http://localhost:4444')
       .get('/wd/hub/123456/element')

--- a/tests/src/index/testNightwatchIndex.js
+++ b/tests/src/index/testNightwatchIndex.js
@@ -2,7 +2,9 @@ var os     = require('os');
 var path   = require('path');
 var fs     = require('fs');
 var mockery = require('mockery');
+var BASE_PATH = process.env.NIGHTWATCH_COV ? 'lib-cov' : 'lib';
 var Client = require('../../nightwatch.js');
+var Logger = require('../../../' + BASE_PATH + '/util/logger');
 
 module.exports = {
   setUp: function (callback) {
@@ -151,6 +153,7 @@ module.exports = {
 
   testSetOptions : function(test) {
     var client = this.client = Client.init({
+      log_screenshot_data: false,
       use_xpath : true,
       launch_url : '/home'
     });
@@ -173,6 +176,7 @@ module.exports = {
 
     eq(client.options.screenshots.enabled, false);
     eq(client.api.options.screenshots, false);
+    eq(Logger.settings.screenshot_data, false);
 
     test.done();
   },


### PR DESCRIPTION
Setting the option `log_screenshot_data` in one of the `test_sestings` environment
causes the screenshot base64 data to be outputted or hidden from the logs.

Fixed #256
