### PR TITLE
Add option to exit on failure when using Mocha

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -373,6 +373,10 @@ CliRunner.prototype = {
           });
 
           mocha.run(nightwatch, this.test_settings, function(failures) {
+            if (failures && mochaOpts.exitOnFailure) {
+              process.exit(1);
+            }
+
             fn(null, {
               failed : failures
             });


### PR DESCRIPTION
Mocha runner would always return with exit code 0, even when
there were test failures. This commit adds an option 'exitOnFailure'
that forces Mocha runner to exit with code 1 when detecting failures.
This behavior is analogous to the regular runner.