### PR TITLE
Properly pass settings to child workers when using parallel processes

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -779,7 +779,7 @@ CliRunner.prototype = {
         var childArgs = args.slice();
         childArgs.push('--test', modulePath, '--test-worker');
 
-        var child = new ChildProcess(outputLabel, index, childOutput, self.settings, childArgs);
+        var child = new ChildProcess(outputLabel, index, childOutput, self.test_settings, childArgs);
         child.setLabel(outputLabel);
 
         self.runningProcesses[child.itemKey] = child;
@@ -791,7 +791,7 @@ CliRunner.prototype = {
           if (remaining > 0) {
             next();
           } else {
-            if (!self.settings.live_output) {
+            if (!self.test_settings.live_output) {
               self.printChildProcessOutput();
             }
 

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -173,7 +173,7 @@ module.exports = new (function() {
     if (opts.parallelMode) {
       opts.currentEnv = process.env.__NIGHTWATCH_ENV_KEY;
     }
-    opts.live_output = additionalOpts.live_output;
+    opts.live_output = additionalOpts.live_output || opts.live_output;
     opts.start_session = additionalOpts.start_session;
     opts.report_prefix = '';
 

--- a/tests/src/cli/testCliRunner.js
+++ b/tests/src/cli/testCliRunner.js
@@ -41,6 +41,25 @@ module.exports = {
         }
       }
     });
+    mockery.registerMock('./live_output.json', {
+      src_folders : ['tests'],
+      live_output : true,
+      test_settings : {
+        'default' : {
+
+        }
+      }
+    });
+
+    mockery.registerMock('./live_output_override.json', {
+      src_folders : ['tests'],
+      live_output : true,
+      test_settings : {
+        'default' : {
+          live_output : false
+        }
+      }
+    });
 
     mockery.registerMock('./empty.json', {
       src_folders : 'tests'
@@ -169,6 +188,12 @@ module.exports = {
         if (b == './output_disabled.json') {
           return './output_disabled.json';
         }
+        if (b == './live_output.json') {
+          return './live_output.json';
+        }
+        if (b == './live_output_override.json') {
+          return './live_output_override.json';
+        }
         if (b == './empty.json') {
           return './empty.json';
         }
@@ -267,6 +292,52 @@ module.exports = {
     }).init();
 
     test.equals(runner.output_folder, false);
+
+    test.done();
+
+  },
+
+  testSetLiveOutput : function(test) {
+    mockery.registerMock('fs', {
+      existsSync : function(module) {
+        if (module == './settings.json' || module == './nightwatch.conf.js') {
+          return false;
+        }
+
+        return true;
+      }
+    });
+
+    var CliRunner = require('../../../'+ BASE_PATH +'/../lib/runner/cli/clirunner.js');
+    var runner = new CliRunner({
+      config : './live_output.json',
+      env : 'default'
+    }).init();
+
+    test.equals(runner.settings.live_output, true);
+
+    test.done();
+
+  },
+
+  testSetLiveOutputOverride : function(test) {
+    mockery.registerMock('fs', {
+      existsSync : function(module) {
+        if (module == './settings.json' || module == './nightwatch.conf.js') {
+          return false;
+        }
+
+        return true;
+      }
+    });
+
+    var CliRunner = require('../../../'+ BASE_PATH +'/../lib/runner/cli/clirunner.js');
+    var runner = new CliRunner({
+      config : './live_output_override.json',
+      env : 'default'
+    }).init();
+
+    test.equals(runner.settings.live_output, false);
 
     test.done();
 

--- a/tests/src/cli/testCliRunner.js
+++ b/tests/src/cli/testCliRunner.js
@@ -41,25 +41,6 @@ module.exports = {
         }
       }
     });
-    mockery.registerMock('./live_output.json', {
-      src_folders : ['tests'],
-      live_output : true,
-      test_settings : {
-        'default' : {
-
-        }
-      }
-    });
-
-    mockery.registerMock('./live_output_override.json', {
-      src_folders : ['tests'],
-      live_output : true,
-      test_settings : {
-        'default' : {
-          live_output : false
-        }
-      }
-    });
 
     mockery.registerMock('./empty.json', {
       src_folders : 'tests'
@@ -188,12 +169,6 @@ module.exports = {
         if (b == './output_disabled.json') {
           return './output_disabled.json';
         }
-        if (b == './live_output.json') {
-          return './live_output.json';
-        }
-        if (b == './live_output_override.json') {
-          return './live_output_override.json';
-        }
         if (b == './empty.json') {
           return './empty.json';
         }
@@ -292,52 +267,6 @@ module.exports = {
     }).init();
 
     test.equals(runner.output_folder, false);
-
-    test.done();
-
-  },
-
-  testSetLiveOutput : function(test) {
-    mockery.registerMock('fs', {
-      existsSync : function(module) {
-        if (module == './settings.json' || module == './nightwatch.conf.js') {
-          return false;
-        }
-
-        return true;
-      }
-    });
-
-    var CliRunner = require('../../../'+ BASE_PATH +'/../lib/runner/cli/clirunner.js');
-    var runner = new CliRunner({
-      config : './live_output.json',
-      env : 'default'
-    }).init();
-
-    test.equals(runner.settings.live_output, true);
-
-    test.done();
-
-  },
-
-  testSetLiveOutputOverride : function(test) {
-    mockery.registerMock('fs', {
-      existsSync : function(module) {
-        if (module == './settings.json' || module == './nightwatch.conf.js') {
-          return false;
-        }
-
-        return true;
-      }
-    });
-
-    var CliRunner = require('../../../'+ BASE_PATH +'/../lib/runner/cli/clirunner.js');
-    var runner = new CliRunner({
-      config : './live_output_override.json',
-      env : 'default'
-    }).init();
-
-    test.equals(runner.settings.live_output, false);
 
     test.done();
 

--- a/tests/src/runner/testLiveUpdate.js
+++ b/tests/src/runner/testLiveUpdate.js
@@ -1,0 +1,65 @@
+var BASE_PATH = process.env.NIGHTWATCH_COV ? 'lib-cov' : 'lib';
+var path = require('path');
+
+module.exports = {
+  setUp : function(cb) {
+    this.Runner = require('../../../'+ BASE_PATH +'/runner/run.js');
+    process.removeAllListeners('exit');
+    process.removeAllListeners('uncaughtException');
+    cb();
+  },
+
+  tearDown : function(callback) {
+    delete require.cache[require.resolve('../../../'+ BASE_PATH +'/runner/run.js')];
+    callback();
+  },
+
+  testLiveUpdateFlag : function(test) {
+    test.expect(6);
+    var testsPath = path.join(process.cwd(), '/sampletests/simple');
+    var options = {
+      seleniumPort : 10195,
+      silent : true,
+      output : false,
+      globals : {
+        test : test
+      },
+      live_output: false
+    };
+    this.Runner.run([testsPath], options, {
+      output_folder : false,
+      start_session : true
+    }, function(err, results) {
+      test.equals(err, null);
+      test.ok('sample' in results.modules);
+      test.ok('demoTest' in results.modules.sample.completed);
+      test.equals(options.live_output, false);
+      test.done();
+    });
+  },
+
+  testLiveUpdateOverrideFlag : function(test) {
+    test.expect(6);
+    var testsPath = path.join(process.cwd(), '/sampletests/simple');
+    var options = {
+      seleniumPort : 10195,
+      silent : true,
+      output : false,
+      globals : {
+        test : test
+      },
+      live_output: false
+    };
+    this.Runner.run([testsPath], options, {
+      live_output : true,
+      output_folder : false,
+      start_session : true
+    }, function(err, results) {
+      test.equals(err, null);
+      test.ok('sample' in results.modules);
+      test.ok('demoTest' in results.modules.sample.completed);
+      test.equals(options.live_output, true);
+      test.done();
+    });
+  }
+};

--- a/tests/src/runner/testParallelExecution.js
+++ b/tests/src/runner/testParallelExecution.js
@@ -123,7 +123,7 @@ module.exports = {
       test.strictEqual(child.index, 0);
       test.equal(child.startDelay, 10);
       test.equal(child.environment, path.join('sampletests', 'async', 'sample'));
-      test.deepEqual(child.settings, runner.settings);
+      test.deepEqual(child.settings, runner.test_settings);
       test.strictEqual(child.globalExitCode, 0);
       test.equal(child.args.length, 3);
       test.equal(child.args[0], '--test');


### PR DESCRIPTION
I believe there are only two situations where these settings are passed through to the test runner (though I may be wrong).

Running tests directly using the runner
Using the cli interface (through grunt or directly) to run the tests
My main concern was the live_output flag not being overridden, so that was specifically what I was looking for. It seems that when starting test workers, the entire settings config was being passed, along with args for things like the environment. However, the child process was never specifying which test settings to use. Switching to passing the test settings for the environment directly lets us just use the correct settings immediately without having to do any additional work to process them.

npm test passes
running the script with the expected changes works as well

Moved to a side branch off of master
Previously https://github.com/nightwatchjs/nightwatch/pull/863, https://github.com/nightwatchjs/nightwatch/issues/841
