### PR TITLE
Allow checkModuleTags to take both tag_filter and skiptags

### DIFF
--- a/lib/runner/filematcher.js
+++ b/lib/runner/filematcher.js
@@ -50,30 +50,28 @@ module.exports = {
      */
     checkModuleTags: function (test, opts) {
       var moduleTags = test['@tags'] || test.tags;
+      var match = true;
 
       if (!Array.isArray(moduleTags)) {
         return typeof opts.tag_filter == 'undefined' && typeof opts.skiptags != 'undefined';
       }
 
-      var tags = opts.tag_filter || opts.skiptags;
-      if (!Array.isArray(tags)) {
-        tags = [tags];
+      if (opts.tag_filter || opts.skiptags){
+        moduleTags = this.convertTagsToString(moduleTags);
+
+        if (opts.tag_filter) {
+          match = this.containsTag(moduleTags, this.convertTagsToString(opts.tag_filter));
+        }
+        if (opts.skiptags) {
+          match = this.excludesTag(moduleTags, this.convertTagsToString(opts.skiptags));
+        }
       }
 
-      tags = this.convertTagsToString(tags);
-      moduleTags = this.convertTagsToString(moduleTags);
-
-      if (opts.tag_filter) {
-        return this.containsTag(moduleTags, tags);
-      } else if (opts.skiptags) {
-        return this.excludesTag(moduleTags, tags);
-      }
-
-      return true;
+      return match;
     },
 
     convertTagsToString : function(tags) {
-      return tags.map(function (tag) {
+      return [].concat(tags).map(function (tag) {
         return String(tag).toLowerCase();
       });
     },

--- a/tests/src/runner/testFileMatcher.js
+++ b/tests/src/runner/testFileMatcher.js
@@ -127,5 +127,41 @@ module.exports = {
 
     test.ok(matched === true);
     test.done();
+  },
+
+  'tag filter does not find module, but skiptag does and excludes it' : function(test) {
+    var matched = matcher.tags.checkModuleTags({
+      tags: ['room', 101]
+    }, {
+      tag_filter : ['other'],
+      skiptags : ['101']
+    });
+
+    test.ok(matched === false);
+    test.done();
+  },
+
+  'tag filter finds module, skiptag also does and excludes it' : function(test) {
+    var matched = matcher.tags.checkModuleTags({
+      tags: ['room', 101]
+    }, {
+      tag_filter : ['room'],
+      skiptags : ['101']
+    });
+
+    test.ok(matched === false);
+    test.done();
+  },
+
+  'tag filter finds module, and skiptag does not' : function(test) {
+    var matched = matcher.tags.checkModuleTags({
+      tags: ['room', 101]
+    }, {
+      tag_filter : ['room'],
+      skiptags : ['other']
+    });
+
+    test.ok(matched === true);
+    test.done();
   }
 };


### PR DESCRIPTION
In relation to https://github.com/nightwatchjs/nightwatch/issues/710