### PR TITLE
Now display error in test file and Selenium stills exit correctly even when there is an error.

### DIFF
--- a/lib/runner/cli/errorhandler.js
+++ b/lib/runner/cli/errorhandler.js
@@ -1,6 +1,6 @@
 var Logger = require('../../util/logger.js');
 
-module.exports = {
+var self = module.exports = {
   handle : function(err, results, finished) {
     finished = finished || function() {};
 
@@ -14,7 +14,7 @@ module.exports = {
         err.message = 'There was an error while running the test.';
       }
 
-      this.logError(err);
+      self.logError(err);
 
       finished(false);
       process.exit(1);


### PR DESCRIPTION
Before this two commit, let's imagine you forgot a ';' or any other error; Nightwatch was just exiting without any message. Now you can debug your code without looking for a needle in a haystack.