### PR TITLE
CLI Runner returns results in callback

### DIFF
--- a/lib/runner/cli/errorhandler.js
+++ b/lib/runner/cli/errorhandler.js
@@ -16,14 +16,14 @@ module.exports = {
 
       this.logError(err);
 
-      finished(false);
+      finished(false, results);
       process.exit(1);
     } else {
       var result = true;
       if (results.failed || results.errors) {
         result = false;
       }
-      finished(result);
+      finished(result, results);
     }
   },
 


### PR DESCRIPTION
Small little addition to the CLI runner to allow it to return the results. This allows one to run the test runner within their own code  for example a CI app for nightwatch. 