### PR TITLE
Allows to define elements in the Page Objects with only selector string

### DIFF
--- a/lib/page-object/page-utils.js
+++ b/lib/page-object/page-utils.js
@@ -13,7 +13,7 @@ module.exports = new (function() {
     var el;
 
     Object.keys(elements).forEach(function(e) {
-      el = elements[e];
+      el = typeof elements[e] === 'string' ? { selector: elements[e] } : elements[e];
       el.parent = parent;
       el.name = e;
       elementObjects[el.name] = new Element(el);

--- a/tests/extra/pageobjects/simplePageObj.js
+++ b/tests/extra/pageobjects/simplePageObj.js
@@ -7,6 +7,7 @@ var testCommands = {
 module.exports = {
   url: 'http://localhost.com',
   elements: {
+    loginAsString: '#weblogin',
     loginCss: { selector: '#weblogin' },
     loginXpath: { selector: '//weblogin', locateStrategy: 'xpath' }
   },

--- a/tests/src/testPageObject.js
+++ b/tests/src/testPageObject.js
@@ -35,6 +35,8 @@ module.exports = {
     test.equal(elements.loginCss.locateStrategy, 'css selector');
     test.equal(elements.loginXpath.selector, '//weblogin');
     test.equal(elements.loginXpath.locateStrategy, 'xpath');
+    test.equal(elements.loginAsString.selector, '#weblogin');
+    test.equal(elements.loginAsString.locateStrategy, 'css selector');
 
     test.done();
   },


### PR DESCRIPTION
Since the `elements` object in the Page Object model already defaults to CSS as locate strategy,
it would remove a lot of boilerplate code to just be able to pass the selector string, and it would
encourage code readability.

I am profoundly happy to see more support going to the Page Object model and to see that basically you are implementing what we were already implementing internally. I would be glad to upgrade my code, but I believe that keeping the Page Object as uncluttered as possible is of utmost importance.

Here's a real world example of one of our Page Object selectors list:

````
selectors = {
        accomodation: {
            armchair: {
                el:    "[id*=ChkSeat]",
                label: "[for*=ChkSeat]"
            },
            bed: {
                el:    "[id*=ChkBed]",
                label: "[for*=ChkBed]"
            },
            cabin: {
                el:    "[id*=ChkCabine]",
                label: "[for*=ChkCabine]"
            },
            deck: {
                el:    "[id*=ChkDeck]",
                label: "[for*=ChkDeck]"
            }
        },
        bookButton:    "[id*=BTNCerca]",
        errorPanel:    "[id*=winErr_PnlError]",
        hiddenInputs:  "[id*=UpdatePanelUCPrenotazione] input[type=hidden]",
        loader:        "#loader",
        outwardInputs: {
            destinations: "[id*=DDPartenze]",
            date:         "[id*=TBPartenza]",
            time:         "[id*=DropLevel]"
        },
        passengers: {
            adults:   "[id*=DDAdulti]",
            boys:     "[id*=DDRagazzi]",
            children: "[id*=DDNeonati]",
            babies:   "[id*=DDInfanti]"
        },
        returnInputs: {
            checkbox:     {
                el:    "[id*=CBRitorno]",
                label: "label[for*=CBRitorno]"
            },
            destinations: "[id*=DDRitorno]",
            date:         "[id*=TBArrivo]",
            time:         "[id*=DropLevelReturn]"
        },
        vehicle: {
            brand: "[id*=ddlVehicleBrand]",
            model: "[id*=ddlVehicleModel]",
            type:  "[id*=ddlVehicleType]",
        }
    };
````

You can see we had implemented our own way to do sectioning and such, but mostly, with these amount of selectors for just one page (this is a simple one in the site), you can imagine that we save quite a bit of time by passing only strings.