### PR TITLE
Added sessionId parameter to session method.

### DIFF
--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -15,23 +15,30 @@ module.exports = function(Nightwatch) {
   // Session related
   //////////////////////////////////////////////////////////////////
   /**
-   * Get info about, delete the current session or create a new session.
+   * Get info about, delete or create a new session. Defaults to the current session.
    *
    * @link /session
    * @param {string} [action] The http verb to use, can be "get", "post" or "delete". If only the callback is passed, get is assumed as default.
+   * @param {string} [sessionId] The id of the session to get info about or delete.
    * @param {function} [callback] Optional callback function to be called when the command finishes.
    * @api protocol
    */
-  Actions.session  = function(action, callback) {
+  Actions.session  = function(action, sessionId, callback) {
     var options = {
       path : '/session'
     };
 
     if (typeof arguments[0] === 'function') {
       callback = arguments[0];
+      sessionId = Nightwatch.sessionId;
       action = 'get';
     } else {
       action = action.toLowerCase();
+    }
+
+    if (typeof arguments[1] === 'function') {
+      callback = arguments[1];
+      sessionId = Nightwatch.sessionId;
     }
 
     switch (action) {
@@ -41,12 +48,17 @@ module.exports = function(Nightwatch) {
     case 'post':
       options.method = 'POST';
       break;
+    case 'get':
+        options.method = 'GET';
+        break;
     default:
+      sessionId = arguments[0];
+      action = 'get';
       options.method = 'GET';
     }
 
     if (action != 'post') {
-      options.path += '/' + Nightwatch.sessionId;
+      options.path += '/' + sessionId;
     }
 
 
@@ -488,14 +500,14 @@ module.exports = function(Nightwatch) {
   Actions.source = function(callback) {
     return getRequest('/source', callback);
   };
-  
-  
-  
+
+
+
   //////////////////////////////////////////////////////////////////
   // Context related
   //////////////////////////////////////////////////////////////////
 
-  /** 
+  /**
    * Get a list of the available contexts.
    *
    * Used by Appium when testing hybrid mobile web apps. More info here: https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/hybrid.md.
@@ -509,7 +521,7 @@ module.exports = function(Nightwatch) {
   };
 
  /**
-  * 
+  *
   * Get current context.
   *
   * @param {function} callback Callback function to be called when the command finishes.
@@ -533,8 +545,8 @@ module.exports = function(Nightwatch) {
     };
     return postRequest('/context', data, callback);
   };
- 
- 
+
+
 
   //////////////////////////////////////////////////////////////////
   // Mouse related

--- a/tests/src/testProtocolActions.js
+++ b/tests/src/testProtocolActions.js
@@ -579,7 +579,21 @@ module.exports = {
     });
   },
 
-  testSessionGET : function(test) {
+  testSessionDefault : function(test) {
+    var protocol = this.protocol;
+
+    this.client.on('selenium:session_create', function(sessionId) {
+
+      var command = protocol.session(function callback() {
+        test.done();
+      });
+
+      test.equal(command.request.method, 'GET');
+      test.equal(command.request.path, '/wd/hub/session/1352110219202');
+    });
+  },
+
+  testSessionGETImplicit : function(test) {
     var protocol = this.protocol;
 
     this.client.on('selenium:session_create', function(sessionId) {
@@ -592,7 +606,7 @@ module.exports = {
     });
   },
 
-  testSessionDefault : function(test) {
+  testSessionGETExplicit : function(test) {
     var protocol = this.protocol;
 
     this.client.on('selenium:session_create', function(sessionId) {
@@ -602,6 +616,32 @@ module.exports = {
 
       test.equal(command.request.method, 'GET');
       test.equal(command.request.path, '/wd/hub/session/1352110219202');
+    });
+  },
+
+  testSessionGETImplicitById : function(test) {
+    var protocol = this.protocol;
+
+    this.client.on('selenium:session_create', function(sessionId) {
+      var command = protocol.session('1352110219203', function callback() {
+        test.done();
+      });
+
+      test.equal(command.request.method, 'GET');
+      test.equal(command.request.path, '/wd/hub/session/1352110219203');
+    });
+  },
+
+  testSessionGETExplicitById : function(test) {
+    var protocol = this.protocol;
+
+    this.client.on('selenium:session_create', function(sessionId) {
+      var command = protocol.session('GET', '1352110219203', function callback() {
+        test.done();
+      });
+
+      test.equal(command.request.method, 'GET');
+      test.equal(command.request.path, '/wd/hub/session/1352110219203');
     });
   },
 
@@ -615,6 +655,19 @@ module.exports = {
 
       test.equal(command.request.method, 'DELETE');
       test.equal(command.request.path, '/wd/hub/session/1352110219202');
+    });
+  },
+
+  testSessionDELETEById : function(test) {
+    var protocol = this.protocol;
+
+    this.client.on('selenium:session_create', function(sessionId) {
+      var command = protocol.session('DELETE', '1352110219203', function callback() {
+        test.done();
+      });
+
+      test.equal(command.request.method, 'DELETE');
+      test.equal(command.request.path, '/wd/hub/session/1352110219203');
     });
   },
 


### PR DESCRIPTION
In Nightwatch, the session method can only address the current session to recover info about, or delete it, however Selenium allows to retrieve info or delete sessions by their id.

The method now allows to retrieve or delete a session by id.

Fixes #623 