### PR TITLE
Microsoft Edge compatibility - elementNotPresent

### DIFF
--- a/lib/api/assertions/elementNotPresent.js
+++ b/lib/api/assertions/elementNotPresent.js
@@ -24,11 +24,7 @@ exports.assertion = function(selector, msg) {
   };
 
   this.value = function(result) {
-    var value = null;
-    if (result.value.length !== 0) {
-      value = 'present';
-    }
-    return value;
+    return (result.status !== 0 || result.value.length === 0) ? null : 'present';
   };
 
   this.command = function(callback) {


### PR DESCRIPTION
Current ```assert.elementNotPresent``` doesn't work with MicrosoftEdge webdriver.

If `elements` doesn't exist, MS Edge webdriver returns exception instead empty array, so ```result.value.length``` is equal ```undefined```, then ```result.value.length === 0``` fails because ```undefined !== 0```

Refactored method to make it similar to current implementation of ```asssert.elementPresent``` 
```
this.value = function(result) {
    return (result.status !== 0 || result.value.length === 0) ? 'not present' : 'present';
};```
and ensure compatibility between different webdrivers