### PR TITLE
Preview Chai.js based expect assertions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,12 +19,6 @@ module.exports = function(grunt) {
       lib: {
         src: ['index.js', 'lib/**/*.js']
       },
-      tests: [
-        'tests/*.js',
-        'tests/extra/**/*.js',
-        'tests/src/**/*.js',
-        'tests/sampletests/**/*.js'
-      ],
       gruntfile: {
         src: 'Gruntfile.js'
       },

--- a/examples/tests/google.js
+++ b/examples/tests/google.js
@@ -1,3 +1,4 @@
+/* jshint expr: true */
 module.exports = {
   tags: ['google'],
   'Demo test Google' : function (client) {
@@ -6,11 +7,12 @@ module.exports = {
       .pause(1000);
 
     client.expect.element('body').to.be.present.before(1000);
-    client.expect.element('#lst-ib').to.have.css('display') //.matches(/block/).before(2000);
+    client.expect.element('#lst-ib').to.have.css('display');
 
     client.expect.element('body').to.have.attribute('class').which.contains('vasq');
     client.expect.element('body').to.have.attribute('class').which.matches(/vasq$/);
     client.expect.element('body').to.have.attribute('class').before(1000);
+
     client.expect.element('#lst-ib').to.be.enabled;
 
     client.expect.element('#hplogo').text.to.match(/Norge/).before(1000);

--- a/tests/nocks.js
+++ b/tests/nocks.js
@@ -43,36 +43,46 @@ module.exports = {
       mock.times(times);
     }
 
-      mock.reply(200, {
-        status: 0,
-        sessionId : '1352110219202',
-        value: value,
-        state : 'success'
-      });
+    mock.reply(200, {
+      status: 0,
+      sessionId : '1352110219202',
+      value: value,
+      state : 'success'
+    });
     return this;
   },
 
-  enabled : function () {
-    nock('http://localhost:10195')
+  enabled : function (times) {
+    var mock = nock('http://localhost:10195')
       .get('/wd/hub/session/1352110219202/element/0/enabled')
-      .reply(200, {
-        status: 0,
-        sessionId : '1352110219202',
-        value: true,
-        state : 'success'
-      });
+
+    if (times) {
+      mock.times(times);
+    }
+
+    mock.reply(200, {
+      status: 0,
+      sessionId : '1352110219202',
+      value: true,
+      state : 'success'
+    });
     return this;
   },
 
-  notEnabled : function () {
-    nock('http://localhost:10195')
+  notEnabled : function (times) {
+    var mock = nock('http://localhost:10195')
       .get('/wd/hub/session/1352110219202/element/0/enabled')
-      .reply(200, {
-        status: 0,
-        sessionId : '1352110219202',
-        value: false,
-        state : 'success'
-      });
+
+    if (times) {
+      mock.times(times);
+    }
+
+    mock.reply(200, {
+      status: 0,
+      sessionId : '1352110219202',
+      value: false,
+      state : 'success'
+    });
     return this;
   },
 
@@ -88,15 +98,20 @@ module.exports = {
     return this;
   },
 
-  notSelected : function () {
-    nock('http://localhost:10195')
+  notSelected : function (times) {
+    var mock = nock('http://localhost:10195')
       .get('/wd/hub/session/1352110219202/element/0/selected')
-      .reply(200, {
-        status: 0,
-        sessionId : '1352110219202',
-        value: false,
-        state : 'success'
-      });
+
+    if (times) {
+      mock.times(times);
+    }
+
+    mock.reply(200, {
+      status: 0,
+      sessionId : '1352110219202',
+      value: false,
+      state : 'success'
+    });
     return this;
   },
 
@@ -112,39 +127,54 @@ module.exports = {
     return this;
   },
 
-  notVisible : function () {
-    nock('http://localhost:10195')
+  notVisible : function (times) {
+    var mock = nock('http://localhost:10195')
       .get('/wd/hub/session/1352110219202/element/0/displayed')
-      .reply(200, {
-        status: 0,
-        sessionId : '1352110219202',
-        value: false,
-        state : 'success'
-      });
+
+    if (times) {
+      mock.times(times);
+    }
+
+    mock.reply(200, {
+      status: 0,
+      sessionId : '1352110219202',
+      value: false,
+      state : 'success'
+    });
     return this;
   },
 
-  value : function (value) {
-    nock('http://localhost:10195')
+  value : function (value, times) {
+    var mock = nock('http://localhost:10195')
       .get('/wd/hub/session/1352110219202/element/0/attribute/value')
-      .reply(200, {
-        status: 0,
-        sessionId : '1352110219202',
-        value: value,
-        state : 'success'
-      });
+
+    if (times) {
+      mock.times(times);
+    }
+
+    mock.reply(200, {
+      status: 0,
+      sessionId : '1352110219202',
+      value: value,
+      state : 'success'
+    });
     return this;
   },
 
-  text : function (value) {
-    nock('http://localhost:10195')
+  text : function (value, times) {
+    var mock = nock('http://localhost:10195')
       .get('/wd/hub/session/1352110219202/element/0/text')
-      .reply(200, {
-        status: 0,
-        sessionId : '1352110219202',
-        value: value,
-        state : 'success'
-      });
+
+    if (times) {
+      mock.times(times);
+    }
+
+    mock.reply(200, {
+      status: 0,
+      sessionId : '1352110219202',
+      value: value,
+      state : 'success'
+    });
     return this;
   },
 

--- a/tests/src/expect/testExpectAttribute.js
+++ b/tests/src/expect/testExpectAttribute.js
@@ -42,10 +42,7 @@ module.exports = {
   'to have attribute with waitFor [FAILED]' : function(test) {
     this.client.api.globals.waitForConditionPollInterval = 50;
 
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.attributeValue(null);
-    }
+    Nocks.elementFound().attributeValue(null);
 
     var expect = this.client.api.expect.element('#weblogin').to.have.attribute('class').before(60);
     this.client.on('nightwatch:finished', function(results, errors) {
@@ -221,11 +218,9 @@ module.exports = {
     this.client.api.globals.waitForConditionPollInterval = 50;
 
     Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.attributeValue(null);
-    }
 
     var expect = this.client.api.expect.element('#weblogin').to.have.attribute('class').equal('hp vasq').before(110);
+    Nocks.attributeValue(null).attributeValue(null);
 
     this.client.on('nightwatch:finished', function(results, errors) {
       test.equals(expect.assertion.waitForMs, 110);
@@ -238,11 +233,7 @@ module.exports = {
 
   'to have attribute equal and waitFor [FAILED] - attribute not equal' : function(test) {
     this.client.api.globals.waitForConditionPollInterval = 10;
-
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.attributeValue('xx');
-    }
+    Nocks.elementFound().attributeValue('xx').attributeValue('xx');
 
     var expect = this.client.api.expect.element('#weblogin').to.have.attribute('class').equal('hp vasq').before(11);
     this.client.on('nightwatch:finished', function(results, errors) {
@@ -389,7 +380,6 @@ module.exports = {
 
   tearDown : function(callback) {
     this.client = null;
-    Nocks.cleanAll();
     // clean up
     callback();
   }

--- a/tests/src/expect/testExpectCss.js
+++ b/tests/src/expect/testExpectCss.js
@@ -49,10 +49,7 @@ module.exports = {
   'to have css property with waitFor [FAILED]' : function(test) {
     this.client.api.globals.waitForConditionPollInterval = 50;
 
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.cssProperty('', 3);
-    }
+    Nocks.elementFound().cssProperty('', 3);
 
     var expect = this.client.api.expect.element('#weblogin').to.have.css('display').before(60);
     this.client.on('nightwatch:finished', function(results, errors) {
@@ -227,30 +224,22 @@ module.exports = {
 
   'to have css property equal and waitFor [FAILED] - property not set' : function(test) {
     this.client.api.globals.waitForConditionPollInterval = 50;
+    Nocks.elementFound().cssProperty('', 3);
 
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.cssProperty('', 3);
-    }
-
-    var expect = this.client.api.expect.element('#weblogin').to.have.css('display').equal('block').before(110);
+    var expect = this.client.api.expect.element('#weblogin').to.have.css('display').equal('block').before(120);
 
     this.client.on('nightwatch:finished', function(results, errors) {
-      test.equals(expect.assertion.waitForMs, 110);
+      test.equals(expect.assertion.waitForMs, 120);
       test.equals(expect.assertion.passed, false);
       test.ok(expect.assertion.retries > 1);
-      test.equals(expect.assertion.message, 'Expected element <#weblogin> to have css property "display" equal to: "block" in 110ms');
+      test.equals(expect.assertion.message, 'Expected element <#weblogin> to have css property "display" equal to: "block" in 120ms');
       test.done();
     })
   },
 
   'to have css property equal and waitFor [FAILED] - property not equal' : function(test) {
     this.client.api.globals.waitForConditionPollInterval = 10;
-
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.cssProperty('xx', 2);
-    }
+    Nocks.elementFound().cssProperty('xx', 3);
 
     var expect = this.client.api.expect.element('#weblogin').to.have.css('display').equal('block').before(20);
     this.client.on('nightwatch:finished', function(results, errors) {

--- a/tests/src/expect/testExpectEnabled.js
+++ b/tests/src/expect/testExpectEnabled.js
@@ -40,10 +40,7 @@ module.exports = {
   'to be enabled with waitFor [FAILED]' : function(test) {
     this.client.api.globals.waitForConditionPollInterval = 50;
 
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.notEnabled();
-    }
+    Nocks.elementFound().notEnabled(3);
 
     var expect = this.client.api.expect.element('#weblogin').to.be.enabled.before(60);
     this.client.on('nightwatch:finished', function(results, errors) {
@@ -142,10 +139,7 @@ module.exports = {
   'to not be enabled with waitFor [FAILED]' : function(test) {
     this.client.api.globals.waitForConditionPollInterval = 50;
 
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.enabled();
-    }
+    Nocks.elementFound().enabled(4);
 
     var expect = this.client.api.expect.element('#weblogin').to.not.be.enabled.before(120);
     this.client.on('nightwatch:finished', function(results, errors) {

--- a/tests/src/expect/testExpectPresent.js
+++ b/tests/src/expect/testExpectPresent.js
@@ -39,9 +39,7 @@ module.exports = {
   'to be present with waitFor [FAILED]' : function(test) {
     this.client.api.globals.waitForConditionPollInterval = 50;
 
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.elementNotFound();
-    }
+    Nocks.elementNotFound().elementNotFound();
 
     var expect = this.client.api.expect.element('#weblogin').to.be.present.before(60);
     this.client.on('nightwatch:finished', function(results, errors) {

--- a/tests/src/expect/testExpectSelected.js
+++ b/tests/src/expect/testExpectSelected.js
@@ -40,10 +40,7 @@ module.exports = {
   'to be selected with waitFor [FAILED]' : function(test) {
     this.client.api.globals.waitForConditionPollInterval = 50;
 
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.notSelected();
-    }
+    Nocks.elementFound().notSelected(3);
 
     var expect = this.client.api.expect.element('#weblogin').to.be.selected.before(60);
     this.client.on('nightwatch:finished', function(results, errors) {
@@ -142,10 +139,7 @@ module.exports = {
   'to not be selected with waitFor [FAILED]' : function(test) {
     this.client.api.globals.waitForConditionPollInterval = 50;
 
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.selected();
-    }
+    Nocks.elementFound().selected(3);
 
     var expect = this.client.api.expect.element('#weblogin').to.not.be.selected.before(120);
     this.client.on('nightwatch:finished', function(results, errors) {

--- a/tests/src/expect/testExpectText.js
+++ b/tests/src/expect/testExpectText.js
@@ -68,14 +68,14 @@ module.exports = {
     this.client.api.globals.waitForConditionPollInterval = 50;
     Nocks.elementFound();
 
-    var expect = this.client.api.expect.element('#weblogin').text.to.equal('hp vasq').before(110);
+    var expect = this.client.api.expect.element('#weblogin').text.to.equal('hp vasq').before(100);
     Nocks.text(null).text('hp vasq');
 
     this.client.on('nightwatch:finished', function(results, errors) {
-      test.equals(expect.assertion.waitForMs, 110);
+      test.equals(expect.assertion.waitForMs, 100);
       test.equals(expect.assertion.passed, true);
       test.equals(expect.assertion.retries, 1);
-      test.equals(expect.assertion.message, 'Expected element <#weblogin> text to equal: "hp vasq" in 110ms - condition was met in ' + expect.assertion.elapsedTime + 'ms');
+      test.equals(expect.assertion.message, 'Expected element <#weblogin> text to equal: "hp vasq" in 100ms - condition was met in ' + expect.assertion.elapsedTime + 'ms');
       test.done();
     })
   },
@@ -83,20 +83,17 @@ module.exports = {
   'text to equal and waitFor [FAILED] - text not equal' : function(test) {
     this.client.api.globals.waitForConditionPollInterval = 10;
 
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.text('xx').text('xx');
-    }
+    Nocks.elementFound().text('xx', 4);
 
-    var expect = this.client.api.expect.element('#weblogin').text.to.equal('hp vasq').before(30);
+    var expect = this.client.api.expect.element('#weblogin').text.to.equal('hp vasq').before(25);
     this.client.on('nightwatch:finished', function(results, errors) {
-      test.equals(expect.assertion.waitForMs, 30);
+      test.equals(expect.assertion.waitForMs, 25);
       test.equals(expect.assertion.passed, false);
       test.ok(expect.assertion.retries >= 1);
-      test.ok(expect.assertion.elapsedTime >= 30);
+      test.ok(expect.assertion.elapsedTime >= 25);
       test.equals(expect.assertion.expected, 'equal \'hp vasq\'');
       test.equals(expect.assertion.actual, 'xx');
-      test.equals(expect.assertion.message, 'Expected element <#weblogin> text to equal: "hp vasq" in 30ms');
+      test.equals(expect.assertion.message, 'Expected element <#weblogin> text to equal: "hp vasq" in 25ms');
       test.done();
     })
   },

--- a/tests/src/expect/testExpectValue.js
+++ b/tests/src/expect/testExpectValue.js
@@ -86,10 +86,7 @@ module.exports = {
 
     var expect = this.client.api.expect.element('#weblogin').to.have.value.equal('hp vasq').before(110);
 
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.value(null);
-    }
+    Nocks.elementFound().value('xx', 3);
 
     this.client.on('nightwatch:finished', function(results, errors) {
       test.equals(expect.assertion.waitForMs, 110);
@@ -101,22 +98,19 @@ module.exports = {
   },
 
   'to have value equal and waitFor [FAILED] - value not equal' : function(test) {
-    this.client.api.globals.waitForConditionPollInterval = 10;
+    this.client.api.globals.waitForConditionPollInterval = 50;
 
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.value('xx');
-    }
+    Nocks.elementFound().value('xx', 4);
 
-    var expect = this.client.api.expect.element('#weblogin').to.have.value.equal('hp vasq').before(11);
+    var expect = this.client.api.expect.element('#weblogin').to.have.value.equal('hp vasq').before(110);
     this.client.on('nightwatch:finished', function(results, errors) {
-      test.equals(expect.assertion.waitForMs, 11);
+      test.equals(expect.assertion.waitForMs, 110);
       test.equals(expect.assertion.passed, false);
       test.ok(expect.assertion.retries >= 1);
-      test.ok(expect.assertion.elapsedTime >= 11);
+      test.ok(expect.assertion.elapsedTime >= 110);
       test.equals(expect.assertion.expected, 'equal to \'hp vasq\'');
       test.equals(expect.assertion.actual, 'xx');
-      test.equals(expect.assertion.message, 'Expected element <#weblogin> to have value equal to: "hp vasq" in 11ms');
+      test.equals(expect.assertion.message, 'Expected element <#weblogin> to have value equal to: "hp vasq" in 110ms');
       test.done();
     })
   },

--- a/tests/src/expect/testExpectVisible.js
+++ b/tests/src/expect/testExpectVisible.js
@@ -40,10 +40,7 @@ module.exports = {
   'to be visible with waitFor [FAILED]' : function(test) {
     this.client.api.globals.waitForConditionPollInterval = 50;
 
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.notVisible();
-    }
+    Nocks.elementFound().notVisible(3);
 
     var expect = this.client.api.expect.element('#weblogin').to.be.visible.before(60);
     this.client.on('nightwatch:finished', function(results, errors) {
@@ -142,10 +139,7 @@ module.exports = {
   'to not be visible with waitFor [FAILED]' : function(test) {
     this.client.api.globals.waitForConditionPollInterval = 50;
 
-    Nocks.elementFound();
-    for (var i = 0 ; i <= 5 ; i++) {
-      Nocks.visible();
-    }
+    Nocks.elementFound().visible();
 
     var expect = this.client.api.expect.element('#weblogin').to.not.be.visible.before(120);
     this.client.on('nightwatch:finished', function(results, errors) {


### PR DESCRIPTION
This is a preview of the new upcoming assertion library in `v0.7` based on [Chai.js](http://chaijs.com). It provides a much more flexible syntax and style.

__Example:__

```js
  client.url('http://google.com')
  
  client.expect.element('#lst-ib').to.be.enabled;
  client.expect.element('body').to.be.present.before(1000);
  client.expect.element('#lst-ib').to.have.css('display').matches(/block/).before(2000);
  client.expect.element('body').to.have.attribute('class').which.matches(/vasq$/);
  client.expect.element('#hplogo').text.to.match(/Norge/).before(1000);

  client.setValue('#lst-ib', 'Norway').pause(500);
  client.expect.element('#lst-ib').to.have.value.equal('Norway');
  client.expect.element('#lst-ib').to.be.an('input');
  client.expect.element('#lst-ib').to.be.not.selected;
  client.expect.element('#lst-ib').to.be.visible;

  client.end();
};
```