### PR TITLE
[Feature] Camelize command names

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -160,6 +160,7 @@ module.exports = new (function() {
         var commandName = path.basename(commandFiles[i], '.js');
         var assertionFn = require(path.join(dirPath, commandFiles[i]));
         createAssertion(commandName, assertionFn, abortOnFailure, parent);
+        createAssertion(camelize(commandName), assertionFn, abortOnFailure, parent);
       }
     }
   }
@@ -323,13 +324,13 @@ module.exports = new (function() {
       } else if (path.extname(file) === '.js') {
         var commandModule = require(fullPath);
         var name = path.basename(file, '.js');
-
         if (!commandModule) {
           throw new Error('Module ' + file + 'should have a public method or function.');
         }
 
         var m = loadCommandModule(commandModule, client.api);
         addCommand(name, m.command, m.context, parent, true);
+        addCommand(camelize(name), m.command, m.context, parent, true);
       }
     });
   }
@@ -528,6 +529,19 @@ module.exports = new (function() {
       CommandQueue.add(name, command, context, args, originalStackTrace);
       return client.api; // for chaining
     };
+  }
+
+  /**
+   * Converts underscored_name to camelizedName
+   * @param {String} underscored
+   * @returns {String}
+   */
+  function camelize(underscored) {
+    return underscored.replace(/_([a-z])/g, upcaseLetter);
+
+    function upcaseLetter(match, letter) {
+      return letter.toUpperCase();
+    }
   }
 
   /**

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -158,9 +158,14 @@ module.exports = new (function() {
     for (var i = 0, len = commandFiles.length; i < len; i++) {
       if (path.extname(commandFiles[i]) === '.js') {
         var commandName = path.basename(commandFiles[i], '.js');
+        var camelizedName = camelize(commandName);
+
         var assertionFn = require(path.join(dirPath, commandFiles[i]));
+
         createAssertion(commandName, assertionFn, abortOnFailure, parent);
-        createAssertion(camelize(commandName), assertionFn, abortOnFailure, parent);
+        if (camelizedName !== commandName) {
+          createAssertion(camelizedName, assertionFn, abortOnFailure, parent);
+        }
       }
     }
   }
@@ -323,14 +328,20 @@ module.exports = new (function() {
         loadCustomCommands(pathFolder, parent[file]);
       } else if (path.extname(file) === '.js') {
         var commandModule = require(fullPath);
+
         var name = path.basename(file, '.js');
+        var camelizedName = camelize(name);
+
         if (!commandModule) {
           throw new Error('Module ' + file + 'should have a public method or function.');
         }
 
         var m = loadCommandModule(commandModule, client.api);
         addCommand(name, m.command, m.context, parent, true);
-        addCommand(camelize(name), m.command, m.context, parent, true);
+
+        if (camelizedName !== name) {
+          addCommand(camelizedName, m.command, m.context, parent, true);
+        }
       }
     });
   }

--- a/test/extra/assertions/underscored_assertion.js
+++ b/test/extra/assertions/underscored_assertion.js
@@ -1,0 +1,25 @@
+exports.assertion = function(test, testVal) {
+  this.expected = true;
+  this.message = '';
+
+  this.pass = function(value) {
+    test.equals(testVal, value, 'Value passed to the `pass` method is incorrect.');
+    return value === this.expected;
+  };
+
+  this.value = function(result) {
+    test.deepEqual(result, {
+      value : testVal
+    }, 'Value passed to the `value` method is incorrect.');
+    return result.value;
+  };
+
+  this.command = function(callback) {
+    callback({
+      value : testVal
+    });
+
+    return this;
+  };
+
+};

--- a/test/extra/commands/underscored_command.js
+++ b/test/extra/commands/underscored_command.js
@@ -1,0 +1,5 @@
+module.exports = {
+  command : function() {
+    return this;
+  }
+};

--- a/test/src/core/testNightwatchApi.js
+++ b/test/src/core/testNightwatchApi.js
@@ -46,6 +46,9 @@ module.exports = MochaTest.add('test Nightwatch Api', {
     assert.ok('other' in client.api, 'Commands under the subfolder were not loaded properly');
     assert.ok('otherCommand' in client.api.other);
 
+    assert.ok('underscored_command' in client.api, 'Test if custom command original name was preserved');
+    assert.ok('underscoredCommand' in client.api, 'Test if command name was camelized');
+
     client.api.customCommandConstructor();
     var queue = client.queue.run();
     var command = queue.currentNode;
@@ -91,6 +94,10 @@ module.exports = MochaTest.add('test Nightwatch Api', {
 
     assert.ok('customAssertion' in client.api.assert);
     assert.ok('customAssertion' in client.api.verify);
+
+    assert.ok('underscored_assertion' in client.api.assert);
+    assert.ok('underscoredAssertion' in client.api.assert);
+
 
     client.api.assert.customAssertion(true);
     client.queue.run();


### PR DESCRIPTION
It would be great to uncouple filenames from command and assertion names.

Currently names of custom commands and assertions are forced to match the basename of file where they are defined. This leads to inconsistency in projects which use underscores for filenames and camelCase for identifiers.

This PR makes it possible to put custom command definition into commands/my_custom_command.js 
and make the command available as myCustomCommand
