### PR TITLE
Adds ability to pass in options on page object init

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -441,7 +441,7 @@ module.exports = new (function() {
    * @param {Object} parent
    */
   function addPageObject(name, pageFnOrObject, context, parent) {
-    parent[name] = function() {
+    parent[name] = function(instanceOptions) {
       var args = Array.prototype.slice.call(arguments);
       args.unshift(context);
 
@@ -460,7 +460,7 @@ module.exports = new (function() {
           return parent;
         };
         pageFnOrObject.name = name;
-        return new Page(pageFnOrObject, loadOntoPageObject, context, client);
+        return new Page(pageFnOrObject, loadOntoPageObject, context, client, instanceOptions);
       }
 
       return new (function() {

--- a/lib/page-object/page.js
+++ b/lib/page-object/page.js
@@ -7,7 +7,8 @@ var CommandWrapper = require('./command-wrapper.js');
  * @param {Object} options Page options defined in page object
  * @constructor
  */
-function Page(options, commandLoader, api, client) {
+function Page(options, commandLoader, api, client, instanceOptions) {
+  this.instanceOptions = instanceOptions;
   this.commandLoader = commandLoader;
   this.api = api;
   this.client = client;

--- a/lib/page-object/page.js
+++ b/lib/page-object/page.js
@@ -8,7 +8,7 @@ var CommandWrapper = require('./command-wrapper.js');
  * @constructor
  */
 function Page(options, commandLoader, api, client, instanceOptions) {
-  this.instanceOptions = instanceOptions;
+  this.instanceOptions = instanceOptions || {};
   this.commandLoader = commandLoader;
   this.api = api;
   this.client = client;

--- a/tests/src/testPageObject.js
+++ b/tests/src/testPageObject.js
@@ -16,10 +16,12 @@ module.exports = {
     test.ok('api' in page);
     test.ok('client' in page);
     test.ok('testCommand' in page);
+    test.ok('instanceOptions' in page);
 
     test.equal(typeof page.api, 'object');
     test.equal(typeof page.client, 'object');
     test.equal(typeof page.elements, 'object');
+    test.equal(typeof page.instanceOptions, 'object');
     test.equal(page.name, 'simplePageObj');
     test.equal(page.url, 'http://localhost.com');
     test.equal(page.testCommand(), page);


### PR DESCRIPTION
Currently, defining a URL as a function isn't overly useful for more dynamic test suite design.  We have a need to be able to specify IDs in URL at runtime, per test.

Example:

We have a before hook in our tests to create a new Object that returns an ID.  We then want to run our test using that new ID, for which the url is localhost:1337/Object/:id.  Right now it's not entirely straightforward to do so with Nightwatch.

This new method allows you to do this:

PageObject:

```
module.exports = {
  url: function(){
    return `http://localhost:1337/Object/${this.instanceOptions.id}`
  }
}
```

```
module.exports = {
  'Shows the object view': function(client){
    client.page.objectView({id: 123})
      .expect('body').text.to.contain('Some expected text')
  }
}
```
