### PR TITLE
Require subdirectories in page object path

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -406,13 +406,14 @@ module.exports = new (function() {
    * Loads page object files
    * @param {string} [dirPath]
    */
-  function loadPageObjects(dirPath) {
+  function loadPageObjects(dirPath, parent) {
     if (!page_objects_path && !dirPath) {
       return;
     }
 
     dirPath = dirPath || page_objects_path;
     client.api.page = client.api.page || {};
+    parent = parent || client.api.page;
 
     if (Array.isArray(dirPath)) {
       dirPath.forEach(function(folder) {
@@ -424,13 +425,18 @@ module.exports = new (function() {
     var absPath = path.resolve(dirPath);
     var pageFiles = fs.readdirSync(absPath);
 
-    for (var i = 0, len = pageFiles.length; i < len; i++) {
-      if (path.extname(pageFiles[i]) === '.js') {
-        var pageName = path.basename(pageFiles[i], '.js');
-        var pageFnOrObject = require(path.join(absPath, pageFiles[i]));
-        addPageObject(pageName, pageFnOrObject, client.api, client.api.page);
+    pageFiles.forEach(function(file) {
+      var fullPath = path.join(absPath, file);
+      if (fs.lstatSync(fullPath).isDirectory()) {
+        parent[file] = parent[file] || {};
+        var pathFolder = path.join(dirPath, file);
+        loadPageObjects(pathFolder, parent[file]);
+      } else if (path.extname(file) === '.js') {
+        var pageName = path.basename(file, '.js');
+        var pageFnOrObject = require(path.join(absPath, file));
+        addPageObject(pageName, pageFnOrObject, client.api, parent);
       }
-    }
+    });
   }
 
   /**

--- a/tests/extra/pageobjects/addl/simplePageObject.js
+++ b/tests/extra/pageobjects/addl/simplePageObject.js
@@ -1,0 +1,3 @@
+module.exports = {
+  elements: {}
+};

--- a/tests/src/testPageObject.js
+++ b/tests/src/testPageObject.js
@@ -58,6 +58,17 @@ module.exports = {
     test.done();
   },
 
+  testPageObjectSubDirectory : function(test) {
+    var client = this.client = require('../nightwatch.js').init({
+      page_objects_path: './extra/pageobjects'
+    });
+
+    test.ok('addl' in client.api.page);
+    test.ok('simplePageObject' in client.api.page.addl);
+
+    test.done();
+  },
+
   testPageObjectAssertionsLoaded : function(test) {
     var client = this.client = require('../nightwatch.js').init({
       page_objects_path: './extra/pageobjects'


### PR DESCRIPTION
Adds feature requested here: https://github.com/nightwatchjs/nightwatch/issues/819

In particular, if the directory structure is:
`root_dir/foo/bar.js` (where `root_dir` is base directory)

the respective page object would be: `page.foo.bar()`