### PR TITLE
Add option to retry failing tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -277,6 +277,10 @@ Nightwatch.prototype.printResult = function(elapsedTime) {
     }
   }
 
+  this.clearResult();
+};
+
+Nightwatch.prototype.clearResult = function() {
   this.errors.length = 0;
   this.results.passed = 0;
   this.results.failed = 0;
@@ -540,4 +544,3 @@ module.exports = new (function() {
     });
   };
 })();
-

--- a/lib/runner/cli/cli.js
+++ b/lib/runner/cli/cli.js
@@ -139,6 +139,10 @@ module.exports = new (function() {
       .defaults('')
       .alias('a');
 
+    // $ nightwatch --retries
+    this.command('retries')
+      .description('Retries failed or errored testcases up <n> times.');
+
     // $ nightwatch -h
     // $ nightwatch --help
     this.command('help')
@@ -154,4 +158,3 @@ module.exports = new (function() {
     return this;
   };
 })();
-

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -307,7 +307,8 @@ CliRunner.prototype = {
         start_session: self.startSession,
         reporter : self.argv.reporter,
         testcase : self.argv.testcase,
-        end_session_on_fail : self.endSessionOnFail
+        end_session_on_fail : self.endSessionOnFail,
+        retries : self.argv.retries
       }, function(err, results) {
         self.stopSelenium();
 

--- a/lib/runner/clientmanager.js
+++ b/lib/runner/clientmanager.js
@@ -62,12 +62,16 @@ ClientManager.prototype.results = function(type, value) {
   return this;
 };
 
+ClientManager.prototype.clearResult = function() {
+  return this['@client'].clearResult();
+};
+
 ClientManager.prototype.terminated = function() {
   return this['@client'].terminated;
 };
 
 ClientManager.prototype.print = function(startTime) {
-  return this['@client'].printResult.call(this['@client'], startTime);
+  return this['@client'].printResult(startTime);
 };
 
 ClientManager.prototype.api = function(key, value) {

--- a/lib/runner/testcase.js
+++ b/lib/runner/testcase.js
@@ -4,9 +4,11 @@ var Logger = require('../util/logger.js');
 var failSymbol = String.fromCharCode(10006);
 var doneSymbol = String.fromCharCode(10004);
 
-function TestCase(suite, testFn) {
+function TestCase(suite, testFn, numRetries, maxRetries) {
   this.suite = suite;
   this.testFn = testFn;
+  this.numRetries = numRetries;
+  this.maxRetries = maxRetries;
 }
 
 TestCase.prototype.print = function () {
@@ -14,8 +16,13 @@ TestCase.prototype.print = function () {
 
   if (opts.output) {
     process.stdout.write('\n');
-    console.log((opts.parallelMode && !opts.live_output ? 'Results for: ' : 'Running: '),
-      Logger.colors.green(this.testFn));
+    if (this.numRetries > 0) {
+      console.log('Retrying (' + this.numRetries + '/' + this.maxRetries + '): ',
+        Logger.colors.red(this.testFn));
+    } else {
+      console.log((opts.parallelMode && !opts.live_output ? 'Results for: ' : 'Running: '),
+        Logger.colors.green(this.testFn));
+    }
   }
   return this;
 };

--- a/lib/runner/testsuite.js
+++ b/lib/runner/testsuite.js
@@ -30,6 +30,7 @@ function TestSuite(modulePath, fullPaths, opts, addtOpts) {
   this.currentTest = '';
   this.module.setReportKey(fullPaths, addtOpts.src_folders);
   this.options = opts;
+  this.maxRetries = addtOpts.retries;
   this.suiteName = Utils.getTestSuiteName(this.module.getName());
   this.setupClient();
   this.initHooks();
@@ -189,6 +190,10 @@ TestSuite.prototype.printResult = function(startTime) {
   return this.client.print(startTime);
 };
 
+TestSuite.prototype.clearResult = function(startTime) {
+  return this.client.clearResult();
+};
+
 TestSuite.prototype.runTestSuiteModule = function() {
   var self = this;
   return this.before()
@@ -246,8 +251,24 @@ TestSuite.prototype.runNextTestCase = function(deffered) {
   if (this.currentTest) {
     this.testResults.steps.splice(this.testResults.steps.indexOf(this.currentTest), 1);
 
-    var testCase = new TestCase(this, this.currentTest);
-    testCase.print().run().then(function(response) {
+    deffered = this.runTestCase(this.currentTest, deffered, 0);
+  } else {
+    deffered.resolve();
+  }
+
+  return deffered.promise;
+};
+
+TestSuite.prototype.runTestCase = function(currentTest, deffered, numRetries) {
+  var self = this;
+  var testCase = new TestCase(this, currentTest, numRetries, this.maxRetries);
+
+  testCase.print().run().then(function(response) {
+    if ((response.results.failed || response.results.errors) && numRetries < self.maxRetries) {
+      numRetries++;
+      self.clearResult();
+      self.runTestCase(currentTest, deffered, numRetries);
+    } else {
       self.onTestCaseFinished(response.results, response.errors, response.time);
 
       if (self.client.terminated()) {
@@ -257,14 +278,12 @@ TestSuite.prototype.runNextTestCase = function(deffered) {
           self.runNextTestCase(deffered);
         });
       }
-    }, function(error) {
-      deffered.reject(error);
-    });
-  } else {
-    deffered.resolve();
-  }
+    }
+  }, function(error) {
+    deffered.reject(error);
+  });
 
-  return deffered.promise;
+  return deffered;
 };
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/sampletests/withfailures/sample.js
+++ b/tests/sampletests/withfailures/sample.js
@@ -1,0 +1,18 @@
+module.exports = {
+  demoTest : function (client) {
+    client.url('http://localhost')
+      .assert.elementPresent('#weblogin')
+      .assert.elementPresent('#badElement')
+      .end();
+  },
+
+  tearDown : function(callback) {
+    var client = this.client;
+    client.globals.test.deepEqual(this.results.passed, 1);
+    client.globals.test.deepEqual(this.results.failed, 1);
+    client.globals.test.deepEqual(this.results.errors, 0);
+    client.globals.test.deepEqual(this.results.skipped, 0);
+    client.globals.test.ok(this.results.tests.length, 2);
+    callback();
+  }
+};

--- a/tests/src/runner/testRunner.js
+++ b/tests/src/runner/testRunner.js
@@ -46,6 +46,26 @@ module.exports = {
     });
   },
 
+  testRunRetries : function(test) {
+    test.expect(11);
+    var testsPath = path.join(process.cwd(), '/sampletests/withfailures');
+    this.Runner.run([testsPath], {
+      seleniumPort : 10195,
+      silent : true,
+      output : false,
+      globals : {
+        test : test
+      }
+    }, {
+      output_folder : false,
+      start_session : true,
+      retries: 1
+    }, function(err, results) {
+      test.equals(err, null);
+      test.done();
+    });
+  },
+
   'test run multiple sources and same module name' : function(test) {
     var srcFolders = [
       path.join(process.cwd(), '/sampletests/simple'),


### PR DESCRIPTION
This adds the feature requested in https://github.com/beatfactor/nightwatch/issues/284

If you pass the command line option `--retries <n>` it will retry up to n times.

An important distinction is that it reruns the *testcase* (test method) not the entire test (all test methods in a test file). I think this is the desired behavior since you wouldn't want to rerun a passing test method and each testcase should be autonomous anyway.

Also, I assume that we would want to rerun both failing and erroring tests since the use case is to address flaky/unreliable tests, where either could happen.

Here's an example where test2 fails the first time but passes the second:

`bin/nightwatch --test examples/tests/github.js  --retries 1`

![screen shot 2015-05-05 at 1 28 14 pm](https://cloud.githubusercontent.com/assets/1311638/7478765/da0aa0f8-f32a-11e4-9a62-ee5eedf89d7b.png)