### PR TITLE
Fix afterEach/tearDown sync calling

### DIFF
--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -212,7 +212,7 @@ module.exports = new (function() {
         if (beforeEachFn.length <= 1) {
           beforeEachFn.call(context, context.client);
           clientFn();
-        } else if (beforeEachFn.length >= 1) {
+        } else if (beforeEachFn.length > 1) {
           beforeEachFn.call(context, context.client, clientFn);
         }
       };
@@ -240,7 +240,7 @@ module.exports = new (function() {
     if (typeof module.afterEach == 'function' || typeof module.tearDown == 'function') {
       var afterEachFn = module.afterEach || module.tearDown;
       afterEach = function(context, clientFn, client, onTestComplete) {
-        var hasCallback = afterEachFn.length >= 0;
+        var hasCallback = afterEachFn.length > 0;
         startClient(context, clientFn, client, function(results, errors) {
           callTearDown(module, results, errors, onTestComplete, hasCallback);
         });

--- a/tests/sampletests/before-after/syncBeforeAndAfter.js
+++ b/tests/sampletests/before-after/syncBeforeAndAfter.js
@@ -1,0 +1,26 @@
+module.exports = {
+  beforeEach : function(client) {
+    client.globals.test.ok('beforeEach callback called.');
+  },
+
+  before : function(client) {
+    client.globals.test.ok('before callback called.');
+  },
+
+  demoTestAsyncOne : function (client) {
+    client.url('http://localhost');
+  },
+
+  demoTestAsyncTwo : function (client) {
+    client.end();
+  },
+
+  afterEach : function() {
+    var client = this.client;
+    client.globals.test.ok('afterEach callback called.');
+  },
+
+  after : function(client) {
+    client.globals.test.ok('after callback called.');
+  }
+};

--- a/tests/src/runner/testRunner.js
+++ b/tests/src/runner/testRunner.js
@@ -103,7 +103,7 @@ module.exports = {
   },
 
   testRunAsyncWithBeforeAndAfter : function(test) {
-    test.expect(10);
+    test.expect(27);
     var testsPath = path.join(process.cwd(), '/sampletests/before-after');
     this.Runner.run([testsPath], {
       seleniumPort : 10195,
@@ -119,6 +119,17 @@ module.exports = {
       test.ok('sampleWithBeforeAndAfter' in results.modules);
       test.ok('demoTestAsyncOne' in results.modules.sampleWithBeforeAndAfter);
       test.ok('demoTestAsyncTwo' in results.modules.sampleWithBeforeAndAfter);
+      test.ok(!('beforeEach' in results.modules.sampleWithBeforeAndAfter));
+      test.ok(!('before' in results.modules.sampleWithBeforeAndAfter));
+      test.ok(!('afterEach' in results.modules.sampleWithBeforeAndAfter));
+      test.ok(!('after' in results.modules.sampleWithBeforeAndAfter));
+      test.ok('syncBeforeAndAfter' in results.modules);
+      test.ok('demoTestAsyncOne' in results.modules.syncBeforeAndAfter);
+      test.ok('demoTestAsyncTwo' in results.modules.syncBeforeAndAfter);
+      test.ok(!('beforeEach' in results.modules.syncBeforeAndAfter));
+      test.ok(!('before' in results.modules.syncBeforeAndAfter));
+      test.ok(!('afterEach' in results.modules.syncBeforeAndAfter));
+      test.ok(!('after' in results.modules.syncBeforeAndAfter));
       test.done();
     });
   },


### PR DESCRIPTION
Currently having a sync `tearDown` method defined on a test module, makes the tests hang.

This PR address this issue.
