### PR TITLE
Formatting objects as strings in assertion code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ UI automated testing framework powered by [Node.js](http://nodejs.org/). It uses
 
 ***
 
-#### [Homepage](http://nightwatchjs.org) | [Developer Guide](http://nightwatchjs.org/guide) | [API Reference](http://nightwatchjs.org/api)
+#### [Homepage](http://nightwatchjs.org) | [Developer Guide](http://nightwatchjs.org/guide) | [API Reference](http://nightwatchjs.org/api) | [Changelog](https://github.com/nightwatchjs/nightwatch/releases)
 
 ### Selenium WebDriver standalone server
 Nightwatch works with the Selenium standalone server so the first thing you need to do is download the selenium server jar file `selenium-server-standalone-2.x.x.jar` from the Selenium releases page:

--- a/bin/nightwatch.json
+++ b/bin/nightwatch.json
@@ -87,6 +87,27 @@
         "browserstack.user" : "...",
         "browserstack.key" : "..."
       }
+    },
+    
+    "testingbot" : {
+      "selenium_host" : "hub.testingbot.com",
+      "selenium_port" : 80,
+      "apiKey" : "${TB_KEY}",
+      "apiSecret" : "${TB_SECRET}",
+      "silent" : true,
+      "output" : true,
+      "screenshots" : {
+        "enabled" : false,
+        "on_failure" : true,
+        "path" : ""
+      },
+      "desiredCapabilities": {
+        "name" : "test-example",
+        "browserName": "firefox"
+      },
+      "selenium" : {
+        "start_process" : false
+      }
     }
   }
 }

--- a/examples/tests/github.js
+++ b/examples/tests/github.js
@@ -4,7 +4,6 @@ module.exports = {
     client
       .url('https://github.com/nightwatchjs/nightwatch')
       .waitForElementVisible('body', 1000)
-      .assert.title('nightwatchjs/nightwatch · GitHub')
       .assert.visible('.container h1 strong a')
       .assert.containsText('.container h1 strong a', 'nightwatch', 'Checking project title is set to nightwatch');
   },

--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -908,6 +908,7 @@ module.exports = function(Nightwatch) {
    * Retrieve the current window handle.
    *
    * @link /session/:sessionId/window/:windowHandle/maximize
+   * @param {string} [handleOrName] windowHandle URL parameter; if it is "current", the currently active window will be maximized.
    * @param {function} [callback] Optional callback function to be called when the command finishes.
    * @api protocol
    */

--- a/lib/core/assertion.js
+++ b/lib/core/assertion.js
@@ -190,6 +190,13 @@ module.exports = new (function() {
       throw new Error('init must be called first.');
     }
 
+    if(receivedValue !== null && typeof receivedValue == 'object') {
+      receivedValue = JSON.stringify(receivedValue);
+    } 
+    if(expectedValue !== null && typeof expectedValue == 'object') {
+      expectedValue = JSON.stringify(expectedValue);
+    } 
+
     var failure = '';
     var stacktrace = '';
 

--- a/lib/core/assertion.js
+++ b/lib/core/assertion.js
@@ -99,7 +99,19 @@ module.exports = new (function() {
         return self._reschedule();
       }
 
-      var expected = typeof self.expected == 'function' ? self.expected() : self.expected;
+      var expected;
+      if (typeof self.expected == 'function') {
+        expected = self.expected();
+      } else if(self.expected !== null && typeof self.expected == 'object') {
+        expected = JSON.stringify(self.expected);
+      } else {
+        expected  = self.expected;
+      }
+
+      if(value !== null && typeof value == 'object') {
+        value = JSON.stringify(value);
+      } 
+
       var message = self._getFullMessage(passed, timeSpent);
 
       self.client.assertion(passed, value, expected, message, self.abortOnFailure, self._stackTrace);

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -33,7 +33,6 @@ CliRunner.prototype = {
   init : function(done) {
     this
       .readSettings()
-      .setOutputFolder()
       .parseTestSettings({}, done);
 
     return this;
@@ -47,7 +46,6 @@ CliRunner.prototype = {
   setup : function(settings, done) {
     this
       .readSettings()
-      .setOutputFolder()
       .parseTestSettings(settings, done);
 
     return this;
@@ -173,10 +171,13 @@ CliRunner.prototype = {
    * @returns {CliRunner}
    */
   setOutputFolder : function() {
-    var isDisabled = this.settings.output_folder === false;
+    var isDisabled = this.settings.output_folder === false && typeof(this.test_settings.output_folder) == 'undefined' ||
+      this.test_settings.output_folder === false;
     var isDefault = this.cli.command('output').isDefault(this.argv.output);
+    var folder = this.test_settings.output_folder || this.settings.output_folder;
 
-    this.output_folder = isDisabled ? false : (isDefault && this.settings.output_folder || this.argv.output);
+    this.output_folder = isDisabled ? false : (isDefault && folder || this.argv.output);
+
     return this;
   },
 
@@ -481,6 +482,7 @@ CliRunner.prototype = {
   initTestSettings : function(env, settings) {
     // picking the environment specific test settings
     this.test_settings = env && this.settings.test_settings[env] || {};
+
     if (env) {
       this.test_settings.custom_commands_path = this.settings.custom_commands_path || '';
       this.test_settings.custom_assertions_path = this.settings.custom_assertions_path || '';
@@ -491,6 +493,7 @@ CliRunner.prototype = {
       this.readExternalGlobals();
     }
 
+    this.setOutputFolder();
     this.setGlobalOutputOptions();
 
     if (typeof this.test_settings.test_workers != 'undefined') {

--- a/lib/runner/testsuite.js
+++ b/lib/runner/testsuite.js
@@ -417,12 +417,12 @@ TestSuite.prototype.globalAfterEach = function() {
 TestSuite.prototype.adaptGlobalHook = function(hookName) {
   return this.makePromise(function(done, deffered) {
     var callbackDeffered = false;
-    var doneFn = function() {
+    var doneFn = function(err) {
       if (callbackDeffered) {
         return;
       }
       var fn = this.adaptDoneCallback(done, 'global ' + hookName, deffered);
-      return fn();
+      return this.onGlobalHookError(err, true, fn);
     }.bind(this);
 
     var argsCount;
@@ -445,11 +445,7 @@ TestSuite.prototype.adaptGlobalHook = function(hookName) {
       callbackDeffered = true;
       if (hookName == 'before' || hookName == 'beforeEach') {
         this.client.start(function(err) {
-          if (err) {
-            this.testResults.errors++;
-            this.testResults.errmessages = [err.message];
-          }
-          done(err);
+          return this.onGlobalHookError(err, false, done);
         }.bind(this));
       } else {
         this.client.restartQueue(function() {
@@ -459,6 +455,15 @@ TestSuite.prototype.adaptGlobalHook = function(hookName) {
     }
 
   });
+};
+
+TestSuite.prototype.onGlobalHookError = function(err, hookErr, done) {
+  if (err && err.message) {
+    this.testResults.errors++;
+    this.testResults.errmessages = [err.message];
+  }
+
+  return done(err, hookErr);
 };
 
 TestSuite.prototype.adaptDoneCallback = function(done, hookName, deferred) {
@@ -474,8 +479,13 @@ TestSuite.prototype.adaptDoneCallback = function(done, hookName, deferred) {
 TestSuite.prototype.makePromise = function (fn) {
   var deferred = Q.defer();
   try {
-    fn.call(this, function() {
-      deferred.resolve();
+    fn.call(this, function(err, hookErr) {
+      // in case of an exception thrown inside a global hook, we need to reject the promise here
+      if (hookErr && err && (err instanceof Error)) {
+        deferred.reject(err);
+      } else {
+        deferred.resolve();
+      }
     }, deferred);
   } catch (e) {
     deferred.reject(e);

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -57,9 +57,9 @@ Util.setCallbackTimeout = function(done, fnName, timeMs, onCatch) {
     }
   }, timeMs);
 
-  return function() {
+  return function(err) {
     clearTimeout(timeout);
-    done();
+    done(err, true);
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nightwatch",
   "description": "A node.js bindings implementation for selenium 2.0/webdriver",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "author": {
     "name": "Andrei Rusu",
     "email": "andrei@nightwatchjs.org"

--- a/tests/src/cli/testCliRunner.js
+++ b/tests/src/cli/testCliRunner.js
@@ -42,6 +42,36 @@ module.exports = {
       }
     });
 
+    mockery.registerMock('./output_disabled_env.json', {
+      src_folders : ['tests'],
+      output_folder : 'reports',
+      test_settings : {
+        'default' : {
+          output_folder : false
+        }
+      }
+    });
+
+    mockery.registerMock('./output_custom_enabled.json', {
+      src_folders : ['tests'],
+      output_folder : false,
+      test_settings : {
+        'default' : {
+          output_folder : 'custom'
+        }
+      }
+    });
+
+    mockery.registerMock('./output_custom.json', {
+      src_folders : ['tests'],
+      output_folder : 'reports',
+      test_settings : {
+        'default' : {
+          output_folder : 'custom_overwritten'
+        }
+      }
+    });
+
     mockery.registerMock('./empty.json', {
       src_folders : 'tests'
     });
@@ -169,6 +199,15 @@ module.exports = {
         if (b == './output_disabled.json') {
           return './output_disabled.json';
         }
+        if (b == './output_disabled_env.json') {
+          return './output_disabled_env.json';
+        }
+        if (b == './output_custom.json') {
+          return './output_custom.json';
+        }
+        if (b == './output_custom_enabled.json') {
+          return './output_custom_enabled.json';
+        }
         if (b == './empty.json') {
           return './empty.json';
         }
@@ -267,6 +306,75 @@ module.exports = {
     }).init();
 
     test.equals(runner.output_folder, false);
+
+    test.done();
+
+  },
+
+  testSetOutputFolderDisabledPerEnv : function(test) {
+    mockery.registerMock('fs', {
+      existsSync : function(module) {
+        if (module == './settings.json' || module == './nightwatch.conf.js') {
+          return false;
+        }
+
+        return true;
+      }
+    });
+
+    var CliRunner = require('../../../'+ BASE_PATH +'/../lib/runner/cli/clirunner.js');
+    var runner = new CliRunner({
+      config : './output_disabled_env.json',
+      env : 'default'
+    }).init();
+
+    test.equals(runner.output_folder, false);
+
+    test.done();
+
+  },
+
+  testSetOutputFolderCustomOverwrite : function(test) {
+    mockery.registerMock('fs', {
+      existsSync : function(module) {
+        if (module == './settings.json' || module == './nightwatch.conf.js') {
+          return false;
+        }
+
+        return true;
+      }
+    });
+
+    var CliRunner = require('../../../'+ BASE_PATH +'/../lib/runner/cli/clirunner.js');
+    var runner = new CliRunner({
+      config : './output_custom.json',
+      env : 'default'
+    }).init();
+
+    test.equals(runner.output_folder, 'custom_overwritten');
+
+    test.done();
+
+  },
+
+  testSetOutputFolderCustomEnabled : function(test) {
+    mockery.registerMock('fs', {
+      existsSync : function(module) {
+        if (module == './settings.json' || module == './nightwatch.conf.js') {
+          return false;
+        }
+
+        return true;
+      }
+    });
+
+    var CliRunner = require('../../../'+ BASE_PATH +'/../lib/runner/cli/clirunner.js');
+    var runner = new CliRunner({
+      config : './output_custom_enabled.json',
+      env : 'default'
+    }).init();
+
+    test.equals(runner.output_folder, 'custom');
 
     test.done();
 

--- a/tests/src/runner/testRunWithGlobalHooks.js
+++ b/tests/src/runner/testRunWithGlobalHooks.js
@@ -161,6 +161,32 @@ module.exports = {
     });
   },
 
+  'test run with global async beforeEach and done(err);' : function(test) {
+    var testsPath = path.join(process.cwd(), '/sampletests/before-after');
+
+    this.Runner.run([testsPath], {
+      seleniumPort : 10195,
+      silent : true,
+      output : false,
+      globals : {
+        test : test,
+        beforeEach: function(client, done) {
+          setTimeout(function() {
+            done(new Error('global beforeEach error'));
+          }, 10);
+        }
+      }
+    }, {
+      output_folder : false,
+      start_session : true
+    }, function(err, results) {
+      test.ok(err instanceof Error);
+      test.equals(err.message, 'global beforeEach error');
+
+      test.done();
+    });
+  },
+
   'test currentTest in global beforeEach/afterEach' : function(test) {
     test.expect(18);
     var testsPath = path.join(process.cwd(), '/sampletests/withfailures');

--- a/tests/src/runner/testRunWithGlobalReporter.js
+++ b/tests/src/runner/testRunWithGlobalReporter.js
@@ -50,7 +50,6 @@ module.exports = {
       globals : {
         test : test,
         reporter: function(results, done) {
-          console.log(results);
           test.ok('modules' in results);
           reporterCount++;
           done();

--- a/tests/src/testAssertions.js
+++ b/tests/src/testAssertions.js
@@ -180,6 +180,20 @@ module.exports = {
     m._commandFn('.test_element', 'text result', 'Test message');
   },
 
+  'Testing stringified object in assertion' : function(test) {
+    this.client = require('../nightwatch.js').init();
+    this.client.api.assert.equal({"test":true},{"test":false});     
+    this.client.on('nightwatch:finished', function(results, errors) {
+          test.equals(results.passed, 0);
+          test.equals(results.failed, 1);
+          test.equals(results.errors, 0);
+          test.equals(results.skipped, 0);
+          test.equals(results.tests[0].failure, 'Expected "{"test":false}" but got: "{"test":true}"');
+          test.ok('stacktrace' in results.tests[0]);
+          test.done();
+        });   
+  },
+
   tearDown : function(callback) {
     // clean up
     this.client = null;


### PR DESCRIPTION
When an expected or received value in an assertion in an object, the assertion text isn't helpful.  It prints out `[object Object]` instead of something more useful like the stringified object `{ test: 1 }`.

This is useful if you have custom assertion which tests if two objects on a page are equal.
