### PR TITLE
return from the wrapped command function

### DIFF
--- a/lib/page-object/command-wrapper.js
+++ b/lib/page-object/command-wrapper.js
@@ -94,7 +94,7 @@ module.exports = new (function() {
           args.push(function() {
             parent.client.locateStrategy = prevLocateStrategy;
             if (callback) {
-              callback.apply(parent.client, arguments);
+              return callback.apply(parent.client, arguments);
             }
           });
         }


### PR DESCRIPTION
... otherwise, the return value of the function passed to a custom command is lost (see https://github.com/nightwatchjs/nightwatch/issues/787). 

(I'm not sure why it should wrap all the functions passed as 2nd parameter to a command - would it be possible to check the function name (http://stackoverflow.com/a/15714445), so it overwrites only the correct function?)