### PR TITLE
Add screenshot path to current test object

### DIFF
--- a/lib/api/client-commands/end.js
+++ b/lib/api/client-commands/end.js
@@ -30,13 +30,14 @@ End.prototype.command = function(callback) {
   if (client.sessionId) {
     if (this.testFailuresExist() && this.shouldTakeScreenshot()) {
       var fileNamePath = Utils.getScreenshotFileName(client.api.currentTest.module + '/' +client.api.currentTest.name, client.options.screenshots.path);
-      // save filename of screenshot for later reference
-      client.api.currentTest.screenshot = fileNamePath;
       Logger.info('We have failures in "' + client.api.currentTest.name + '". Taking screenshot...');
 
       client.api.saveScreenshot(fileNamePath, function(result, err) {
-        if (err || result.status !== 0)  {
+        if (err || result.status !== 0) {
           Logger.warn('Error saving screenshot...', err || result);
+        } else {
+          // save filename of screenshot for later reference
+          client.api.currentTest.screenshot = fileNamePath;
         }
       });
     }

--- a/lib/api/client-commands/end.js
+++ b/lib/api/client-commands/end.js
@@ -30,6 +30,8 @@ End.prototype.command = function(callback) {
   if (client.sessionId) {
     if (this.testFailuresExist() && this.shouldTakeScreenshot()) {
       var fileNamePath = Utils.getScreenshotFileName(client.api.currentTest.module + '/' +client.api.currentTest.name, client.options.screenshots.path);
+      // save filename of screenshot for later reference
+      client.api.currentTest.screenshot = fileNamePath;
       Logger.info('We have failures in "' + client.api.currentTest.name + '". Taking screenshot...');
 
       client.api.saveScreenshot(fileNamePath, function(result, err) {


### PR DESCRIPTION
It can be handy to have programmatic access to the filename of the screenshot that was created on error. For example, you can console output the filename, or use it to auto-create hyperlinks for easy viewing in a browser, etc. The currentTest object seemed like the logical place for it to reside.
