### PR TITLE
Allow turning on screenshots for test failures

### DIFF
--- a/lib/core/assertion.js
+++ b/lib/core/assertion.js
@@ -1,6 +1,7 @@
 var util = require('util');
 var events = require('events');
 var Logger = require('./../util/logger.js');
+var path = require('path');
 
 module.exports = new (function() {
   var doneSymbol = String.fromCharCode(10004);
@@ -196,8 +197,37 @@ module.exports = new (function() {
       failure : failure !== '' ? failure : false
     });
 
-    if (!passed && abortOnFailure) {
-      client.terminate();
+    if (!passed) {
+      if (client.options.screenshots.onFail) {
+        var theBrowser = client.desiredCapabilities.browserName;
+        var d = new Date();
+        var dateStamp = d.toLocaleString('en-GB', {
+          weekday: 'narrow',
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          timeZoneName: 'short',
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+          era: 'short'
+        }).replace(/:/g, '').replace(/\s/g, '-').replace(/-\(.+?\)/, '');
+        var testName = client.options.desiredCapabilities.name;
+        var screenshotName = ('FAIL_' + testName + '_' + theBrowser + '_' + dateStamp).replace(/[^A-Za-z0-9_-]/g, '');
+        var screenshotPath = path.resolve(path.join(client.options.screenshots.path, screenshotName + '.png'));
+        client.api.saveScreenshot(screenshotPath, function(result) {
+          if (abortOnFailure) {
+            client.terminate();
+          }
+        });
+        if (abortOnFailure) {
+          client.api.pause(); // ensure test doesn't continue while we're taking a screenshot
+        }
+      } else {
+        if (abortOnFailure) {
+          client.terminate();
+        }
+      }
     }
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -293,7 +293,7 @@ Nightwatch.prototype.runProtocolAction = function(requestOptions, callback) {
     })
     .on('error', function(result, response, screenshotContent) {
       result = self.handleTestError(result);
-      if (screenshotContent && self.options.screenshots.enabled) {
+      if (screenshotContent && self.options.screenshots.enabled  && self.options.screenshots.onSeleniumError) {
         var d = new Date();
         var dateStamp = d.toLocaleString('en-GB', {
           weekday       : 'narrow',

--- a/tests/src/index/testNightwatchIndex.js
+++ b/tests/src/index/testNightwatchIndex.js
@@ -46,6 +46,7 @@ module.exports = {
 
     client.saveScreenshotToFile = function() {};
     client.options.screenshots.enabled = true;
+    client.options.screenshots.onSeleniumError = true;
     client.on('selenium:session_create', function(sessionId) {
       var request = client.runProtocolAction({
         host : '127.0.0.1',


### PR DESCRIPTION
Allow turning on screenshots for test failures.
2 new config options have been added.

* "onFail" - If enabled, will take a screenshot when an assertion fails, aborting the test if appropriate
* "onSeleniumError" - If enabled, will take a screenshot for every selenium error. This is prone to producing a lot of screenshots for tests will long running parts e.g. a 30 second server-side task while waiting for a success back in the browser. The reason for this is because commands like waitForElementPresent repeatedly execute a selenium api command until it passes or times out.

```json
      "screenshots": {
        "enabled": true,
        "onFail": true,
        "onSeleniumError": false,
        "path": "screenshots"
      }
```