### PR TITLE
Added TeamCity reporter

### DIFF
--- a/lib/runner/reporters/teamcity.js
+++ b/lib/runner/reporters/teamcity.js
@@ -32,8 +32,8 @@ module.exports = new (function() {
 	this.isTeamCity = function() {
 		return true;
 		if (_isTeamCity === null) {
-			// If the TEAMCITY_DATA_PATH is defined then we are being run from TeamCity.
-			_isTeamCity = !! process.env.TEAMCITY_DATA_PATH;
+			// If the TEAMCITY_VERSION is defined then we are being run from TeamCity.
+			_isTeamCity = !! process.env.TEAMCITY_VERSION;
 		}
 
 		return _isTeamCity;

--- a/lib/runner/reporters/teamcity.js
+++ b/lib/runner/reporters/teamcity.js
@@ -1,5 +1,5 @@
 /**
- * Created by paul on 1/3/15.
+ * Created by pstuart2 on 1/3/15.
  */
 
 var path = require('path');
@@ -7,44 +7,87 @@ var path = require('path');
 'use strict';
 module.exports = new (function() {
 
-	/*
+	var
+			/**
+			 * This is the current test suite we are running. We are counting the top most directory as the
+			 * test suite. We use this to see when we change and then know when to call testSuiteFinished().
+			 *
+			 * @type {null}|{string}
+			 */
+			_currentSuite = null,
 
-	 ##teamcity[testSuiteStarted name='suiteName']
+			/**
+			 * This is just holds the status of our environment check so that we only have to hit it once.
+			 *
+			 * @type {null}|{boolean}
+			 * @private
+			 */
+			_isTeamCity = null;
 
-	 ##teamcity[testSuiteStarted name='nestedSuiteName']
-	 ##teamcity[testStarted name='package_or_namespace.ClassName.TestName']
-	 ##teamcity[testFailed name='package_or_namespace.ClassName.TestName' message='The number should be 20000' details='junit.framework.AssertionFailedError: expected:<20000> but was:<10000>|n|r    at junit.framework.Assert.fail(Assert.java:47)|n|r    at junit.framework.Assert.failNotEquals(Assert.java:280)|n|r...']
-	 ##teamcity[testFinished name='package_or_namespace.ClassName.TestName']
-	 ##teamcity[testSuiteFinished name='nestedSuiteName']
-	 ##teamcity[testSuiteFinished name='suiteName']
-
+	/**
+	 * Returns true if we are running in a TeamCity environment, else false.
+	 *
+	 * @returns {boolean}
 	 */
+	this.isTeamCity = function() {
+		if (_isTeamCity === null) {
+			// If the TEAMCITY_DATA_PATH is defined then we are being run from TeamCity.
+			_isTeamCity = !! process.env.TEAMCITY_DATA_PATH;
+		}
 
-	var currentSuite = null;
+		return _isTeamCity;
+	};
 
+	/**
+	 * Starts a test suite. A test suite is currently the top most directory of the module key.
+	 *
+	 * @param moduleKey
+	 */
 	this.testSuiteStarted = function (moduleKey) {
+		if (!this.isTeamCity()) { return; }
+
 		var paths = moduleKey.split('/');
 		if (paths.length && currentSuite !== paths[0]) {
 			// Finish the previous suite.
 			this.testSuiteFinished();
 
-			currentSuite = paths[0];
-			console.log("##teamcity[testSuiteStarted name='" + currentSuite + "']");
+			_currentSuite = paths[0];
+			console.log("##teamcity[testSuiteStarted name='" + _currentSuite + "']");
 		}
 	};
 
+	/**
+	 * Finishes a test suite. Called internally except for after all tests complete, then
+	 * it must be called manually the last time.
+	 */
 	this.testSuiteFinished = function () {
-		if (currentSuite) {
-			console.log("##teamcity[testSuiteFinished name='" + currentSuite + "']");
-			currentSuite = null;
+		if (!this.isTeamCity()) { return; }
+
+		if (_currentSuite) {
+			console.log("##teamcity[testSuiteFinished name='" + _currentSuite + "']");
+			_currentSuite = null;
 		}
 	};
 
+	/**
+	 * Starts a test.
+	 *
+	 * @param moduleKey
+	 */
 	this.testStarted = function (moduleKey) {
+		if (!this.isTeamCity()) { return; }
 		console.log("##teamcity[testStarted name='" + moduleKey + "']");
 	};
 
-	this.testFinished = function (moduleKey, results, errors) {
+	/**
+	 * Completes the test providing TeamCity with the pass / fail.
+	 *
+	 * @param moduleKey
+	 * @param results
+	 */
+	this.testFinished = function (moduleKey, results) {
+		if (!this.isTeamCity()) { return; }
+
 		if (results.failed || results.errors) {
 
 			// Get the last results.tests as that will be the failure.

--- a/lib/runner/reporters/teamcity.js
+++ b/lib/runner/reporters/teamcity.js
@@ -4,9 +4,9 @@
 
 var path = require('path');
 
-'use strict';
 module.exports = new (function() {
-
+	'use strict';
+	
 	var
 			/**
 			 * This is the current test suite we are running. We are counting the top most directory as the
@@ -30,7 +30,6 @@ module.exports = new (function() {
 	 * @returns {boolean}
 	 */
 	this.isTeamCity = function() {
-		return true;
 		if (_isTeamCity === null) {
 			// If the TEAMCITY_VERSION is defined then we are being run from TeamCity.
 			_isTeamCity = !! process.env.TEAMCITY_VERSION;
@@ -53,7 +52,7 @@ module.exports = new (function() {
 			this.testSuiteFinished();
 
 			_currentSuite = paths[0];
-			console.log("##teamcity[testSuiteStarted name='" + _currentSuite + "']");
+			console.log('##teamcity[testSuiteStarted name=\'' + _currentSuite + '\']');
 		}
 	};
 
@@ -65,7 +64,7 @@ module.exports = new (function() {
 		if (!this.isTeamCity()) { return; }
 
 		if (_currentSuite) {
-			console.log("##teamcity[testSuiteFinished name='" + _currentSuite + "']");
+			console.log('##teamcity[testSuiteFinished name=\'' + _currentSuite + '\']');
 			_currentSuite = null;
 		}
 	};
@@ -79,15 +78,15 @@ module.exports = new (function() {
 		if (!this.isTeamCity()) { return; }
 
 		var testName;
-		if (path.sep === "/") {
+		if (path.sep === '/') {
 			testName = moduleKey.replace(/\//g, '.');
-		} else if(path.sep === "\\") {
+		} else if(path.sep === '\\') {
 			testName = moduleKey.replace(/\\/g, '.');
 		} else {
 			testName = moduleKey.replace(/path.sep/g, '.');
 		}
 
-		console.log("##teamcity[testStarted name='" + testName + "']");
+		console.log('##teamcity[testStarted name=\'' + testName + '\']');
 	};
 
 	/**
@@ -105,11 +104,11 @@ module.exports = new (function() {
 
 			// Get the last results.tests as that will be the failure.
 			var failure = results.tests[results.tests.length - 1],
-					details = failure.stacktrace.replace(/\n/g, '|n|r');
+					details = failure.stacktrace.replace(/\n/g, '|n|r').replace('\'', '|\'');
 
-			console.log("##teamcity[testFailed name='" + testName + "' message='" + failure.message + "' details='" + details + "']");
+			console.log('##teamcity[testFailed name=\'' + testName + '\' message=\'' + failure.message + '\' details=\'' + details + '\']');
 		} else {
-			console.log("##teamcity[testFinished name='" + testName + "']");
+			console.log('##teamcity[testFinished name=\'' + testName + '\']');
 		}
 	};
 

--- a/lib/runner/reporters/teamcity.js
+++ b/lib/runner/reporters/teamcity.js
@@ -47,7 +47,7 @@ module.exports = new (function() {
 		if (!this.isTeamCity()) { return; }
 
 		var paths = moduleKey.split('/');
-		if (paths.length && currentSuite !== paths[0]) {
+		if (paths.length && _currentSuite !== paths[0]) {
 			// Finish the previous suite.
 			this.testSuiteFinished();
 

--- a/lib/runner/reporters/teamcity.js
+++ b/lib/runner/reporters/teamcity.js
@@ -46,7 +46,7 @@ module.exports = new (function() {
 	this.testSuiteStarted = function (moduleKey) {
 		if (!this.isTeamCity()) { return; }
 
-		var paths = moduleKey.split('/');
+		var paths = moduleKey.split(path.sep);
 		if (paths.length && _currentSuite !== paths[0]) {
 			// Finish the previous suite.
 			this.testSuiteFinished();
@@ -76,7 +76,9 @@ module.exports = new (function() {
 	 */
 	this.testStarted = function (moduleKey) {
 		if (!this.isTeamCity()) { return; }
-		console.log("##teamcity[testStarted name='" + moduleKey + "']");
+
+		var testName = moduleKey.replace(/path.sep/g, '.');
+		console.log("##teamcity[testStarted name='" + testName + "']");
 	};
 
 	/**
@@ -88,15 +90,17 @@ module.exports = new (function() {
 	this.testFinished = function (moduleKey, results) {
 		if (!this.isTeamCity()) { return; }
 
+		var testName = moduleKey.replace(/path.sep/g, '.');
+
 		if (results.failed || results.errors) {
 
 			// Get the last results.tests as that will be the failure.
 			var failure = results.tests[results.tests.length - 1],
 					details = failure.stacktrace.replace(/\n/g, '|n|r');
 
-			console.log("##teamcity[testFailed name='" + moduleKey + "' message='" + failure.message + "' details='" + details + "']");
+			console.log("##teamcity[testFailed name='" + testName + "' message='" + failure.message + "' details='" + details + "']");
 		} else {
-			console.log("##teamcity[testFinished name='" + moduleKey + "']");
+			console.log("##teamcity[testFinished name='" + testName + "']");
 		}
 	};
 

--- a/lib/runner/reporters/teamcity.js
+++ b/lib/runner/reporters/teamcity.js
@@ -30,6 +30,7 @@ module.exports = new (function() {
 	 * @returns {boolean}
 	 */
 	this.isTeamCity = function() {
+		return true;
 		if (_isTeamCity === null) {
 			// If the TEAMCITY_DATA_PATH is defined then we are being run from TeamCity.
 			_isTeamCity = !! process.env.TEAMCITY_DATA_PATH;
@@ -77,7 +78,15 @@ module.exports = new (function() {
 	this.testStarted = function (moduleKey) {
 		if (!this.isTeamCity()) { return; }
 
-		var testName = moduleKey.replace(/path.sep/g, '.');
+		var testName;
+		if (path.sep === "/") {
+			testName = moduleKey.replace(/\//g, '.');
+		} else if(path.sep === "\\") {
+			testName = moduleKey.replace(/\\/g, '.');
+		} else {
+			testName = moduleKey.replace(/path.sep/g, '.');
+		}
+
 		console.log("##teamcity[testStarted name='" + testName + "']");
 	};
 

--- a/lib/runner/reporters/teamcity.js
+++ b/lib/runner/reporters/teamcity.js
@@ -1,0 +1,60 @@
+/**
+ * Created by paul on 1/3/15.
+ */
+
+var path = require('path');
+
+'use strict';
+module.exports = new (function() {
+
+	/*
+
+	 ##teamcity[testSuiteStarted name='suiteName']
+
+	 ##teamcity[testSuiteStarted name='nestedSuiteName']
+	 ##teamcity[testStarted name='package_or_namespace.ClassName.TestName']
+	 ##teamcity[testFailed name='package_or_namespace.ClassName.TestName' message='The number should be 20000' details='junit.framework.AssertionFailedError: expected:<20000> but was:<10000>|n|r    at junit.framework.Assert.fail(Assert.java:47)|n|r    at junit.framework.Assert.failNotEquals(Assert.java:280)|n|r...']
+	 ##teamcity[testFinished name='package_or_namespace.ClassName.TestName']
+	 ##teamcity[testSuiteFinished name='nestedSuiteName']
+	 ##teamcity[testSuiteFinished name='suiteName']
+
+	 */
+
+	var currentSuite = null;
+
+	this.testSuiteStarted = function (moduleKey) {
+		var paths = moduleKey.split('/');
+		if (paths.length && currentSuite !== paths[0]) {
+			// Finish the previous suite.
+			this.testSuiteFinished();
+
+			currentSuite = paths[0];
+			console.log("##teamcity[testSuiteStarted name='" + currentSuite + "']");
+		}
+	};
+
+	this.testSuiteFinished = function () {
+		if (currentSuite) {
+			console.log("##teamcity[testSuiteFinished name='" + currentSuite + "']");
+			currentSuite = null;
+		}
+	};
+
+	this.testStarted = function (moduleKey) {
+		console.log("##teamcity[testStarted name='" + moduleKey + "']");
+	};
+
+	this.testFinished = function (moduleKey, results, errors) {
+		if (results.failed || results.errors) {
+
+			// Get the last results.tests as that will be the failure.
+			var failure = results.tests[results.tests.length - 1],
+					details = failure.stacktrace.replace(/\n/g, '|n|r');
+
+			console.log("##teamcity[testFailed name='" + moduleKey + "' message='" + failure.message + "' details='" + details + "']");
+		} else {
+			console.log("##teamcity[testFinished name='" + moduleKey + "']");
+		}
+	};
+
+})();

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -9,6 +9,7 @@ var Nightwatch = require('../../index.js');
 var Logger = require('../util/logger.js');
 var Utils = require('../util/utils.js');
 var fileMatcher = require('./filematcher.js');
+var teamCity = require('./reporters/teamcity.js');
 
 module.exports = new (function() {
   var globalStartTime;
@@ -76,6 +77,10 @@ module.exports = new (function() {
     };
 
     var onTestFinished = function (results, errors, startTime) {
+      if (opts.team_city) {
+        teamCity.testFinished(moduleKey, results, errors);
+      }
+
       globalResults.modules[moduleKey][currentTest] = {
         passed  : results.passed,
         failed  : results.failed,
@@ -148,6 +153,11 @@ module.exports = new (function() {
           console.log((opts.parallelMode && !opts.live_output ? 'Results for: ' : 'Running: '),
             Logger.colors.green(currentTest), '\n');
         }
+
+        if (opts.team_city) {
+          teamCity.testStarted(moduleKey);
+        }
+
         var localStartTime = new Date().getTime();
         var test = wrapTest(beforeEach, afterEach, module[currentTest], module, function(results, errors) {
           onTestFinished(results, errors, localStartTime);
@@ -549,6 +559,10 @@ module.exports = new (function() {
         console.log(Logger.colors.purple(new Array(testSuiteDisplay.length + 1).join('=')));
       }
 
+      if (opts.team_city) {
+        teamCity.testSuiteStarted(moduleKey);
+      }
+
       opts.desiredCapabilities = opts.desiredCapabilities || {};
       if (opts.sync_test_names || (typeof opts.sync_test_names == 'undefined')) {
         // optionally send the local test name (derived from filename)
@@ -583,6 +597,11 @@ module.exports = new (function() {
             } else {
               if (opts.output) {
                 printTotalResults(globalResults, modulekeys, globalStartTime);
+              }
+
+              // Only call manually at the very end.
+              if (opts.team_city) {
+                teamCity.testSuiteFinished();
               }
 
               if (additional_opts.output_folder === false) {

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -77,9 +77,7 @@ module.exports = new (function() {
     };
 
     var onTestFinished = function (results, errors, startTime) {
-      if (opts.team_city) {
-        teamCity.testFinished(moduleKey, results, errors);
-      }
+      teamCity.testFinished(moduleKey, results, errors);
 
       globalResults.modules[moduleKey][currentTest] = {
         passed  : results.passed,
@@ -154,9 +152,7 @@ module.exports = new (function() {
             Logger.colors.green(currentTest), '\n');
         }
 
-        if (opts.team_city) {
-          teamCity.testStarted(moduleKey);
-        }
+        teamCity.testStarted(moduleKey);
 
         var localStartTime = new Date().getTime();
         var test = wrapTest(beforeEach, afterEach, module[currentTest], module, function(results, errors) {
@@ -559,9 +555,7 @@ module.exports = new (function() {
         console.log(Logger.colors.purple(new Array(testSuiteDisplay.length + 1).join('=')));
       }
 
-      if (opts.team_city) {
-        teamCity.testSuiteStarted(moduleKey);
-      }
+      teamCity.testSuiteStarted(moduleKey);
 
       opts.desiredCapabilities = opts.desiredCapabilities || {};
       if (opts.sync_test_names || (typeof opts.sync_test_names == 'undefined')) {
@@ -600,9 +594,7 @@ module.exports = new (function() {
               }
 
               // Only call manually at the very end.
-              if (opts.team_city) {
-                teamCity.testSuiteFinished();
-              }
+              teamCity.testSuiteFinished();
 
               if (additional_opts.output_folder === false) {
                 globalReporter.call(opts.globals, globalResults, function() {


### PR DESCRIPTION
The TeamCity reporter will look for a TeamCity environment variable and if found will start emitting the TeamCity [service messages](https://confluence.jetbrains.com/display/TCD8/Build+Script+Interaction+with+TeamCity). This will allow TeamCity to give live reporting of how your tests are running. Nice for these Selenium style tests since they take quite a bit longer than unit tests. It will report a failed test as soon as it sees it in the log instead of waiting until the end.