### PR TITLE
fix #698 Add support for dynamic page objects

### DIFF
--- a/lib/page-object/command-wrapper.js
+++ b/lib/page-object/command-wrapper.js
@@ -11,7 +11,7 @@ module.exports = new (function() {
     if(typeof elementObj.selector !== 'function'){
       throw new Error(elementObj.name + ' was called as a dynamic page object, but with no function type selector.');
     }
-    var finalObj = Object.assign({}, elementObj);
+    var finalObj = Object.create(elementObj);
     finalObj.selector = finalObj.selector.apply(null, args);
     finalObj.parent = elementObj.parent;
     return finalObj;

--- a/lib/page-object/command-wrapper.js
+++ b/lib/page-object/command-wrapper.js
@@ -1,6 +1,23 @@
 module.exports = new (function() {
 
   /**
+   * Given selector argument, build the final selector
+   *
+   * @param {Object} elementObj The original element object
+   * @param {Array} args The arguments will be applied to the selector
+   * @returns {Object} The built element object
+   */
+  function convertSelector(elementObj, args){
+    if(typeof elementObj.selector !== 'function'){
+      throw new Error(elementObj.name + ' was called as a dynamic page object, but with no function type selector.');
+    }
+    var finalObj = Object.assign({}, elementObj);
+    finalObj.selector = finalObj.selector.apply(null, args);
+    finalObj.parent = elementObj.parent;
+    return finalObj;
+  }
+
+  /**
    * Given an element name, returns that element object
    *
    * @param {Object} parent The parent page or section
@@ -9,11 +26,19 @@ module.exports = new (function() {
    */
   function getElement(parent, elementName) {
     elementName = elementName.substring(1);
-    if (!(elementName in parent.elements)) {
-      throw new Error(elementName + ' was not found in "' + parent.name +
-        '". Available elements: ' + Object.keys(parent.elements));
+    if(elementName in parent.elements){
+      return parent.elements[elementName];
     }
-    return parent.elements[elementName];
+    if (elementName.match(/[^<]+<.*>$/)) {
+      var args = [];
+      args = elementName.substring(elementName.indexOf('<') + 1, elementName.lastIndexOf('>')).split(',');
+      elementName = elementName.substring(0, elementName.indexOf('<'));
+      if(elementName in parent.elements){
+        return convertSelector(parent.elements[elementName], args);
+      }
+    }
+    throw new Error(elementName + ' was not found in "' + parent.name +
+      '". Available elements: ' + Object.keys(parent.elements));
   }
 
   /**

--- a/lib/page-object/page-utils.js
+++ b/lib/page-object/page-utils.js
@@ -33,7 +33,7 @@ module.exports = new (function() {
 
     elements.forEach(function(els) {
       Object.keys(els).forEach(function(e) {
-        el = typeof els[e] === 'string' ? { selector: els[e] } : els[e];
+        el = (typeof els[e] === 'string' || typeof els[e] ==='function') ? { selector: els[e] } : els[e];
         el.parent = parent;
         el.name = e;
         elementObjects[el.name] = new Element(el);

--- a/test/extra/pageobjects/simplePageObj.js
+++ b/test/extra/pageobjects/simplePageObj.js
@@ -9,7 +9,12 @@ module.exports = {
   elements: {
     loginAsString: '#weblogin',
     loginCss: { selector: '#weblogin' },
-    loginXpath: { selector: '//weblogin', locateStrategy: 'xpath' }
+    loginXpath: { selector: '//weblogin', locateStrategy: 'xpath' },
+    loginDynamicNoArgsInline: function(){return '#weblogin';},
+    loginDynamicSingleArgInline: function(element){return '' + element;},
+    loginDynamicMultiArgsInline: function(arg1, arg2){return arg1 + arg2;},
+    loginDynamicArgsCss: {selector: function(element){return '' + element;}},
+    loginDynamicArgsXpath: {selector: function(element){return '' + element;}, locateStrategy:'xpath'}
   },
   sections: {
     signUp: {

--- a/test/src/page-object/testPageObjectCommands.js
+++ b/test/src/page-object/testPageObjectCommands.js
@@ -134,6 +134,93 @@ module.exports = {
       assert.equal(typeof page.section.propTest.props, 'object', 'props function should be called and set page.props equals its returned object');
       assert.ok(page.section.propTest.props.defaults.propTest, 'props function should be called with page context');
       assert.equal(page.section.propTest.props.defaults.propTest, '#propTest Value' );
+    },
+
+    testDynamicPageObjectInline: function(done){
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/0/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/0/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+      var page = this.client.api.page.simplePageObj();
+      page.click('@loginDynamicSingleArgInline<#weblogin>', function callback(result){
+        assert.equal(result.status, 0);
+      }).click('@loginDynamicMultiArgsInline<#web,login>', function callback(result){
+        assert.equal(result.status, 0);
+        done();
+      });
+
+      this.client.start();
+    },
+
+    testDynamicPageObjectNotInline: function(done){
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/0/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/0/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+      var page = this.client.api.page.simplePageObj();
+      page.click('@loginDynamicArgsCss<#weblogin>', function callback(result){
+        assert.equal(result.status, 0);
+      }).click('@loginDynamicArgsXpath<//weblogin>', function callback(result){
+        assert.equal(result.status, 0);
+        done();
+      });
+
+      this.client.start();
+    },
+
+    testDynamicPageObjectNoArgs: function(done){
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/0/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+      var page = this.client.api.page.simplePageObj();
+      page.click('@loginDynamicNoArgsInline<>', function callback(result){
+        assert.equal(result.status, 0);
+        done();
+      });
+
+      this.client.start();
+    },
+    testDynamicPageObjectErrorUsage: function(done){
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/0/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+      var page = this.client.api.page.simplePageObj();
+      this.client.start();
+      assert.throws(
+        function(){
+          page.click('@loginCss<>');
+        }, 'should throw exception when called as dynamic page object but with no function type selector.'
+      );
+      done();
     }
+    
   }
 };


### PR DESCRIPTION
For #698. I've read all the discussions in #698. In this implementation a pair of angle brackets will be used to wrap the parameters. And I think functions can be more flexible to build the dynamic page object's selector. How do you think?

usage:

```
elements:{
  obj1: function(param1, param2){
    return `#some-element-id ${param1}${param2}`;
  },
  obj2:{
    selector: function(param){
      return `#element-id ${param}`;
    }
  }
}
...
...
// use angle brackets to wrap the parameters
// and parameters separated by comma
page.click('@obj1<div,ul li:nth-child(2)>')
.click('@obj2<div.some-class>');

```
