### PR TITLE
Detect page object on the Url or Commands keys

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -474,7 +474,7 @@ module.exports = new (function() {
   }
 
   function useEnhancedModel(pageFnOrObject) {
-    return typeof pageFnOrObject == 'object' && (pageFnOrObject.elements || pageFnOrObject.sections);
+    return typeof pageFnOrObject == 'object' && (pageFnOrObject.url || pageFnOrObject.elements || pageFnOrObject.sections || pageFnOrObject.commands);
   }
 
   /**


### PR DESCRIPTION
At the moment, the docs have a page object with only the `url` key, but this code only instantiates a proper page object if the `elements` or `sections` key is present. This looks for `url` or `commands` to be present as well, fixing #570
