### PR TITLE
Amended failing github test with passing version

### DIFF
--- a/examples/tests/github.js
+++ b/examples/tests/github.js
@@ -5,8 +5,8 @@ module.exports = {
       .url('https://github.com/nightwatchjs/nightwatch')
       .waitForElementVisible('body', 1000)
       .assert.title('nightwatchjs/nightwatch · GitHub')
-      .assert.visible('.container .breadcrumb a span')
-      .assert.containsText('.container .breadcrumb a span', 'nightwatch', 'Checking project title is set to nightwatch');
+      .assert.visible('div.repohead-details-container span.author > a > span')
+      .assert.containsText('div.repohead-details-container span.author > a > span', 'nightwatchjs', 'Checking repo title is set to nightwatchjs');
   },
 
   after : function(client) {


### PR DESCRIPTION
When working through the Quick Start guide the example tests are failing as the web sites under test have moved on. This change provides a variant of the github test that passes with the current markup on the github page.