### PR TITLE
Issue 687 - waitForElementVisible fails due to stale element reference error

### DIFF
--- a/lib/api/element-commands/_waitForElement.js
+++ b/lib/api/element-commands/_waitForElement.js
@@ -239,6 +239,10 @@ WaitForElement.prototype.isVisible = function() {
       return self.elementVisible(result, now);
     }
 
+    if (result.status === -1 && result.errorStatus === 10) {
+      return self.checkElement();
+    }
+
     return self.elementNotVisible(result, now);
   });
 };

--- a/tests/src/commands/testWaitForElementVisible.js
+++ b/tests/src/commands/testWaitForElementVisible.js
@@ -32,6 +32,40 @@ module.exports = {
     });
   },
 
+  testStaleElementReference : function(test) {
+    var assertion = [];
+    this.client.assertion = function(result, actual, expected, msg, abortObFailure) {
+      Array.prototype.unshift.apply(assertion, arguments);
+    };
+
+    MockServer.addMock({ url : '/wd/hub/session/1352110219202/elements',
+      method:'POST',
+      response : JSON.stringify({
+        status: 0,
+        state: 'success',
+        value: [ { ELEMENT: '0' } ]
+      })
+    },
+    {
+      url : '/wd/hub/session/1352110219202/element/0/displayed',
+      method:'GET',
+      response : JSON.stringify({
+        sessionId: '1352110219202',
+        state: 'stale element reference',
+        status:10
+      })
+    });
+
+    this.client.api.waitForElementVisible('#weblogin', 110, 50, function callback(result, instance) {
+      test.equal(assertion[0], false);
+      test.equal(assertion[1], 'not visible');
+      test.equal(assertion[3], 'Timed out while waiting for element <#weblogin> to be visible for 110 milliseconds.');
+      test.equal(assertion[4], true);
+
+      test.done();
+    });
+  },
+
   'test not visible with global timeout default': function(test) {
     var assertion = [];
     this.client.assertion = function(result, actual, expected, msg, abortObFailure) {


### PR DESCRIPTION
This PR is for https://github.com/nightwatchjs/nightwatch/issues/687 

This PR solves the issue by trying to relocate the element again when a stale element reference error is thrown and then checks for the visibility of the element again. 