### PR TITLE
show total time in minutes

### DIFF
--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -296,7 +296,7 @@ module.exports = new (function() {
     process.stdout.write('\n');
     if (testresults.passed > 0 && testresults.errors === 0 && testresults.failed === 0) {
       console.log(Logger.colors.green('OK. ' + testresults.passed),
-        'total assertions passed. (' + elapsedTime + ' ms)');
+        'total assertions passed. (' + elapsedTime + ' ms | ' + elapsedTime / 1000 / 60 + ' min)');
     } else {
       var skipped = '';
       if (testresults.skipped) {


### PR DESCRIPTION
it's much easier to read time in minutes then milliseconds 

example of output

`TEST FAILURE: 7 errors during execution, 7 assertions failed, 444 passed and 1 skipped.. (248142 ms | 4.1357 min)`
