### PR TITLE
Fix #708 misleading error message if syntax error in globals_path

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -139,6 +139,10 @@ CliRunner.prototype = {
 
     var fullPath = path.resolve(this.settings.globals_path);
 
+    if (!fs.existsSync(fullPath)) {
+      throw new Error('External global file could not be located - using '+ this.settings.globals_path + '.');
+    }
+
     try {
       var externalGlobals = require(fullPath);
 
@@ -159,7 +163,7 @@ CliRunner.prototype = {
       this.test_settings.globals = globals;
 
     } catch (err) {
-      throw new Error('External global file could not be located - using '+ this.settings.globals_path + '.');
+      throw new Error('Error reading external global file: ' + err);
     }
 
     return this;
@@ -749,7 +753,7 @@ CliRunner.prototype = {
         ErrorHandler.handle(error, null, doneCallback);
         return;
       }
-      
+
       var remaining = modulePaths.length;
       Utils.processAsyncQueue(workerCount, modulePaths, function(modulePath, index, next) {
         var outputLabel = Utils.getModuleKey(modulePath, self.settings.src_folders, modulePaths);


### PR DESCRIPTION
If file doesn't exist, throw the ''External global file could not be located' message, otherwise, re-throw original exception (SyntaxError, etc)