### PR TITLE
Add global `beforeEach` and `afterEach` hooks

### DIFF
--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -499,6 +499,8 @@ module.exports = new (function() {
     opts.parallelMode = process.env.__NIGHTWATCH_PARALLEL_MODE == '1';
     opts.live_output = additional_opts.live_output;
     opts.report_prefix = '';
+    var runGlobalBeforeEach = opts.globals && opts.globals.beforeEach || function() {};
+    var runGlobalAfterEach = opts.globals && opts.globals.afterEach || function() {};
 
     globalStartTime = new Date().getTime();
     finishCallback = finishCallback || function() {};
@@ -516,6 +518,24 @@ module.exports = new (function() {
 
     if (paths.length === 0) {
       throw new Error('No tests to run.');
+    }
+
+    // Convert synchronous beforeEach to async.
+    if (runGlobalBeforeEach.length === 0) {
+      var _syncBeforeEach = runGlobalBeforeEach;
+      runGlobalBeforeEach = function(done) {
+        _syncBeforeEach();
+        done();
+      };
+    }
+
+    // Convert synchronous afterEach to async.
+    if (runGlobalAfterEach.length === 0) {
+      var _syncAfterEach = runGlobalAfterEach;
+      runGlobalAfterEach = function(done) {
+        _syncAfterEach();
+        done();
+      };
     }
 
     runFiles(paths, function runTestModule(err, fullpaths) {
@@ -569,42 +589,46 @@ module.exports = new (function() {
         }
       }
 
-      runModule(module, opts, moduleName, moduleKey, function moduleCallback(err, modulekeys) {
-        if (fullpaths.length) {
-          setTimeout(function() {
-            runTestModule(err, fullpaths);
-          }, 1000);
-        } else {
-          if (opts.output) {
-            printTotalResults(globalResults, modulekeys, globalStartTime);
-          }
-
-          if (additional_opts.output_folder === false) {
-            finishCallback(null, globalResults, modulekeys);
-          } else {
-            mkpath(additional_opts.output_folder, function(err) {
-              if (err) {
-                console.log(Logger.colors.yellow('Output folder doesn\'t exist and cannot be created.'));
-                console.log(err.stack);
-                finishCallback(null);
-                return;
+      runGlobalBeforeEach(function() {
+        runModule(module, opts, moduleName, moduleKey, function moduleCallback(err, modulekeys) {
+          runGlobalAfterEach(function() {
+            if (fullpaths.length) {
+              setTimeout(function() {
+                runTestModule(err, fullpaths);
+              }, 1000);
+            } else {
+              if (opts.output) {
+                printTotalResults(globalResults, modulekeys, globalStartTime);
               }
 
-              var Reporter = require('./reporters/junit.js');
-              Reporter.save(globalResults, {
-                output_folder : additional_opts.output_folder,
-                filename_prefix : opts.report_prefix
-              }, function(err) {
-                if (err) {
-                  console.log(Logger.colors.yellow('Warning: Failed to save report file to folder: ' + additional_opts.output_folder));
-                  console.log(err.stack);
-                }
-                finishCallback(null, globalResults);
-              });
-            });
-          }
-        }
-      }, finishCallback);
+              if (additional_opts.output_folder === false) {
+                finishCallback(null, globalResults, modulekeys);
+              } else {
+                mkpath(additional_opts.output_folder, function(err) {
+                  if (err) {
+                    console.log(Logger.colors.yellow('Output folder doesn\'t exist and cannot be created.'));
+                    console.log(err.stack);
+                    finishCallback(null);
+                    return;
+                  }
+
+                  var Reporter = require('./reporters/junit.js');
+                  Reporter.save(globalResults, {
+                    output_folder : additional_opts.output_folder,
+                    filename_prefix : opts.report_prefix
+                  }, function(err) {
+                    if (err) {
+                      console.log(Logger.colors.yellow('Warning: Failed to save report file to folder: ' + additional_opts.output_folder));
+                      console.log(err.stack);
+                    }
+                    finishCallback(null, globalResults);
+                  });
+                });
+              }
+            }
+          });
+        }, finishCallback);
+      });
     }, opts);
 
     processListener(finishCallback);

--- a/tests/src/runner/testRunner.js
+++ b/tests/src/runner/testRunner.js
@@ -136,6 +136,58 @@ module.exports = {
     });
   },
 
+  testRunWithGlobalBeforeAndAfter : function(test) {
+    test.expect(15);
+    var testsPath = path.join(process.cwd(), '/sampletests/before-after');
+    var beforeEachCount = 0;
+    var afterEachCount = 0;
+    this.Runner.run([testsPath], {
+      seleniumPort : 10195,
+      silent : true,
+      output : false,
+      globals : {
+        test : test,
+        beforeEach: function() { beforeEachCount++; },
+        afterEach: function() { afterEachCount++; }
+      }
+    }, {
+      output_folder : false
+    }, function(err, results) {
+      test.equals(err, null);
+      test.equals(beforeEachCount, 2);
+      test.equals(afterEachCount, 2);
+      test.done();
+    });
+  },
+
+  testRunWithGlobalAsyncBeforeAndAfter : function(test) {
+    test.expect(15);
+    var testsPath = path.join(process.cwd(), '/sampletests/before-after');
+    var beforeEachCount = 0;
+    var afterEachCount = 0;
+    this.Runner.run([testsPath], {
+      seleniumPort : 10195,
+      silent : true,
+      output : false,
+      globals : {
+        test : test,
+        beforeEach: function(done) {
+          setTimeout(function() { beforeEachCount++; done(); }, 100);
+        },
+        afterEach: function(done) {
+          setTimeout(function() { afterEachCount++; done(); }, 100);
+        }
+      }
+    }, {
+      output_folder : false
+    }, function(err, results) {
+      test.equals(err, null);
+      test.equals(beforeEachCount, 2);
+      test.equals(afterEachCount, 2);
+      test.done();
+    });
+  },
+
   testRunMixed : function(test) {
     test.expect(6);
     var testsPath = path.join(process.cwd(), '/sampletests/mixed');


### PR DESCRIPTION
Adds global hooks to run code before and after each test suite (file). These are specified as global functions `beforeEach` and `afterEach` in the file loaded using the `globals_path` setting in `nightwatch.json`. They may be synchronous or asynchronous (taking a single `done` callback argument). To illustrate, the execution order for two test suites would be: 

```
(global) before
  (global) beforeEach
    testSuite1.js
  (global) afterEach
  (global) beforeEach
    testSuite2.js
  (global) afterEach
(global) after
```

I use this to clear my database in between test suites so that my app and tests aren't contaminated with data from other suites.

This is like global definition of per-suite before/after hooks (in contrast to #212, global definition of per-test beforeEach/afterEach). It was partly inspired by a [mailing list discussion](https://groups.google.com/forum/#!searchin/nightwatchjs/before$20after/nightwatchjs/60dmbhLKBCg/TDCK9u3fq_kJ) about `beforeClass` and `afterClass` hooks. I'm open to suggestions on the hook names. I chose these because of the symmetry between global `before` and `after` hooks and the per-suite `before` and `after`.
