### PR TITLE
BugFix-589: Unable to provide filters & tags

### DIFF
--- a/lib/runner/walk.js
+++ b/lib/runner/walk.js
@@ -116,17 +116,17 @@ module.exports = {
             return false;
           }
 
-          if (opts.filter) {
-            return fileMatcher.filter.match(filePath, Matchers.filter);
+          if (opts.filter && !fileMatcher.filter.match(filePath, Matchers.filter)) {
+            return false;
           }
 
           var filename = filePath.split(path.sep).slice(-1)[0];
-          if (opts.filename_filter) {
-            return minimatch(filename, opts.filename_filter);
+          if (opts.filename_filter && !minimatch(filename, opts.filename_filter)) {
+            return false;
           }
 
-          if (opts.tag_filter || opts.skiptags) {
-            return fileMatcher.tags.match(filePath, opts);
+          if ((opts.tag_filter || opts.skiptags) && !fileMatcher.tags.match(filePath, opts)) {
+            return false;
           }
 
           return true;


### PR DESCRIPTION
From comment I made here:
https://github.com/nightwatchjs/nightwatch/issues/589

Added the ability to use both Filters + Tags side by side.