### PR TITLE
update clirunner to merge config and settings

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -45,8 +45,8 @@ CliRunner.prototype = {
    */
   setup : function(settings, done) {
     this
-      .readSettings()
-      .parseTestSettings(settings, done);
+      .readSettings(settings)
+      .parseTestSettings(done);
 
     return this;
   },
@@ -54,7 +54,7 @@ CliRunner.prototype = {
   /**
    * Read the provided config json file; defaults to settings.json if one isn't provided
    */
-  readSettings : function() {
+  readSettings : function(settings) {
     // use default nightwatch.json file if we haven't received another value
 
     if (this.cli.command('config').isDefault(this.argv.config)) {
@@ -82,9 +82,18 @@ CliRunner.prototype = {
 
     this.argv.env = typeof this.argv.env == 'string' ? this.argv.env : 'default';
 
-    // reading the settings file
     try {
-      this.settings = require(this.argv.config);
+      if (typeof this.argv.config == 'string') {
+        // reading the settings file
+        this.settings = require(this.argv.config);
+      }
+
+      if (Utils.isObject(settings) && Object.prototype.toString.call(settings) !== '[object Array]') {
+        // if settings are passed in, then merge them with settings from `nightwatch.json`
+        // or if not set them as `this.settings` if no config file is provided
+        this.settings = defaults(this.settings, settings);
+      }
+
       this.replaceEnvVariables();
 
       this.manageSelenium = !this.isParallelMode() && this.settings.selenium &&
@@ -454,7 +463,7 @@ CliRunner.prototype = {
       return this;
     }
 
-    this.initTestSettings(this.argv.env, settings);
+    this.initTestSettings(this.argv.env);
 
     if (this.parallelModeWorkers()) {
       this.setupParallelMode(null, done);
@@ -479,7 +488,7 @@ CliRunner.prototype = {
    * @param {object} [settings]
    * @returns {CliRunner}
    */
-  initTestSettings : function(env, settings) {
+  initTestSettings : function(env) {
     // picking the environment specific test settings
     this.test_settings = env && this.settings.test_settings[env] || {};
 
@@ -489,7 +498,7 @@ CliRunner.prototype = {
       this.test_settings.page_objects_path = this.settings.page_objects_path || '';
 
       this.inheritFromDefaultEnv();
-      this.updateTestSettings(settings || {});
+      this.updateTestSettings();
       this.readExternalGlobals();
     }
 
@@ -530,15 +539,9 @@ CliRunner.prototype = {
    * @param {Object} [test_settings]
    * @returns {CliRunner}
    */
-  updateTestSettings : function(test_settings) {
+  updateTestSettings : function() {
     if (this.parallelMode && !this.parallelModeWorkers()) {
       return this;
-    }
-
-    if (test_settings && typeof test_settings == 'object') {
-      for (var key in test_settings) {
-        this.test_settings[key] = test_settings[key];
-      }
     }
 
     this.settings.selenium = this.settings.selenium || {};


### PR DESCRIPTION
Sometimes it is more useful to run `nightwatch` programatically rather than from the `cli`. The big blocker for this is the need for a `nightwatch.json` config file, and some mixed up code that took a `settings` object as the third argument to `nightwatch.runner` but these settings only every added test targets to `test_settings` in the `updateTestSettings` method of the `clirunner`. On top of this `test_settings` had to be present in the `nightwatch.json` otherwise an error is thrown in `parseTestSettings`. These removes a users ability to add `test_settings` and therefore `capabilities` programatically.

This PR introduces a way to use the `nightwatch.runner` with or without a `nightwatch.json` file present. 
- if a `nightwatch.json` file is present it will be `require`d
- if a `settings` object is passed as the third argument to `nightwatch.runner` then it will be "merged" with any previous settings from `nightwatch.json`, or if one is not specified using the `config` key in the first argument to `nightwatch.json`, then the `settings` will act as the entire config.

I believe this addresses some old requests for a runnable API and cleans up some passing around of the `settings` object in the `clirunner` that was seemingly unnecessary. 

https://github.com/nightwatchjs/nightwatch/issues/396
##### To Test:

``` js
import nightwatch from 'nightwatch';

nightwatch.runner({
   config: path.resolve(__dirname, 'nightwatch.json')
 }, done, settings);
```

or use it without a config file at all

``` js
nightwatch.runner({}, done, settings);
```

I ran the `grunt all` task and it seems `complexity` is breaking but I don't believe it is due to this PR.

Also, I ran the tests but it seems they are freezing locally and in CI at `testParallelExecution` which isn't happening on `master` so I'm assuming I screwed something up. Advice on that would be great 
