### PR TITLE
Allows use of java version 8

### DIFF
--- a/lib/runner/selenium.js
+++ b/lib/runner/selenium.js
@@ -7,7 +7,7 @@ var child_process = require('child_process');
 var util = require('util');
 var Logger = require('../util/logger.js');
 
-var SENTINEL = ['Started org.openqa.jetty.jetty.Server', 'INFO - Selenium Server is up and running'];
+var SENTINEL = ['INFO - Selenium Server is up and running', 'Started org.openqa.jetty.jetty.Server'];
 var DEFAULT_HOST = '127.0.0.1';
 var DEFAULT_PORT = 4444;
 var DEFAULT_LOG_FILE = 'selenium-debug.log';


### PR DESCRIPTION
Changed order of var SENTINEL strings so that not two Selenium Server instances are started when using jdk version 8

fixes #597 