### PR TITLE
Move ASYNC_HOOK_TIMEOUT to global setting

### DIFF
--- a/examples/globalsModule.js
+++ b/examples/globalsModule.js
@@ -15,6 +15,10 @@ module.exports = {
   // elements are found using the given locate strategy and selector
   throwOnMultipleElementsReturned : true,
 
+  // controls the timeout time for async hooks. Expects the done() call to be made within this time
+  // or an error is thrown
+  asyncHookTimeout : 10000,
+
   'default' : {
     myGlobal : function() {
       return 'I\'m a method';

--- a/lib/runner/testsuite.js
+++ b/lib/runner/testsuite.js
@@ -9,7 +9,6 @@ var Logger = require('../util/logger.js');
 var Utils = require('../util/utils.js');
 
 function noop() {}
-var ASYNC_HOOK_TIMEOUT = 10000;
 
 function TestSuite(modulePath, fullPaths, opts, addtOpts) {
   events.EventEmitter.call(this);
@@ -451,14 +450,15 @@ TestSuite.prototype.adaptGlobalHook = function(hookName) {
 };
 
 TestSuite.prototype.adaptDoneCallback = function(done, hookName, deferred) {
+  var maxTimeout = this.client.api().globals.asyncHookTimeout || 10000;
   var timeout = setTimeout(function() {
     try {
-      throw new Error('done() callback timeout was reached while executing '+ hookName + '.' +
+      throw new Error('done() callback timeout was reached while executing ' + hookName + '.' +
         ' Make sure to call the done() callback when the operation finishes.');
     } catch (err) {
       deferred.reject(err);
     }
-  }, ASYNC_HOOK_TIMEOUT);
+  }, maxTimeout);
 
   return function() {
     clearTimeout(timeout);


### PR DESCRIPTION
This just moves the ASYNC_HOOK_TIMEOUT constant to a configurable
global setting.

Currently missing a test.