### PR TITLE
Fix parallel mode exiting with wrong exit code

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -698,6 +698,7 @@ CliRunner.prototype = {
 
   startEnvChildren : function(envs, availColors, args, doneCallback) {
     var self = this;
+    var hasFailure = false;
 
     envs.forEach(function(environment, index) {
       self.childProcessOutput[environment] = [];
@@ -708,12 +709,14 @@ CliRunner.prototype = {
       child.setLabel(environment + ' environment');
       self.runningProcesses[child.itemKey] = child;
       self.runningProcesses[child.itemKey].run(availColors, function(output, exitCode) {
+        if (exitCode !== 0) {
+          hasFailure = true;
+        }
         if (self.processesRunning() === 0) {
           if (!self.settings.live_output) {
             self.printChildProcessOutput();
           }
-
-          doneCallback(exitCode || 0);
+          doneCallback(hasFailure ? 1 : 0);
         }
       });
     });


### PR DESCRIPTION
Fixes #671.

The current implementation always exits with the exit code of the last finished child. If a previous child process exits with a non-zero code, it simply gets ignored. This causes parallel runs with failed envs to exit with 0 even when some of the envs have failed.