### PR TITLE
Add a hide_stack_trace option to config. Default false.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -144,6 +144,8 @@ Nightwatch.prototype.setOptions = function(options) {
 
   this.endSessionOnFail(typeof this.options.end_session_on_fail == 'undefined' || this.options.end_session_on_fail);
 
+  this.api.options.hide_stack_trace = this.options.hide_stack_trace;
+
   return this;
 };
 

--- a/lib/runner/testcase.js
+++ b/lib/runner/testcase.js
@@ -74,6 +74,9 @@ TestCase.prototype.run = function () {
           var parts = err.stack.split('\n');
           var headline = parts.shift();
 
+          if (self.suite.options.hide_stack_trace) {
+            parts = [];
+          }
           Utils.showStackTrace(failSymbol + ' ' + headline, parts);
           self.suite.client.terminate();
         }


### PR DESCRIPTION
I haven't found the stack traces on web assertions to add any value for me. Instead they just add noise and make it harder to read the raw results. This change makes the stack trace optional. There is a PR to add docs for this option as well: https://github.com/nightwatchjs/nightwatch-docs/pull/19.
