### PR TITLE
Show meaningful HTTP error response

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -229,6 +229,7 @@ module.exports = (function() {
     try {
       result = JSON.parse(data);
     } catch (err) {
+      console.log(data);
       console.log(err.stack);
       result = {value: -1, error: err.message};
     }


### PR DESCRIPTION
When communicating with a remote Selenium server, such as SauceLabs, sometimes there is an error establishing a connection.

The error shown on the console isn't very helpful in figuring out what the problem is.

Here's the console output when there's an authentication error:

```
SyntaxError: Unexpected token S
    at Object.parse (native)
    at parseResult (/Users/dcadwal/dev/magellan/node_modules/nightwatch/lib/http/request.js:230:21)
    at IncomingMessage.<anonymous> 
```

With this PR, if the HTTP response fails to parse as JSON, we just dump the raw message to the console like so:

```
Sauce Labs Authentication Error.
You used username 'foo' and access key 'XXXXXXXX-XXXX-XXXX-XXXX-XXXX' to authenticate, which are not valid Sauce Labs credentials.
```

That makes it much easier to figure out what's wrong.
