### PR TITLE
Remove EventEmmiter max listeners warning if there are more then 10 tests

### DIFF
--- a/lib/runner/testcase.js
+++ b/lib/runner/testcase.js
@@ -35,6 +35,18 @@ TestCase.prototype.getErrors = function () {
   return this.errors;
 };
 
+TestCase.prototype.countTests = function() {
+  var count = 0;
+  if('@module' in this.suite.module) {
+    for(var key in this.suite.module['@module']) {
+      if(this.suite.module['@module'].hasOwnProperty(key) && Object.prototype.toString.call(this.suite.module['@module'][key]) === '[object Function]') {
+        count ++;
+      }
+    }
+  }
+  return count;
+};
+
 TestCase.prototype.run = function () {
   var self = this;
   var deferred = Q.defer();
@@ -42,6 +54,8 @@ TestCase.prototype.run = function () {
   this.startTime = new Date().getTime();
   this.results = null;
   this.errors = null;
+
+  this.suite.client.setMaxListeners(this.countTests()+1);
 
   this.suite
     .beforeEach()


### PR DESCRIPTION
Remove EventEmmiter max listeners warning if there are more then 10 tests
in one test file (suite).

Fixes #408 issue (enchasment). Based on solution by firejune (https://github.com/nightwatchjs/nightwatch/issues/408#issuecomment-112247217) and with some additional automatization.

Signed-off-by: Egor Bolgov <e.bolgov@semrush.com>