### PR TITLE
Add option use screenshots.path on saveScreenshots

### DIFF
--- a/lib/api/client-commands.js
+++ b/lib/api/client-commands.js
@@ -1,4 +1,5 @@
 var events = require('events');
+var path = require('path');
 
 module.exports = function(client) {
   return {
@@ -100,8 +101,16 @@ module.exports = function(client) {
      */
     saveScreenshot : function(fileName, callback) {
       var self = this;
+
+      var resolved_path = fileName;
+      // this option is for backward-compatibility
+      if( client.api.options.use_screenshot_path ) {
+        var root_path = client.api.options.screenshots.path;
+        resolved_path = path.join(root_path, resolved_path);
+      }
+
       return this.screenshot(client.api.options.log_screenshot_data, function(result) {
-        client.saveScreenshotToFile(fileName, result.value, function(err) {
+        client.saveScreenshotToFile(resolved_path, result.value, function(err) {
           if (typeof callback === 'function') {
             callback.call(self, result, err);
           }


### PR DESCRIPTION
`saveScreenshot` take a fileName, and output it.
But if you run testcases on multiple environment, all screenshot files overwrite by last executed environment testcase.
(for exsample: `nightwatch --env chrome,firefox` make only `firefox` case screenshots.)
I think this behavior undesirable.

Following patch is answer for this issue.
Please review it.