### PR TITLE
Expose log_timestamp in logger.js as a testsetting

### DIFF
--- a/lib/api/element-commands/_waitForElement.js
+++ b/lib/api/element-commands/_waitForElement.js
@@ -208,9 +208,9 @@ WaitForElement.prototype.checkElement = function() {
       if (result.value.length > 1) {
         var message = 'WaitForElement found ' + result.value.length + ' elements for selector "' + self.selector + '".';
         if (self.throwOnMultipleElementsReturned) {
-          throw new Error(message);
+          throw new Error(Logger.getTimeStamp() + message);
         } else if (self.client.options.output) {
-          console.log(Logger.colors.green('  Warn: ' + message + ' Only the first one will be checked.'));
+          console.log(Logger.getTimeStamp() + Logger.colors.green('  Warn: ' + message + ' Only the first one will be checked.'));
         }
       }
 

--- a/lib/core/assertion.js
+++ b/lib/core/assertion.js
@@ -195,7 +195,7 @@ module.exports = new (function() {
 
     if (passed) {
       if (client.options.output) {
-        console.log(' ' + Logger.colors.green(doneSymbol) + ' ' + message);
+        console.log(Logger.getTimeStamp() + ' ' + Logger.colors.green(doneSymbol) + ' ' + message);
       }
       client.results.passed++;
     } else {
@@ -204,7 +204,7 @@ module.exports = new (function() {
       try {
         var err = new Error();
 
-        err.name = message;
+        err.name = Logger.getTimeStamp() + message;
         err.message = message + ' - ' + failure;
 
         if (originalStackTrace) {
@@ -222,7 +222,7 @@ module.exports = new (function() {
 
         throw err;
       } catch (ex) {
-        var logged = ' ' + Logger.colors.red(failSymbol) + ' ' + message;
+        var logged = Logger.getTimeStamp() + ' ' + Logger.colors.red(failSymbol) + ' ' + message;
         if (typeof expectedValue != 'undefined' && typeof receivedValue != 'undefined') {
           logged += ' ' + Logger.colors.white(' - expected ' + Logger.colors.green('"' +
             expectedValue + '"')) + ' but got: ' + Logger.colors.red(receivedValue);

--- a/lib/core/queue.js
+++ b/lib/core/queue.js
@@ -37,18 +37,18 @@ AsyncTree.prototype.append = function(nodeName, command, context, args, stackTra
 };
 
 AsyncTree.prototype.print = function(node, level) {
-  process.stdout.write(node.name + '\n');
+  process.stdout.write(Logger.getTimeStamp() + node.name + '\n');
   level = level || 1;
   for (var i = 0; i < node.children.length; i++) {
     var childNode = node.children[i];
     for (var k = 0; k < level; k++) {
-      process.stdout.write(' |- ');
+      process.stdout.write(Logger.getTimeStamp() +' |- ');
     }
     if (childNode.children.length) {
       var levelUp = level + 1;
       arguments.callee(childNode, levelUp);
     } else {
-      process.stdout.write(childNode.name + '\n');
+      process.stdout.write(Logger.getTimeStamp() + childNode.name + '\n');
     }
   }
   process.stdout.write('');
@@ -72,7 +72,7 @@ AsyncTree.prototype.traverse = function() {
   try {
     this.walkDown(this.currentNode);
   } catch (err) {
-    console.log(err.stack);
+    console.log(Logger.getTimeStamp() + err.stack);
   }
 
   this.currentNode.started = true;

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -130,10 +130,10 @@ module.exports = (function() {
         }
 
         if (errorMessage !== '') {
-          console.log(Logger.colors.yellow('There was an error while executing the Selenium command') +
+          console.log(Logger.getTimeStamp() +  Logger.colors.yellow('There was an error while executing the Selenium command') +
             (!Logger.isEnabled() ? ' - enabling the --verbose option might offer more details.' : '')
           );
-          console.log(errorMessage);
+          console.log(Logger.getTimeStamp() + errorMessage);
         }
 
         self.emit('beforeResult', result);
@@ -266,8 +266,8 @@ module.exports = (function() {
     try {
       result = JSON.parse(data);
     } catch (err) {
-      console.log(Logger.colors.red('Error processing the server response:'), '\n', data);
-      result = {value: -1, error: err.message};
+      console.log(Logger.getTimeStamp() +  Logger.colors.red('Error processing the server response:'), '\n', err.stack);
+      result = {value: data, error: err.message};
     }
     return result;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -302,16 +302,16 @@ Nightwatch.prototype.printResult = function(elapsedTime) {
     }
 
     if (ok && this.results.passed > 0) {
-      console.log('\n' + Logger.colors.green('OK.'),
+      console.log('\n' + Logger.getTimeStamp() + Logger.colors.green('OK.'),
         Logger.colors.green(this.results.passed) + ' assertions passed. (' + Utils.formatElapsedTime(elapsedTime, true) + ')');
     } else if (ok && this.results.passed === 0) {
       if (this.options.start_session) {
-        console.log(Logger.colors.green('No assertions ran.'));
+        console.log('\n' + Logger.getTimeStamp() + Logger.colors.green('No assertions ran.'));
       }
     } else {
       var failure_msg = this.getFailureMessage();
 
-      console.log('\n' +  Logger.colors.red('FAILED: '), failure_msg, '(' + Utils.formatElapsedTime(elapsedTime, true) + ')');
+      console.log('\n' + Logger.getTimeStamp() + Logger.colors.red('FAILED: '), failure_msg, '(' + Utils.formatElapsedTime(elapsedTime, true) + ')');
     }
   }
 };

--- a/lib/runner/cli/child-process.js
+++ b/lib/runner/cli/child-process.js
@@ -51,7 +51,7 @@ ChildProcess.prototype = {
       self.processRunning = true;
 
       if (self.settings.output) {
-        console.log('Started child process for:' + self.env_label);
+        console.log(Logger.getTimeStamp() + 'Started child process for:' + self.env_label);
       }
 
       self.child.stdout.on('data', function (data) {
@@ -64,7 +64,7 @@ ChildProcess.prototype = {
 
       self.child.on('exit', function (code) {
         if (self.settings.output) {
-          console.log('\n  >>' + self.env_label + 'finished. ', '\n');
+          console.log('\n'+ Logger.getTimeStamp() +  '  >>' + self.env_label + 'finished. ', '\n');
         }
 
         if (code) {
@@ -119,9 +119,9 @@ ChildProcess.prototype = {
     output += '  ' + data;
 
     if (this.settings.live_output) {
-      process.stdout.write(output + '\n');
+      process.stdout.write(Logger.getTimeStamp() + output + '\n');
     } else {
-      this.env_output.push(output);
+      this.env_output.push(Logger.getTimeStamp() + output);
     }
   }
 };

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -555,6 +555,7 @@ CliRunner.prototype = {
 
     this.mergeSeleniumOptions();
     this.disableCliColorsIfNeeded();
+    this.enableLogTimeStamp();
 
     this.endSessionOnFail = typeof this.settings.end_session_on_fail == 'undefined' || this.settings.end_session_on_fail;
     if (typeof this.test_settings.end_session_on_fail != 'undefined') {
@@ -566,6 +567,13 @@ CliRunner.prototype = {
   disableCliColorsIfNeeded : function() {
     if (this.settings.disable_colors || this.test_settings.disable_colors) {
       Logger.disableColors();
+    }
+    return this;
+  },
+  
+  enableLogTimeStamp: function() {
+    if (this.settings.log_timestamp || this.test_settings.log_timestamp) {
+      Logger.enableTimeStamp();
     }
     return this;
   },

--- a/lib/runner/reporter.js
+++ b/lib/runner/reporter.js
@@ -71,7 +71,7 @@ Reporter.prototype.save = function() {
 
       reporter.write(self.globalResults, self.options, function(err) {
         if (err) {
-          console.log(Logger.colors.yellow('Warning: Failed to save report file to folder: ' + self.options.output_folder));
+          console.log(Logger.getTimeStamp() + Logger.colors.yellow('Warning: Failed to save report file to folder: ' + self.options.output_folder));
           console.log(err.stack);
         }
         deferred.resolve();
@@ -90,7 +90,7 @@ Reporter.prototype.printTotalResults = function(modulekeys, results) {
     var countMessage = this.getTestsFailedMessage();
 
     console.log('----------------------------------------------------');
-    console.log(Logger.colors.light_red('TEST FAILURE:'), countMessage, '(' + Utils.formatElapsedTime(elapsedTime) + ')');
+    console.log(Logger.getTimeStamp() + Logger.colors.light_red('TEST FAILURE:'), countMessage, '(' + Utils.formatElapsedTime(elapsedTime) + ')');
 
     this.printSummary();
     console.log('');
@@ -122,15 +122,15 @@ Reporter.prototype.hasAssertionCount = function() {
 
 Reporter.prototype.getTestsPassedMessage = function() {
   var hasCount = this.hasAssertionCount();
-  var message;
+  var message = Logger.getTimeStamp();
   var count;
 
   if (hasCount) {
     count = this.globalResults.passed;
-    message = Logger.colors.green('OK. ' + count) + (count > 1 ? ' total assertions' : ' assertion') + ' passed.';
+    message += Logger.colors.green('OK. ' + count) + (count > 1 ? ' total assertions' : ' assertion') + ' passed.';
   } else {
     count = this.getTotalTestsCount();
-    message = Logger.colors.green('OK. ' + count) + ' tests passed.';
+    message += Logger.colors.green('OK. ' + count) + ' tests passed.';
   }
 
   return message;

--- a/lib/runner/selenium.js
+++ b/lib/runner/selenium.js
@@ -46,7 +46,7 @@ SeleniumServer.prototype.setCliArgs = function() {
 
 SeleniumServer.prototype.start = function() {
   if (this.settings.output) {
-    process.stdout.write(Logger.colors.light_purple('Starting selenium server' + (this.settings.parallelMode ? ' in parallel mode' : '') +'... '));
+    process.stdout.write(Logger.getTimeStamp() + Logger.colors.light_purple('Starting selenium server' + (this.settings.parallelMode ? ' in parallel mode' : '') +'... '));
   }
 
   this.setCliArgs();

--- a/lib/runner/testcase.js
+++ b/lib/runner/testcase.js
@@ -18,10 +18,10 @@ TestCase.prototype.print = function () {
   if (opts.output) {
     process.stdout.write('\n');
     if (this.numRetries > 0) {
-      console.log('Retrying (' + this.numRetries + '/' + this.maxRetries + '): ',
+      console.log(Logger.getTimeStamp() + 'Retrying (' + this.numRetries + '/' + this.maxRetries + '): ',
         Logger.colors.red(this.testFn));
     } else {
-      console.log((opts.parallelMode && !opts.live_output ? 'Results for: ' : 'Running: '),
+      console.log((opts.parallelMode && !opts.live_output ? Logger.getTimeStamp() + 'Results for: ' : Logger.getTimeStamp() + 'Running: '),
         Logger.colors.green(this.testFn));
     }
   }
@@ -63,9 +63,9 @@ TestCase.prototype.run = function () {
         if (!self.suite.options.start_session) {
           deferred.promise.then(function(results) {
             if (err instanceof Error) {
-              console.log(' ' + Logger.colors.red(failSymbol + ' Failed ('+ results.time +'ms)'));
+              console.log(Logger.getTimeStamp() + ' ' + Logger.colors.red(failSymbol + ' Failed ('+ results.time +'ms)'));
             } else {
-              console.log(' ' + Logger.colors.green(doneSymbol + ' Passed ('+ results.time +'ms)'));
+              console.log(Logger.getTimeStamp() + ' ' + Logger.colors.green(doneSymbol + ' Passed ('+ results.time +'ms)'));
             }
           });
         }

--- a/lib/runner/testsuite.js
+++ b/lib/runner/testsuite.js
@@ -257,7 +257,7 @@ TestSuite.prototype.clearResult = function() {
 
 TestSuite.prototype.printRetry = function() {
   if (this.options.output) {
-    console.log('Retrying: ',
+    console.log('\n' + Logger.getTimeStamp() + 'Retrying: ',
       Logger.colors.red('[' + this.suiteName + '] Test Suite '),
       '(' + this.suiteRetries + '/' + this.suiteMaxRetries + '): ');
   }
@@ -514,7 +514,7 @@ TestSuite.prototype.updateDesiredCapabilities = function() {
 TestSuite.prototype.print = function() {
   if (this.options.output) {
     var testSuiteDisplay = '[' + this.suiteName + '] Test Suite';
-    console.log('\n' + Logger.colors.cyan(testSuiteDisplay, Logger.colors.background.black));
+    console.log('\n' + Logger.getTimeStamp() + Logger.colors.cyan(testSuiteDisplay, Logger.colors.background.black));
     console.log(Logger.colors.purple(new Array(testSuiteDisplay.length + 1).join('=')));
   }
 };

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -17,13 +17,17 @@ function pad(n) {
   return n < 10 ? '0' + n.toString(10) : n.toString(10);
 }
 
-// 26 Feb 16:19:34
-function timestamp() {
-  var d = new Date();
-  var time = [pad(d.getHours()),
-    pad(d.getMinutes()),
-    pad(d.getSeconds())].join(':');
-  return [d.getDate(), months[d.getMonth()], time].join(' ');
+function formattedTimestamp() {
+  if (Settings.log_timestamp) {
+    var d = new Date();
+    var time = [pad(d.getHours()),
+        pad(d.getMinutes()),
+        pad(d.getSeconds())].join(':');
+    return colors.white('[' + [d.getDate(), months[d.getMonth()], time].join(' ') + '] ');
+  }
+  else {
+    return '';
+  }
 }
 
 function getPrefix(tag, severity) {
@@ -97,36 +101,25 @@ function logObject(obj) {
   }));
 }
 
-function logTimestamp() {
-  if (Settings.log_timestamp) {
-    return colors.white(timestamp()) + ' ';
-  }
-  return '';
-}
-
 function logMessage(type, message, args) {
   if (!message || !Settings.enabled) {
     return;
   }
 
-  var messageStr = '';
-  var timestamp = logTimestamp();
+  var messageStr = '\n';
+  var timestamp = formattedTimestamp();
   switch (type) {
   case 'ERROR':
-    messageStr = colors.yellow(type, colors.background.dark_gray) +' '+
-                timestamp + colors.light_green(message);
+    messageStr = timestamp + colors.yellow(type, colors.background.dark_gray) + ' '+ colors.light_green(message);
     break;
   case 'INFO':
-    messageStr = colors.light_purple(type, colors.background.black) +' '+
-                timestamp + colors.light_cyan(message);
+    messageStr = timestamp + colors.light_purple(type, colors.background.black) + ' ' + colors.light_cyan(message);
     break;
   case 'LOG':
-    messageStr = colors.white(type+' ', colors.background.black) +' '+
-                timestamp + colors.white(message);
+    messageStr = timestamp + colors.white(type+' ', colors.background.black) + ' ' + colors.white(message);
     break;
   case 'WARN':
-    messageStr = colors.light_green(type, colors.background.black) +' '+
-                timestamp + colors.light_green(message);
+    messageStr = timestamp + colors.light_green(type, colors.background.black) + ' ' + colors.light_green(message);
     break;
   }
 
@@ -194,3 +187,13 @@ exports.isEnabled = function() {
   return Settings.enabled;
 };
 exports.colors = colors;
+
+exports.disableTimeStamp = function() {
+	Settings.log_timestamp = false;
+};
+
+exports.enableTimeStamp = function() {
+	Settings.log_timestamp = true;
+};
+
+exports.getTimeStamp = formattedTimestamp;

--- a/tests/src/cli/testCliRunner.js
+++ b/tests/src/cli/testCliRunner.js
@@ -99,7 +99,8 @@ module.exports = {
       test_settings : {
         'default' : {
           output : false,
-          disable_colors: true
+          disable_colors: true,
+		  log_timestamp: false
         }
       }
     });
@@ -145,6 +146,7 @@ module.exports = {
         'default' : {
           output : false,
           disable_colors: true,
+          log_timestamp: false,
           globals : {
             overwritten : '2',
             testGlobalOne : 'one',
@@ -440,6 +442,7 @@ module.exports = {
     test.equal(runner.settings.selenium.host, 'other.host');
     test.equal(runner.test_settings.output, false);
     test.equal(runner.test_settings.disable_colors, true);
+	test.equal(runner.test_settings.log_timestamp, false);
     test.equal(runner.test_settings.username, 'testuser');
     test.equal(runner.test_settings.credentials.service.user, 'testuser');
     test.equal(runner.test_settings.desiredCapabilities['test.user'], 'testuser');


### PR DESCRIPTION
Exposing log_timestamp setting in logger.js in test settings. So it can be consumed to print the time stamp of console / logger messages. 

Updated docs in separate PR https://github.com/nightwatchjs/nightwatch-docs/pull/26