### PR TITLE
Add support for "orientation"

### DIFF
--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -534,7 +534,37 @@ module.exports = function(Nightwatch) {
     return postRequest('/context', data, callback);
   };
  
- 
+
+
+  //////////////////////////////////////////////////////////////////
+  // Orientation
+  //////////////////////////////////////////////////////////////////
+
+  /**
+   * Get the current browser orientation.
+   *
+   * @param {function} callback Callback function to be called when the command finishes.
+   * @returns {string} The current browser orientation: {LANDSCAPE|PORTRAIT}
+   * @api protocol
+   */
+  Actions.getOrientation  = function(callback) {
+    return getRequest('/orientation', callback);
+  };
+
+  /**
+   * Sets the browser orientation.
+   *
+   * @param {string} orientation The new browser orientation: {LANDSCAPE|PORTRAIT}
+   * @param {function} [callback] Optional callback function to be called when the command finishes.
+   * @api protocol
+   */
+  Actions.setOrientation = function (orientation, callback) {
+    var data = {};
+    if (orientation === ('LANDSCAPE' || 'PORTRAIT')) {
+      data.orientation = orientation;
+    }
+    return postRequest('/orientation', data, callback);
+  };
 
   //////////////////////////////////////////////////////////////////
   // Mouse related

--- a/tests/src/testProtocolActions.js
+++ b/tests/src/testProtocolActions.js
@@ -1107,6 +1107,33 @@ module.exports = {
     });
   },
 
+  testGetOrientation: function (test) {
+    var protocol = this.protocol;
+
+    this.client.on('selenium:session_create', function (sessionId) {
+      var command = protocol.getOrientation(function callback() {
+        test.done();
+      });
+
+      test.equal(command.request.method, 'GET');
+      test.equal(command.request.path, '/wd/hub/session/1352110219202/orientation');
+    });
+  },
+
+  testSetOrientation: function (test) {
+    var protocol = this.protocol;
+
+    this.client.on('selenium:session_create', function (sessionId) {
+      var command = protocol.setOrientation('LANDSCAPE',function callback() {
+        test.done();
+      });
+
+      test.equal(command.request.method, 'POST');
+      test.equal(command.data, '{"orientation":"LANDSCAPE"}');
+      test.equal(command.request.path, '/wd/hub/session/1352110219202/orientation');
+    });
+  },
+
   tearDown : function(callback) {
     this.client = null;
     // clean up


### PR DESCRIPTION
Reference: https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/orientation

This PR adds methods to get and set the browser orientation, which can be either 'LANDSCAPE' or 'PORTRAIT'. 

We use this when we test hybrid apps. 
