### PR TITLE
Handle correctly multiline entries to stdout by prefixing all lines in parallel mode

### DIFF
--- a/lib/runner/cli/child-process.js
+++ b/lib/runner/cli/child-process.js
@@ -95,9 +95,15 @@ ChildProcess.prototype = {
     return args;
   },
 
-  writeToStdout : function(data) {
-    data = data.toString().trim();
+  writeToStdout: function(lines) {
+    var self = this;
+    var lines = lines.toString().trim().split('\n');
+    lines.forEach(function (line) {
+      self.writeLineToStdout(line);
+    })
+  },
 
+  writeLineToStdout : function(data) {
     var color_pair = this.availColors[this.index%4];
     var output = '';
 

--- a/lib/runner/cli/child-process.js
+++ b/lib/runner/cli/child-process.js
@@ -97,10 +97,10 @@ ChildProcess.prototype = {
 
   writeToStdout: function(lines) {
     var self = this;
-    var lines = lines.toString().trim().split('\n');
+    lines = lines.toString().trim().split('\n');
     lines.forEach(function (line) {
       self.writeLineToStdout(line);
-    })
+    });
   },
 
   writeLineToStdout : function(data) {


### PR DESCRIPTION
Hello,

 I discovered strange output logs from Nightwatch in parallel mode. Not all lines were prefixed with environment. It's because the data could contain multiline strings. We need to split the data to properly prefix all log entries.

<img src="https://files.gitter.im/mucsi96/nightwatch-cucumber/G2G0/Screen-Shot-2016-04-25-at-10.36.26-AM.png">
Please note this is not a standart Nightwatch output. It was created using https://github.com/mucsi96/nightwatch-cucumber plugin

Please review my change

Thanks
Igor
