### PR TITLE
when something's not visible recheck for it's presence.

### DIFF
--- a/lib/api/commands/waitForElementNotVisible.js
+++ b/lib/api/commands/waitForElementNotVisible.js
@@ -39,8 +39,8 @@ WaitForElementNotVisible.prototype.elementFound = function() {
 
 WaitForElementNotVisible.prototype.elementVisible = function(result, now) {
   if (now - this.startTimer < this.ms) {
-    // element wasn't visible, schedule another check
-    this.reschedule('isVisible');
+    // element was visible, schedule another check
+    this.reschedule();
     return this;
   }
 

--- a/lib/api/commands/waitForElementVisible.js
+++ b/lib/api/commands/waitForElementVisible.js
@@ -53,7 +53,7 @@ WaitForElementVisible.prototype.elementVisible = function(result, now) {
 WaitForElementVisible.prototype.elementNotVisible = function(result, now) {
   if (now - this.startTimer < this.ms) {
     // element wasn't visible, schedule another check
-    this.reschedule('isVisible');
+    this.reschedule();
     return this;
   }
 


### PR DESCRIPTION
The problem we was with the original implementation was, on some of our animated components, the end component was replaced when the animation finished, which means for a brief time it was not present, then present again.

The fix is that if the element is present but not visible, return to searching for presence.  This makes certain that elements are in lock-step with presence and visibility.

Addendum, this is also true for not-visible