### PR TITLE
add errors into testSteps result

### DIFF
--- a/lib/runner/reporters/junit.xml.ejs
+++ b/lib/runner/reporters/junit.xml.ejs
@@ -8,15 +8,22 @@
     tests="<%= module.tests %>" time="<%= module.time %>" timestamp="<%= module.timestamp %>">
   <% for (var item in module.completed) {
     var testcase = module.completed[item];
+    var errorsMessages = testcase.errorsMessages;
     var assertions = testcase.assertions %>
     <testcase name="<%= item %>" time="<%= testcase.time %>" assertions="<%= assertions.length %>"><% for (var i = 0; i < assertions.length; i++) { %><% if (assertions[i].failure) { %>  <failure message="<%= assertions[i].message %>"><%= assertions[i].stacktrace %></failure><% } %>
 <% if (assertions[i].screenshots && assertions[i].screenshots.length > 0) { %><system-out><% for (var j = 0; j < assertions[i].screenshots.length; j++) { %>[[ATTACHMENT|<%= assertions[i].screenshots[j] %>]]<% } %></system-out><% } %>
     <% } %>
-    </testcase><% if (systemerr != '') {%>
-      <system-err>
-        <%= systemerr %>
-      </system-err><% } %>
+    <% if (errorsMessages && errorsMessages.length) { %>
+    <% for (var i = 0; i < errorsMessages.length; i++) { %>
+        <error message="<%= errorsMessages[i] %>"></error>
+    <% } %>
+    <% } %>
+    </testcase>
   <% } %>
+  <% if (systemerr != '') {%>
+  <system-err>
+    <%= systemerr %>
+  </system-err><% } %>
   <% if (module.skipped && (module.skipped.length > 0)) { %>
     <% for (var j = 0; j < module.skipped.length; j++) { %>
     <testcase

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -58,6 +58,7 @@ module.exports = new (function() {
         errors  : results.errors,
         skipped : results.skipped,
         assertions  : [].concat(results.tests),
+        errorsMessages: (Array.isArray(errors) && errors.length) ? errors.slice() : null,
         time : (time/1000).toPrecision(4)
       };
 

--- a/tests/src/runner/testRunner.js
+++ b/tests/src/runner/testRunner.js
@@ -46,7 +46,7 @@ module.exports = {
   },
 
   testRunNoSkipTestcasesOnFail : function(test) {
-    test.expect(11);
+    test.expect(12);
     var testsPath = path.join(process.cwd(), '/sampletests/withfailures');
     this.Runner.run([testsPath], {
       seleniumPort : 10195,
@@ -63,6 +63,7 @@ module.exports = {
       test.equals(results.passed, 2);
       test.equals(results.failed, 2);
       test.equals(results.errors, 0);
+      test.equals(results.errorsMessages, null);
       test.equals(results.skipped, 0);
       test.equals(err, null);
       test.done();
@@ -70,7 +71,7 @@ module.exports = {
   },
 
   testRunSkipTestcasesOnFail : function(test) {
-    test.expect(9);
+    test.expect(10);
     var testsPath = path.join(process.cwd(), '/sampletests/withfailures');
     this.Runner.run([testsPath], {
       seleniumPort : 10195,
@@ -86,6 +87,7 @@ module.exports = {
       test.equals(results.passed, 1);
       test.equals(results.failed, 1);
       test.equals(results.errors, 0);
+      test.equals(results.errorsMessages, null);
       test.equals(results.modules.sample.skipped[0], 'demoTest2');
       test.equals(err, null);
       test.done();
@@ -93,7 +95,7 @@ module.exports = {
   },
 
   testRunRetries : function(test) {
-    test.expect(11);
+    test.expect(12);
     var testsPath = path.join(process.cwd(), '/sampletests/withfailures');
     this.Runner.run([testsPath], {
       seleniumPort : 10195,
@@ -110,6 +112,7 @@ module.exports = {
       test.equals(results.passed, 1);
       test.equals(results.failed, 1);
       test.equals(results.errors, 0);
+      test.equals(results.errorsMessages, null);
       test.equals(results.skipped, 0);
       test.equals(err, null);
       test.done();
@@ -117,7 +120,7 @@ module.exports = {
   },
 
   testRunRetriesNoSkipTestcasesOnFail : function(test) {
-    test.expect(15);
+    test.expect(16);
     var testsPath = path.join(process.cwd(), '/sampletests/withfailures');
     this.Runner.run([testsPath], {
       seleniumPort : 10195,
@@ -135,6 +138,7 @@ module.exports = {
       test.equals(results.passed, 2);
       test.equals(results.failed, 2);
       test.equals(results.errors, 0);
+      test.equals(results.errorsMessages, null);
       test.equals(results.skipped, 0);
       test.equals(err, null);
       test.done();
@@ -142,7 +146,7 @@ module.exports = {
   },
 
   testRunSuiteRetries : function(test) {
-    test.expect(13);
+    test.expect(14);
     var testsPath = path.join(process.cwd(), '/sampletests/withfailures');
     this.Runner.run([testsPath], {
       seleniumPort : 10195,
@@ -159,6 +163,7 @@ module.exports = {
       test.equals(results.passed, 1);
       test.equals(results.failed, 1);
       test.equals(results.errors, 0);
+      test.equals(results.errorsMessages, null);
       test.equals(results.skipped, 0);
       test.equals(err, null);
       test.done();
@@ -166,7 +171,7 @@ module.exports = {
   },
 
   testRunSuiteRetriesNoSkipTestcasesOnFail : function(test) {
-    test.expect(13);
+    test.expect(14);
     var testsPath = path.join(process.cwd(), '/sampletests/withfailures');
     this.Runner.run([testsPath], {
       seleniumPort : 10195,
@@ -182,6 +187,7 @@ module.exports = {
       suite_retries: 1
     }, function(err, results) {
       test.equals(results.errors, 0);
+      test.equals(results.errorsMessages, null);
       test.equals(results.skipped, 0);
       test.equals(err, null);
       test.done();

--- a/tests/src/testAssertions.js
+++ b/tests/src/testAssertions.js
@@ -1,6 +1,7 @@
 var BASE_PATH = process.env.NIGHTWATCH_COV ? 'lib-cov' : 'lib';
 var Api = require('../../' + BASE_PATH + '/core/api.js');
 var nock = require('nock');
+var path = require('path');
 
 module.exports = {
   setUp: function (callback) {
@@ -22,6 +23,7 @@ module.exports = {
       test.equals(results.passed, 0);
       test.equals(results.failed, 1);
       test.equals(results.errors, 0);
+      test.equals(results.errorsMessages, null);
       test.equals(results.skipped, 0);
       test.equals(results.tests[0].message, 'Testing if element <#weblogin> is present.');
       test.equals(results.tests[0].failure, 'Expected "present" but got: "not present"');
@@ -46,6 +48,7 @@ module.exports = {
       test.equals(results.passed, 1);
       test.equals(results.failed, 0);
       test.equals(results.errors, 0);
+      test.equals(results.errorsMessages, null);
       test.equals(results.skipped, 0);
       test.equals(results.tests[0].message, 'Testing if element <#weblogin> is present.');
       test.equals(results.tests[0].failure, false);

--- a/tests/src/testAssertions.js
+++ b/tests/src/testAssertions.js
@@ -1,7 +1,6 @@
 var BASE_PATH = process.env.NIGHTWATCH_COV ? 'lib-cov' : 'lib';
 var Api = require('../../' + BASE_PATH + '/core/api.js');
 var nock = require('nock');
-var path = require('path');
 
 module.exports = {
   setUp: function (callback) {


### PR DESCRIPTION
Currently if test fails because of javascript error (not assertion), jenkinsCI shows such tests as passed.
Let's pass error message into testSteps result, then we can reuse it to generate junit report that includes (or not) these errors
