### PR TITLE
Fix "Error: maxBuffer exceeded" when test workers are used

### DIFF
--- a/lib/runner/cli/child-process.js
+++ b/lib/runner/cli/child-process.js
@@ -1,4 +1,4 @@
-var execFile = require('child_process').execFile;
+var child_process = require('child_process');
 var Logger = require('../../util/logger.js');
 
 function ChildProcess(environment, index, env_output, settings, args) {
@@ -42,11 +42,15 @@ ChildProcess.prototype = {
       env.__NIGHTWATCH_ENV = self.environment;
       env.__NIGHTWATCH_ENV_KEY = self.itemKey;
 
-      self.child = execFile(process.execPath, cliArgs, {
+      self.child = child_process.spawn(process.execPath, cliArgs, {
         cwd: process.cwd(),
         encoding: 'utf8',
         env: env
-      }, function (error, stdout, stderr) {});
+      }, function (error, stdout, stderr) {
+        if (error) {
+          throw error;
+        }
+      });
 
       self.processRunning = true;
 
@@ -96,7 +100,7 @@ ChildProcess.prototype = {
   },
 
   writeToStdout : function(data) {
-    data = data.trim();
+    data = (typeof data === "object" ? new String(data) : data).trim();
 
     var color_pair = this.availColors[this.index%4];
     var output = '';

--- a/lib/runner/cli/child-process.js
+++ b/lib/runner/cli/child-process.js
@@ -100,7 +100,7 @@ ChildProcess.prototype = {
   },
 
   writeToStdout : function(data) {
-    data = (typeof data === "object" ? new String(data) : data).trim();
+    data = data.toString().trim();
 
     var color_pair = this.availColors[this.index%4];
     var output = '';

--- a/tests/src/runner/testParallelExecution.js
+++ b/tests/src/runner/testParallelExecution.js
@@ -12,7 +12,7 @@ module.exports = {
 
     mockery.enable({ useCleanCache: true, warnOnUnregistered: false });
     mockery.registerMock('child_process', {
-      execFile : function(path, args, opts) {
+      spawn : function(path, args, opts) {
         self.allArgs.push(args);
         self.allOpts.push(opts);
 

--- a/tests/src/runner/testParallelExecutionExitCode.js
+++ b/tests/src/runner/testParallelExecutionExitCode.js
@@ -11,7 +11,7 @@ module.exports = {
     var index = 0;
     mockery.enable({ useCleanCache: true, warnOnUnregistered: false });
     mockery.registerMock('child_process', {
-      execFile : function(path, args, opts) {
+      spawn : function(path, args, opts) {
         self.allArgs.push(args);
         self.allOpts.push(opts);
         


### PR DESCRIPTION
When test workers are used and worker standard output exceeds 200Kb, then process is killed. Exceeding 200Kb standard output is quite easy when suite has several testSteps and ```retry``` option is used. Ofc after child process is killed, there are several problems like:
* browser is not closed
* not all tests are executed
* test report is not generated

Changes include:
* use ```spawn``` instead ```execFile```. As described here: http://www.hacksparrow.com/difference-between-spawn-and-exec-of-node-js-child_process.html when child process is designed to handle console output, it is better to use ```spawn```
* throw error if there is any problem with child process instead just ignoring them