### PR TITLE
Allow running individual test files in parallel via test workers

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "eqnull":true,
   "bitwise":true,
   "curly":true,
   "noempty":true,

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-
+var async = require('async');
 var Runner = require('../run.js');
 var Logger = require('../../util/logger.js');
 var Utils = require('../../util/utils.js');
@@ -348,12 +348,22 @@ CliRunner.prototype = {
       }
     }
 
-    if (envs.length > 1) {
+    if (envs.length > 1 && (this.settings.testWorkers == null || !this.settings.testWorkers.enabled)) {
       this.setupParallelMode(envs, done);
       return this;
     }
 
     this.setTestSettings(this.argv.env);
+
+    if (!this.isParallelMode() && envs.length < 2 && 
+      (this.argv.group == null || this.argv.group === '') &&
+      (this.argv.skipgroup == null || this.argv.skipgroup === '') &&
+      (this.argv.filter == null || this.argv.filter === '') &&
+      (this.argv.tag == null || this.argv.tag === '') &&
+      (this.argv.test == null || this.argv.test === '') &&
+      this.settings.testWorkers && this.settings.testWorkers.enabled) {
+      this.setupTestWorkerMode(done);
+    }
 
     return this;
   },
@@ -369,6 +379,7 @@ CliRunner.prototype = {
     this.test_settings.custom_commands_path = this.settings.custom_commands_path || '';
     this.test_settings.custom_assertions_path = this.settings.custom_assertions_path || '';
     this.test_settings.page_objects_path = this.settings.page_objects_path || '';
+    this.test_settings.testWorkers = this.settings.testWorkers || {};
 
     this.inheritFromDefaultEnv();
 
@@ -467,6 +478,26 @@ CliRunner.prototype = {
         self.stopSelenium();
         if (done) {
           done(o, code);
+        }
+        if (code) {
+          process.exit(code);
+        }
+      });
+    });
+
+
+    return this;
+  },
+
+  setupTestWorkerMode: function(callback) {
+    this.parallelMode = true;
+    var self = this;
+
+    this.startSelenium(function() {
+      self.startTestWorkers(function(o, code) {
+        self.stopSelenium();
+        if (callback) {
+          callback();
         }
         if (code) {
           process.exit(code);
@@ -618,6 +649,171 @@ CliRunner.prototype = {
         });
       }, index * processStartDelay);
     });
+  },
+
+  startTestWorkers : function(finishCallback) {
+    var execFile = require('child_process').execFile, child, self = this;
+    var mainModule = process.mainModule.filename;
+    finishCallback = finishCallback || function() {};
+
+    var availColors = this.getAvailableColors();
+    var prevIndex = 0;
+    var output = {};
+    var globalExitCode = 0;
+    var writeToSdtout = function(data, item, index) {
+      data = data.replace(/^\s+|\s+$/g, '');
+      output[item] = output[item] || [];
+
+      var env_output = '';
+      var color_pair = availColors[index%4];
+      if (prevIndex !== index) {
+        prevIndex = index;
+        if (self.settings.live_output) {
+          env_output += '\n';
+        }
+      }
+
+      env_output += Logger.colors[color_pair[1]](' ' + item + ' ',
+        Logger.colors.background[color_pair[0]]);
+
+      if (self.settings.live_output) {
+        env_output += ' ' + data;
+      } else {
+        env_output += '\t' + data + '\n';
+      }
+
+      if (self.settings.live_output) {
+        console.log(env_output);
+      } else {
+        output[item].push(env_output);
+      }
+    };
+
+    function walk(dir, done, opts) {
+      var results = [];
+      fs.readdir(dir, function(err, list) {
+        if (err) {
+          return done(err);
+        }
+        var pending = list.length;
+
+        if (pending === 0) {
+          return done(null, results);
+        }
+
+        list.forEach(function(file) {
+          var basename = file;
+          file = [dir, file].join(path.sep);
+
+          fs.stat(file, function(err, stat) {
+            if (stat && stat.isDirectory()) {
+              var dirName = file.split(path.sep).slice(-1)[0];
+              var isExcluded = opts.exclude && opts.exclude.indexOf(file) > -1;
+              var isSkipped = opts.skipgroup && opts.skipgroup.indexOf(dirName) > -1;
+
+              if (isExcluded || isSkipped) {
+                pending = pending-1;
+              } else {
+                walk(file, function(err, res) {
+                  results = results.concat(res);
+                  pending = pending-1;
+                  if (!pending) {
+                    done(null, results);
+                  }
+                }, opts);
+              }
+            } else {
+              if (path.extname(basename) === '.js') { // only js files
+                results.push(basename);
+              }
+              pending = pending-1;
+              if (!pending) {
+                done(null, results);
+              }
+            }
+          });
+        });
+      });
+    }
+
+    var source = this.getTestSource();
+    var paths = source.map(function (p) {
+      if (p.indexOf(process.cwd()) === 0) {
+        return p;
+      }
+      return path.join(process.cwd(), p);
+    });
+
+    walk(paths[0], function(err, tests) {
+      if (err) {
+        return finishCallback(err, 1);
+      }
+
+      var workers = 1;
+      if ('number' === typeof self.test_settings.testWorkers.workers) {
+        workers = self.test_settings.testWorkers.workers;
+      } else if (self.test_settings.testWorkers.workers === 'auto') {
+        workers = require('os').cpus().length;
+      }
+      console.log('Creating queue with ' + workers + ' worker(s)');
+
+      var queue = async.queue(function(item, cb) {
+        var index = Math.floor((Math.random() * 10));
+        var cliArgs = self.getChildProcessArgs(mainModule);
+        cliArgs.push('--filter', item, '--parallel-mode');
+        var env = process.env;
+
+        env.__NIGHTWATCH_PARALLEL_MODE = 1;
+        env.__NIGHTWATCH_ENV = self.argv.env;
+
+        child = execFile(process.execPath, cliArgs, {
+          cwd : process.cwd(),
+          encoding: 'utf8',
+          env : env
+        });
+
+        self.runningProcesses[item] = true;
+        console.log('Started child process for test:',
+          Logger.colors.yellow(' ' + item + ' ', Logger.colors.background.black), '\n');
+
+        child.stdout.on('data', function (data) {
+          writeToSdtout(data, item, index);
+        });
+
+        child.stderr.on('data', function (data) {
+          writeToSdtout(data, item, index);
+        });
+
+        child.on('close', function(code) {
+          return cb(output, globalExitCode);
+        });
+
+        child.on('exit', function (code) {
+          if (code) {
+            globalExitCode = 2;
+          }
+          if (!self.settings.live_output) {
+            var child_output = output[item] || '';
+            for (var i = 0; i < child_output.length; i++) {
+              process.stdout.write(child_output[i]);
+            }
+            console.log('');
+          }
+
+          self.runningProcesses[item] = false;
+        });
+      }, workers);
+
+      console.log('Adding test files to worker queue', tests);
+      queue.push(tests, function(output, globalExitCode) {
+        // single test finished
+      });
+      queue.drain = function() {
+        if (!self.processesRunning()) {
+          finishCallback(output, globalExitCode);
+        }
+      };
+    }, this.test_settings);
   },
 
   processesRunning : function() {

--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
     "url": "git@github.com:beatfactor/nightwatch.git"
   },
   "dependencies": {
-    "grunt": "~0.4.4",
+    "async": "^0.9.0",
     "ejs": ">=0.8.3",
-    "optimist": ">=0.3.5",
+    "grunt": "~0.4.4",
     "minimatch": "~0.2.14",
-    "mkpath": ">=0.1.0"
+    "mkpath": ">=0.1.0",
+    "optimist": ">=0.3.5"
   },
   "devDependencies": {
     "nodeunit": "latest",

--- a/tests/src/runner/testCliRunner.js
+++ b/tests/src/runner/testCliRunner.js
@@ -180,6 +180,7 @@ module.exports = {
       custom_commands_path: '',
       custom_assertions_path: '',
       page_objects_path: '',
+      testWorkers: {},
       output: true
     }});
 


### PR DESCRIPTION
Added a new top level config to nightwatch.json,

defaults to being disabled, i.e. behaves as nightwatch currently does:
```json
  "testWorkers": {}
```

If testWorkers are enabled, a second option can be specified, with a default value of "auto":
```json
  "testWorkers": {
    "enabled": true,
    "workers": "auto"
  }
```

This `workers` option configures how many nightwatch workers can run concurrently.
* "auto" - determined by number of CPUs e.g. 4 CPUs means 4 workers
* <number> - specifies an exact number of workers

If workers are enabled, the nightwatch cli process that is invoked initially does not run any tests.
Instead, it runs nightwatch sub-processes, reporting back on results as tests finish.

Test concurrency is done at the file level. Each test file will fill a test worker slot. Individual tests/steps in a test file will not run concurrently.
