### PR TITLE
Extend Nightwatch to use externally loaded tests.

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -626,7 +626,7 @@ CliRunner.prototype = {
     return false;
   },
 
-  runPreloadedTests: function(modules) {
+  runPreloadedTests: function(modules, callback) {
     if(this.parallelMode) {
       return this;
     }
@@ -639,16 +639,17 @@ CliRunner.prototype = {
         output_folder: self.output_folder,
         src_folders: self.settings.src_folders,
         live_output: self.settings.live_output
-      }, function(err) {
+      }, function(err, results) {
+
         self.stopSelenium();
 
-        var afterGlobal = self.test_settings.globals && self.test_settings.globals.after || function(done) {
-          done();
-        };
-        var context = self.test_settings && self.test_settings.globals || null;
-        afterGlobal.call(context, function() {
-          self.globalErrorHandler(err);
+        var globalsContext = self.test_settings && self.test_settings.globals || null;
+        var afterGlobal = Utils.checkFunction('after', globalsContext) || function(done) {done();};
+
+        afterGlobal.call(globalsContext, function done() {
+          self.globalErrorHandler(err, results, callback);
         });
+
       });
 
       Runner.runTestModule(null, modules);

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -624,6 +624,37 @@ CliRunner.prototype = {
       }
     }
     return false;
+  },
+
+  runPreloadedTests: function(modules) {
+    if(this.parallelMode) {
+      return this;
+    }
+
+    var self = this;
+
+    this.startSelenium(function() {
+
+      Runner.init(self.test_settings, {
+        output_folder: self.output_folder,
+        src_folders: self.settings.src_folders,
+        live_output: self.settings.live_output
+      }, function(err) {
+        self.stopSelenium();
+
+        var afterGlobal = self.test_settings.globals && self.test_settings.globals.after || function(done) {
+          done();
+        };
+        var context = self.test_settings && self.test_settings.globals || null;
+        afterGlobal.call(context, function() {
+          self.globalErrorHandler(err);
+        });
+      });
+
+      Runner.runTestModule(null, modules);
+    });
+
+    return this;
   }
 };
 

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -22,7 +22,15 @@ module.exports = new (function() {
     modules : {}
   };
 
-  function runModule(module, opts, moduleName, moduleKey, moduleCallback, finishCallback) {
+  var globalFinishCallback = null;
+  var globalOpts = null;
+  var globalAdditionalOpts = null;
+  var globalPaths = null;
+  var globalReporter = null;
+  var runGlobalBeforeEach = null;
+  var runGlobalAfterEach = null;
+
+  var runModule = function runModule(module, opts, moduleName, moduleKey, moduleCallback, finishCallback) {
     var client;
     var keys = Object.keys(module);
     var currentTest;
@@ -270,7 +278,7 @@ module.exports = new (function() {
     } else {
       setTimeout(next, 0);
     }
-  }
+  };
 
   function callTearDown(module, results, errors, onTestComplete, hasCallback) {
     module.results = results;
@@ -472,6 +480,8 @@ module.exports = new (function() {
     return diffInFolder;
   }
 
+  function noopFn() {}
+
   /**
    *
    * @param {Array} test_source
@@ -479,41 +489,39 @@ module.exports = new (function() {
    * @param {object} additional_opts
    * @param {function} finishCallback
    */
-  this.run = function runner(test_source, opts, additional_opts, finishCallback) {
+  var run = function runner(test_source, opts, additional_opts, finishCallback) {
     opts.parallelMode = process.env.__NIGHTWATCH_PARALLEL_MODE == '1';
     opts.live_output = additional_opts.live_output;
     opts.report_prefix = '';
-
-    globalStartTime = new Date().getTime();
-    var noopFn = function() {};
-    finishCallback = finishCallback || noopFn;
 
     if (typeof test_source == 'string') {
       test_source = [test_source];
     }
 
-    var paths = test_source.map(function (p) {
+    globalPaths = test_source.map(function (p) {
       if (p.indexOf(process.cwd()) === 0) {
         return p;
       }
       return path.join(process.cwd(), p);
     });
 
-    if (paths.length === 0) {
+    if (globalPaths.length === 0) {
       throw new Error('No tests to run.');
     }
 
-    function runTestModule(err, fullpaths) {
-      var errorMessage = ['No tests defined! using source folder:', paths];
+    init(opts, additional_opts, finishCallback);
 
-      if (opts.tag_filter) {
-        errorMessage.push('; using tags:', opts.tag_filter);
+    function runTestModule(err, fullpaths) {
+      var errorMessage = ['No tests defined! using source folder:', globalPaths];
+
+      if (globalOpts.tag_filter) {
+        errorMessage.push('; using tags:', globalOpts.tag_filter);
       }
 
-      opts.modulesNo = fullpaths && fullpaths.length || 0;
+      globalOpts.modulesNo = fullpaths && fullpaths.length || 0;
 
       if (!fullpaths || fullpaths.length === 0) {
-        finishCallback({message: errorMessage.join(' ')});
+        globalFinishCallback({message: errorMessage.join(' ')});
         return;
       }
 
@@ -522,96 +530,87 @@ module.exports = new (function() {
       try {
         module = require(modulePath);
       } catch (err) {
-        finishCallback(err);
+        globalFinishCallback(err);
         throw err;
       }
 
       var moduleParts = modulePath.split(path.sep);
       var moduleName = moduleParts.pop();
-      var subFolder = getPathDiff(moduleParts.join(path.sep), additional_opts);
+      var subFolder = getPathDiff(moduleParts.join(path.sep), globalAdditionalOpts);
       var moduleKey = path.join(subFolder, moduleName);
 
-      if (paths.length > 1) {
+      if (globalPaths.length > 1) {
         var parentFolder = moduleParts.pop();
         moduleKey = parentFolder + path.sep + moduleKey;
       }
       globalResults.modules[moduleKey] = {};
 
       var testSuiteName = Utils.getTestSuiteName(moduleName);
-      if (opts.output) {
+      if (globalOpts.output) {
         var testSuiteDisplay = '[' + testSuiteName + '] Test Suite';
         console.log('\n' + Logger.colors.cyan(testSuiteDisplay, Logger.colors.background.black));
         console.log(Logger.colors.purple(new Array(testSuiteDisplay.length + 1).join('=')));
       }
 
-      opts.desiredCapabilities = opts.desiredCapabilities || {};
-      if (opts.sync_test_names || (typeof opts.sync_test_names == 'undefined')) {
+      globalOpts.desiredCapabilities = globalOpts.desiredCapabilities || {};
+      if (globalOpts.sync_test_names || (typeof globalOpts.sync_test_names == 'undefined')) {
         // optionally send the local test name (derived from filename)
         // to the remote selenium server. useful for test reporting in cloud service providers
-        opts.desiredCapabilities.name = testSuiteName;
+        globalOpts.desiredCapabilities.name = testSuiteName;
       }
 
       if (typeof module.desiredCapabilities == 'object') {
         for (var capability in module.desiredCapabilities) {
           if (module.desiredCapabilities.hasOwnProperty(capability)) {
-            opts.desiredCapabilities[capability] = module.desiredCapabilities[capability];
+            globalOpts.desiredCapabilities[capability] = module.desiredCapabilities[capability];
           }
         }
       }
 
-      var runGlobalBeforeEach = !module.disabled && Utils.checkFunction('beforeEach', opts.globals) || noopFn;
-      var runGlobalAfterEach = !module.disabled && Utils.checkFunction('afterEach', opts.globals) || noopFn;
-      var globalReporter = Utils.checkFunction('reporter', opts.globals) || noopFn;
-
-      // Convert synchronous functions to async if necessary.
-      runGlobalBeforeEach = Utils.makeFnAsync(1, runGlobalBeforeEach);
-      runGlobalAfterEach = Utils.makeFnAsync(1, runGlobalAfterEach);
-      globalReporter = Utils.makeFnAsync(2, globalReporter);
-
-      runGlobalBeforeEach.call(opts.globals, function() {
-        runModule(module, opts, moduleName, moduleKey, function moduleCallback(err, modulekeys) {
-          runGlobalAfterEach.call(opts.globals, function() {
+      runGlobalBeforeEach.call(globalOpts.globals, function() {
+        runModule(module, globalOpts, moduleName, moduleKey, function moduleCallback(err, modulekeys) {
+          runGlobalAfterEach.call(globalOpts.globals, function() {
             if (fullpaths.length) {
               setTimeout(function() {
                 runTestModule(err, fullpaths);
               }, 1000);
             } else {
-              if (opts.output) {
+              if (globalOpts.output) {
                 printTotalResults(globalResults, modulekeys, globalStartTime);
               }
 
-              if (additional_opts.output_folder === false) {
-                globalReporter.call(opts.globals, globalResults, function() {
-                  finishCallback(null, globalResults, modulekeys);
+              if (globalAdditionalOpts.output_folder === false) {
+                globalReporter.call(globalOpts.globals, globalResults, function() {
+                  globalFinishCallback(null, globalResults, modulekeys);
                 });
               } else {
-                mkpath(additional_opts.output_folder, function(err) {
+                mkpath(globalAdditionalOpts.output_folder, function(err) {
                   if (err) {
                     console.log(Logger.colors.yellow('Output folder doesn\'t exist and cannot be created.'));
                     console.log(err.stack);
-                    finishCallback(null);
+                    globalFinishCallback(null);
                     return;
                   }
 
                   var Reporter = require('./reporters/junit.js');
                   Reporter.save(globalResults, {
-                    output_folder : additional_opts.output_folder,
-                    filename_prefix : opts.report_prefix
+                    output_folder : globalAdditionalOpts.output_folder,
+                    filename_prefix : globalOpts.report_prefix
                   }, function(err) {
                     if (err) {
-                      console.log(Logger.colors.yellow('Warning: Failed to save report file to folder: ' + additional_opts.output_folder));
+                      console.log(Logger.colors.yellow('Warning: Failed to save report file to folder: ' + globalAdditionalOpts.output_folder));
                       console.log(err.stack);
                     }
 
-                    globalReporter.call(opts.globals, globalResults, function() {
-                      finishCallback(null, globalResults);
+                    globalReporter.call(globalOpts.globals, globalResults, function() {
+                      globalFinishCallback(null, globalResults);
                     });
                   });
                 });
               }
             }
           });
-        }, finishCallback);
+        }, globalFinishCallback);
       });
     }
 
@@ -619,17 +618,39 @@ module.exports = new (function() {
     var foundPaths = [];
     var joinedPaths = 0;
 
-    runFiles(paths, function (err, fullpaths) {
+    runFiles(globalPaths, function (err, fullpaths) {
       if (fullpaths && fullpaths.length > 0) {
         foundPaths = foundPaths.concat(fullpaths);
       }
       joinedPaths++;
 
-      if (joinedPaths === paths.length) {
+      if (joinedPaths === globalPaths.length) {
         runTestModule(null, foundPaths);
       }
-    }, opts);
+    }, globalOpts);
 
-    processListener(finishCallback);
+    processListener(globalFinishCallback);
   };
+
+  var init = function(opts, additional_opts, finishCallback) {
+    globalOpts = opts;
+    globalAdditionalOpts = additional_opts;
+
+    globalStartTime = new Date().getTime();
+
+    globalFinishCallback = finishCallback || noopFn;
+
+    var runGlobalBeforeEach = !module.disabled && Utils.checkFunction('beforeEach', opts.globals) || noopFn;
+    var runGlobalAfterEach = !module.disabled && Utils.checkFunction('afterEach', opts.globals) || noopFn;
+    var globalReporter = Utils.checkFunction('reporter', opts.globals) || noopFn;
+
+    // Convert synchronous functions to async if necessary.
+    runGlobalBeforeEach = Utils.makeFnAsync(1, runGlobalBeforeEach);
+    runGlobalAfterEach = Utils.makeFnAsync(1, runGlobalAfterEach);
+    globalReporter = Utils.makeFnAsync(2, globalReporter);
+  };
+
+  this.init = init;
+  this.run = run;
+
 })();

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -482,6 +482,109 @@ module.exports = new (function() {
 
   function noopFn() {}
 
+  function runTestModule(err, fullpaths) {
+    var errorMessage = ['No tests defined! using source folder:', globalPaths];
+
+    if (globalOpts.tag_filter) {
+      errorMessage.push('; using tags:', globalOpts.tag_filter);
+    }
+
+    globalOpts.modulesNo = fullpaths && fullpaths.length || 0;
+
+    if (!fullpaths || fullpaths.length === 0) {
+      globalFinishCallback({message: errorMessage.join(' ')});
+      return;
+    }
+
+    var module;
+    var modulePath = fullpaths.shift();
+    try {
+      module = require(modulePath);
+    } catch (err) {
+      globalFinishCallback(err);
+      throw err;
+    }
+
+    var moduleParts = modulePath.split(path.sep);
+    var moduleName = moduleParts.pop();
+    var subFolder = getPathDiff(moduleParts.join(path.sep), globalAdditionalOpts);
+    var moduleKey = path.join(subFolder, moduleName);
+
+    if (globalPaths.length > 1) {
+      var parentFolder = moduleParts.pop();
+      moduleKey = parentFolder + path.sep + moduleKey;
+    }
+    globalResults.modules[moduleKey] = {};
+
+    var testSuiteName = Utils.getTestSuiteName(moduleName);
+    if (globalOpts.output) {
+      var testSuiteDisplay = '[' + testSuiteName + '] Test Suite';
+      console.log('\n' + Logger.colors.cyan(testSuiteDisplay, Logger.colors.background.black));
+      console.log(Logger.colors.purple(new Array(testSuiteDisplay.length + 1).join('=')));
+    }
+
+    globalOpts.desiredCapabilities = globalOpts.desiredCapabilities || {};
+    if (globalOpts.sync_test_names || (typeof globalOpts.sync_test_names == 'undefined')) {
+      // optionally send the local test name (derived from filename)
+      // to the remote selenium server. useful for test reporting in cloud service providers
+      globalOpts.desiredCapabilities.name = testSuiteName;
+    }
+
+    if (typeof module.desiredCapabilities == 'object') {
+      for (var capability in module.desiredCapabilities) {
+        if (module.desiredCapabilities.hasOwnProperty(capability)) {
+          globalOpts.desiredCapabilities[capability] = module.desiredCapabilities[capability];
+        }
+      }
+    }
+
+    runGlobalBeforeEach.call(globalOpts.globals, function() {
+      runModule(module, globalOpts, moduleName, moduleKey, function moduleCallback(err, modulekeys) {
+        runGlobalAfterEach.call(globalOpts.globals, function() {
+          if (fullpaths.length) {
+            setTimeout(function() {
+              runTestModule(err, fullpaths);
+            }, 1000);
+          } else {
+            if (globalOpts.output) {
+              printTotalResults(globalResults, modulekeys, globalStartTime);
+            }
+
+            if (globalAdditionalOpts.output_folder === false) {
+              globalReporter.call(globalOpts.globals, globalResults, function() {
+                globalFinishCallback(null, globalResults, modulekeys);
+              });
+            } else {
+              mkpath(globalAdditionalOpts.output_folder, function(err) {
+                if (err) {
+                  console.log(Logger.colors.yellow('Output folder doesn\'t exist and cannot be created.'));
+                  console.log(err.stack);
+                  globalFinishCallback(null);
+                  return;
+                }
+
+                var Reporter = require('./reporters/junit.js');
+                Reporter.save(globalResults, {
+                  output_folder : globalAdditionalOpts.output_folder,
+                  filename_prefix : globalOpts.report_prefix
+                }, function(err) {
+                  if (err) {
+                    console.log(Logger.colors.yellow('Warning: Failed to save report file to folder: ' + globalAdditionalOpts.output_folder));
+                    console.log(err.stack);
+                  }
+
+                  globalReporter.call(globalOpts.globals, globalResults, function() {
+                    globalFinishCallback(null, globalResults);
+                  });
+                });
+              });
+            }
+          }
+        });
+      }, globalFinishCallback);
+    });
+  }
+
   /**
    *
    * @param {Array} test_source
@@ -510,109 +613,6 @@ module.exports = new (function() {
     }
 
     init(opts, additional_opts, finishCallback);
-
-    function runTestModule(err, fullpaths) {
-      var errorMessage = ['No tests defined! using source folder:', globalPaths];
-
-      if (globalOpts.tag_filter) {
-        errorMessage.push('; using tags:', globalOpts.tag_filter);
-      }
-
-      globalOpts.modulesNo = fullpaths && fullpaths.length || 0;
-
-      if (!fullpaths || fullpaths.length === 0) {
-        globalFinishCallback({message: errorMessage.join(' ')});
-        return;
-      }
-
-      var module;
-      var modulePath = fullpaths.shift();
-      try {
-        module = require(modulePath);
-      } catch (err) {
-        globalFinishCallback(err);
-        throw err;
-      }
-
-      var moduleParts = modulePath.split(path.sep);
-      var moduleName = moduleParts.pop();
-      var subFolder = getPathDiff(moduleParts.join(path.sep), globalAdditionalOpts);
-      var moduleKey = path.join(subFolder, moduleName);
-
-      if (globalPaths.length > 1) {
-        var parentFolder = moduleParts.pop();
-        moduleKey = parentFolder + path.sep + moduleKey;
-      }
-      globalResults.modules[moduleKey] = {};
-
-      var testSuiteName = Utils.getTestSuiteName(moduleName);
-      if (globalOpts.output) {
-        var testSuiteDisplay = '[' + testSuiteName + '] Test Suite';
-        console.log('\n' + Logger.colors.cyan(testSuiteDisplay, Logger.colors.background.black));
-        console.log(Logger.colors.purple(new Array(testSuiteDisplay.length + 1).join('=')));
-      }
-
-      globalOpts.desiredCapabilities = globalOpts.desiredCapabilities || {};
-      if (globalOpts.sync_test_names || (typeof globalOpts.sync_test_names == 'undefined')) {
-        // optionally send the local test name (derived from filename)
-        // to the remote selenium server. useful for test reporting in cloud service providers
-        globalOpts.desiredCapabilities.name = testSuiteName;
-      }
-
-      if (typeof module.desiredCapabilities == 'object') {
-        for (var capability in module.desiredCapabilities) {
-          if (module.desiredCapabilities.hasOwnProperty(capability)) {
-            globalOpts.desiredCapabilities[capability] = module.desiredCapabilities[capability];
-          }
-        }
-      }
-
-      runGlobalBeforeEach.call(globalOpts.globals, function() {
-        runModule(module, globalOpts, moduleName, moduleKey, function moduleCallback(err, modulekeys) {
-          runGlobalAfterEach.call(globalOpts.globals, function() {
-            if (fullpaths.length) {
-              setTimeout(function() {
-                runTestModule(err, fullpaths);
-              }, 1000);
-            } else {
-              if (globalOpts.output) {
-                printTotalResults(globalResults, modulekeys, globalStartTime);
-              }
-
-              if (globalAdditionalOpts.output_folder === false) {
-                globalReporter.call(globalOpts.globals, globalResults, function() {
-                  globalFinishCallback(null, globalResults, modulekeys);
-                });
-              } else {
-                mkpath(globalAdditionalOpts.output_folder, function(err) {
-                  if (err) {
-                    console.log(Logger.colors.yellow('Output folder doesn\'t exist and cannot be created.'));
-                    console.log(err.stack);
-                    globalFinishCallback(null);
-                    return;
-                  }
-
-                  var Reporter = require('./reporters/junit.js');
-                  Reporter.save(globalResults, {
-                    output_folder : globalAdditionalOpts.output_folder,
-                    filename_prefix : globalOpts.report_prefix
-                  }, function(err) {
-                    if (err) {
-                      console.log(Logger.colors.yellow('Warning: Failed to save report file to folder: ' + globalAdditionalOpts.output_folder));
-                      console.log(err.stack);
-                    }
-
-                    globalReporter.call(globalOpts.globals, globalResults, function() {
-                      globalFinishCallback(null, globalResults);
-                    });
-                  });
-                });
-              }
-            }
-          });
-        }, globalFinishCallback);
-      });
-    }
 
     // Accumulate various test paths under one or more src_folder paths, then run tests.
     var foundPaths = [];

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -31,6 +31,9 @@ module.exports = new (function() {
   var runGlobalAfterEach = null;
 
   var runModule = function runModule(module, opts, moduleName, moduleKey, moduleCallback, finishCallback) {
+
+    globalResults.modules[moduleKey] = {};
+
     var client;
     var keys = Object.keys(module);
     var currentTest;
@@ -482,41 +485,58 @@ module.exports = new (function() {
 
   function noopFn() {}
 
-  function runTestModule(err, fullpaths) {
+  function loadModules(err, fullpaths) {
+
+    var modules = [];
+
+    fullpaths.forEach(function(fullpath) {
+
+      var moduleParts = fullpath.split(path.sep);
+      var moduleName = moduleParts.pop();
+      var subFolder = getPathDiff(moduleParts.join(path.sep), globalAdditionalOpts);
+      var moduleKey = path.join(subFolder, moduleName);
+
+      if (globalPaths.length > 1) {
+        var parentFolder = moduleParts.pop();
+        moduleKey = parentFolder + path.sep + moduleKey;
+      }
+
+      try {
+        var module = require(fullpath);
+
+        if (module) {
+          module.moduleKey = moduleKey;
+          module.moduleName = moduleName;
+
+          modules.push(module);
+        }
+      } catch(err) {
+        globalFinishCallback(err);
+        throw err;
+      }
+    });
+
+    return modules;
+
+  }
+
+  function runTestModule(err, modules) {
     var errorMessage = ['No tests defined! using source folder:', globalPaths];
 
     if (globalOpts.tag_filter) {
       errorMessage.push('; using tags:', globalOpts.tag_filter);
     }
 
-    globalOpts.modulesNo = fullpaths && fullpaths.length || 0;
+    globalOpts.modulesNo = modules && modules.length || 0;
 
-    if (!fullpaths || fullpaths.length === 0) {
+    if (!modules || modules.length === 0) {
       globalFinishCallback({message: errorMessage.join(' ')});
       return;
     }
 
-    var module;
-    var modulePath = fullpaths.shift();
-    try {
-      module = require(modulePath);
-    } catch (err) {
-      globalFinishCallback(err);
-      throw err;
-    }
+    var module = modules.shift();
 
-    var moduleParts = modulePath.split(path.sep);
-    var moduleName = moduleParts.pop();
-    var subFolder = getPathDiff(moduleParts.join(path.sep), globalAdditionalOpts);
-    var moduleKey = path.join(subFolder, moduleName);
-
-    if (globalPaths.length > 1) {
-      var parentFolder = moduleParts.pop();
-      moduleKey = parentFolder + path.sep + moduleKey;
-    }
-    globalResults.modules[moduleKey] = {};
-
-    var testSuiteName = Utils.getTestSuiteName(moduleName);
+    var testSuiteName = Utils.getTestSuiteName(module.moduleName);
     if (globalOpts.output) {
       var testSuiteDisplay = '[' + testSuiteName + '] Test Suite';
       console.log('\n' + Logger.colors.cyan(testSuiteDisplay, Logger.colors.background.black));
@@ -539,11 +559,11 @@ module.exports = new (function() {
     }
 
     runGlobalBeforeEach.call(globalOpts.globals, function() {
-      runModule(module, globalOpts, moduleName, moduleKey, function moduleCallback(err, modulekeys) {
+      runModule(module, globalOpts, module.moduleName, module.moduleKey, function moduleCallback(err, modulekeys) {
         runGlobalAfterEach.call(globalOpts.globals, function() {
-          if (fullpaths.length) {
+          if (modules.length) {
             setTimeout(function() {
-              runTestModule(err, fullpaths);
+              runTestModule(err, modules);
             }, 1000);
           } else {
             if (globalOpts.output) {
@@ -624,9 +644,14 @@ module.exports = new (function() {
       }
       joinedPaths++;
 
+      var modules = loadModules(err, foundPaths);
+
+      runTestModule(err, modules);
+
+      /*
       if (joinedPaths === globalPaths.length) {
         runTestModule(null, foundPaths);
-      }
+      }*/
     }, globalOpts);
 
     processListener(globalFinishCallback);
@@ -640,9 +665,9 @@ module.exports = new (function() {
 
     globalFinishCallback = finishCallback || noopFn;
 
-    var runGlobalBeforeEach = !module.disabled && Utils.checkFunction('beforeEach', opts.globals) || noopFn;
-    var runGlobalAfterEach = !module.disabled && Utils.checkFunction('afterEach', opts.globals) || noopFn;
-    var globalReporter = Utils.checkFunction('reporter', opts.globals) || noopFn;
+    runGlobalBeforeEach = !module.disabled && Utils.checkFunction('beforeEach', opts.globals) || noopFn;
+    runGlobalAfterEach = !module.disabled && Utils.checkFunction('afterEach', opts.globals) || noopFn;
+    globalReporter = Utils.checkFunction('reporter', opts.globals) || noopFn;
 
     // Convert synchronous functions to async if necessary.
     runGlobalBeforeEach = Utils.makeFnAsync(1, runGlobalBeforeEach);

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -536,6 +536,10 @@ module.exports = new (function() {
 
     var module = modules.shift();
 
+    if (module.moduleKey === undefined) {
+      module.moduleKey = module.moduleName;
+    }
+
     var testSuiteName = Utils.getTestSuiteName(module.moduleName);
     if (globalOpts.output) {
       var testSuiteDisplay = '[' + testSuiteName + '] Test Suite';
@@ -677,5 +681,6 @@ module.exports = new (function() {
 
   this.init = init;
   this.run = run;
+  this.runTestModule = runTestModule;
 
 })();

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "grunt": "~0.4.4",
-    "ejs": ">=0.8.3",
+    "ejs": "~0.8.3",
     "optimist": ">=0.3.5",
     "minimatch": "~0.2.14",
     "mkpath": ">=0.1.0"

--- a/tests/src/runner/testRunner.js
+++ b/tests/src/runner/testRunner.js
@@ -73,7 +73,7 @@ module.exports = {
   },
 
   testRunMultipleSrcFolders : function(test) {
-    test.expect(8);
+    test.expect(9);
     var testsPath = path.join(process.cwd(), '/sampletests/simple');
     var testsPath2 = path.join(process.cwd(), '/sampletests/srcfolders');
     this.Runner.run([testsPath2, testsPath], {

--- a/tests/src/runner/testRunnerExt.js
+++ b/tests/src/runner/testRunnerExt.js
@@ -1,0 +1,49 @@
+var BASE_PATH = process.env.NIGHTWATCH_COV ? 'lib-cov' : 'lib';
+
+var simpleSampleTest = require('../../sampletests/simple/sample');
+var path = require('path');
+
+module.exports = {
+	setUp : function(cb) {
+		this.Runner = require('../../../'+ BASE_PATH +'/runner/run.js');
+		process.removeAllListeners('exit');
+		process.removeAllListeners('uncaughtException');
+		cb();
+	},
+
+	tearDown : function(callback) {
+		delete require.cache[require.resolve('../../../'+ BASE_PATH +'/runner/run.js')];
+		callback();
+	},
+
+	'load modules externally execute tests with runTestModule': function(test) {
+
+		//console.log(simpleSampleTest);
+
+		var modules = [];
+
+		simpleSampleTest.moduleName = 'demoTest';
+		modules.push(simpleSampleTest);
+
+		var opts = {
+			seleniumPort: 10195,
+			silent: true,
+			output: false,
+			globals: {
+				test: test
+			}
+		};
+
+		this.Runner.init(opts, {
+			output_folder: false
+		}, function(err, results) {
+
+			test.equals(err, null);
+			test.ok('simple/sample' in results.modules);
+			test.ok('demoTest' in results.modules['simple/sample']);
+			test.done();
+		});
+
+		this.Runner.runTestModule(null, modules);
+	}
+};


### PR DESCRIPTION
Extended Nightwatch to allow you to use externally loaded tests with the Nightwatch CliRunner.

My primary driver for this change, was a requirement to run BDD style tests using Yadda. There are examples where this was done before: [Yadda + Nightwatch.js](https://gist.github.com/kbingman/730b9f2307ef776f1f66)

However because Nightwatch's currently loads tests via a filepath, the approach shown above had some limitations.
* Only one test could be run
* Test reporter couldn't deal with multiple modules
* Test reporter didn't reporter didn't record correct steps

### How to use applied changes

You can now load your tests externally and pass it directly to the CliRunner

```javascript
var testModules = [];
var someTest = require('./tests/sometest');
someTest.moduleName = 'Your Module Name';
testModules.push(someTest);

var runner = new CliRunner(...);
runner.runPreloadedTests(testModules);
```
**Note:*** All modules require a moduleName and or a moduleKey if no moduleName is supplied the moduleKey would be derived from the name.

### Notes

* All tests are passing
* Changes applied to the run.js meant I had to move quite a number of variables into global scope (within run.js) this is not ideal, if I had more time I would have tried to break run.js into multiple files.

@beatfactor I've reopened this pull request, as my old one got stale. 
I've tried to make my commits tell a story of how I changed run.js, I'm quite keen to get this pull request merged, as we've invested heavily using this framework, we have a number of enhancements that would really benefit everyone using this framework :smiley: 