### PR TITLE
Expand element variables in selectors of page commands

### DIFF
--- a/lib/page-object/command-wrapper.js
+++ b/lib/page-object/command-wrapper.js
@@ -33,6 +33,27 @@ module.exports = new (function() {
   }
 
   /**
+   * Given a selector, returns selector with expanded page elements.
+   * E.g. `table @row @button` ~> `table .row .btn-primary`
+   *
+   * @param  {String} selector CSS or Xpath selector
+   * @param  {Object} parent The parent page or section
+   * @param  {String} prevLocateStrategy Currently used location strategy
+   * @return {String} New selector
+   */
+  function expandCssSelector(selector, parent, prevLocateStrategy){
+    return selector.replace(/@(\w+)/g, function(match){
+      console.log('MATCH', match);
+      var element = getElement(parent, match);
+      if (element.locateStrategy !== prevLocateStrategy){
+        // Can be supported in future
+        throw new Error("Selector `" + selector + "` is attempting to mix location strategies (" + element.locateStrategy + " and " + prevLocateStrategy + ")");
+      }
+      return element.selector;
+    });
+  }
+
+  /**
    * Calls use(Css|Xpath|Recursion) command
    *
    * Uses `useXpath`, `useCss`, and `useRecursion` commands.
@@ -54,6 +75,22 @@ module.exports = new (function() {
   }
 
   /**
+   * Determines if the command is an element command based on passed arguments
+   * @param  {Object} parent Page or section object
+   * @param  {Array} args Command arguments
+   * @return {Boolean}
+   */
+  function determineElementCommand(parent, args){
+    return (typeof args[0] === 'string') && (function(){
+      var selector = args[0];
+      var elementNames = parent.elements ? Object.keys(parent.elements) : [];
+      return elementNames.some(function(name){
+        return selector.indexOf('@' + name) !== -1;
+      });
+    })();
+  }
+
+  /**
    * Creates a closure that enables calling commands and assertions on the page or section.
    * For all element commands and assertions, it fetches element's selector and locate strategy
    *  For elements nested under sections, it sets 'recursion' as the locate strategy and passes as its first argument to the command an array of its ancestors + self
@@ -68,22 +105,29 @@ module.exports = new (function() {
   function makeWrappedCommand(parent, commandFn, commandName, isChaiAssertion) {
     return function() {
       var args = Array.prototype.slice.call(arguments);
-      var isElementCommand = args[0].toString().indexOf('@') === 0;
+      var isElementCommand = determineElementCommand(parent, args);
       var prevLocateStrategy = parent.client.locateStrategy;
 
       if (isElementCommand) {
         var firstArg, desiredStrategy, callback;
-        var elementOrSectionName = args.shift();
-        var getter = (isChaiAssertion && commandName === 'section') ? getSection : getElement;
-        var elementOrSection = getter(parent, elementOrSectionName);
-        var ancestors = getAncestorsWithElement(elementOrSection);
-
-        if (ancestors.length === 1) {
-          firstArg = elementOrSection.selector;
-          desiredStrategy = elementOrSection.locateStrategy;
+        var selector = args.shift();
+        // Element or section name is a valid identifier prefixed with '@'
+        if (selector.match(/[^\w@_$]/)){
+          firstArg = expandCssSelector(selector, parent, prevLocateStrategy);
+          desiredStrategy = prevLocateStrategy;
         } else {
-          firstArg = ancestors;
-          desiredStrategy = 'recursion';
+          var elementOrSectionName = selector;
+          var getter = (isChaiAssertion && commandName === 'section') ? getSection : getElement;
+          var elementOrSection = getter(parent, elementOrSectionName);
+          var ancestors = getAncestorsWithElement(elementOrSection);
+
+          if (ancestors.length === 1) {
+            firstArg = elementOrSection.selector;
+            desiredStrategy = elementOrSection.locateStrategy;
+          } else {
+            firstArg = ancestors;
+            desiredStrategy = 'recursion';
+          }
         }
 
         setLocateStrategy(parent.client, desiredStrategy);

--- a/lib/page-object/command-wrapper.js
+++ b/lib/page-object/command-wrapper.js
@@ -43,7 +43,6 @@ module.exports = new (function() {
    */
   function expandCssSelector(selector, parent, prevLocateStrategy){
     return selector.replace(/@(\w+)/g, function(match){
-      console.log('MATCH', match);
       var element = getElement(parent, match);
       if (element.locateStrategy !== prevLocateStrategy){
         // Can be supported in future


### PR DESCRIPTION
This PR enables expansion of element variables in selectors of page commands. For example calling `page.click('table > @row @button')` will expand `@row` and `@button` into `page.click('table > .row .btn-primary')` (given that you defined page elements `@row` and `@button` to be `.row` and `.btn-primary`). If you mixed lookup strategies, it would throw an error.

It just feels natural to be able to write this in our tests.

I'll add tests and clean it up if it's something you would accept.
