### PR TITLE
Restore Screenshots Functionality. Soves issue #867.

### DIFF
--- a/lib/api/client-commands/end.js
+++ b/lib/api/client-commands/end.js
@@ -28,8 +28,9 @@ End.prototype.command = function(callback) {
   var client = this.client;
 
   if (client.sessionId) {
+	var fileNamePath = null;
     if (this.testFailuresExist() && this.shouldTakeScreenshot()) {
-      var fileNamePath = Utils.getScreenshotFileName(client.api.currentTest, false, client.options.screenshots.path);
+      fileNamePath = Utils.getScreenshotFileName(client.api.currentTest, false, client.options.screenshots.path);
       Logger.info('We have failures in "' + client.api.currentTest.name + '". Taking screenshot...');
 
       client.api.saveScreenshot(fileNamePath, function(result, err) {
@@ -41,6 +42,10 @@ End.prototype.command = function(callback) {
 
     client.api.session('delete', function(result) {
       client.sessionId = client.api.sessionId = null;
+		// Do I have a screenshot? Let's save it for later.
+		if (fileNamePath) {
+		  result.lastScreenshotFile = fileNamePath;
+		}
       self.complete(callback, result);
     });
   } else {


### PR DESCRIPTION
Solves issue #867.
Now when a screenshot is taken, it is saved as `result.lastScreenshotFile `. This allow index.js to be aware that a screenshot is taken and to carry it over until junit reports are created. With this fix, screenshots shows up into the .xml reports.
I'm using nightwatch-html-reporter and with this fix screenshots shows up there as well.

The end of the session seemed like the best place for this to be added. I welcome suggestions as I'm very new to this framework and I've been using it only for a few days. Please let me know if I can help to make this better.