### PR TITLE
Fixed multi string css name assertion test

### DIFF
--- a/lib/api/assertions/cssClassNotPresent.js
+++ b/lib/api/assertions/cssClassNotPresent.js
@@ -27,8 +27,7 @@ exports.assertion = function(selector, className, msg) {
   };
 
   this.pass = function(value) {
-    var classes = value.split(' ');
-    return classes.indexOf(className) === -1;
+    return value.indexOf(className) === -1;
   };
 
   this.failure = function(result) {

--- a/lib/api/assertions/cssClassPresent.js
+++ b/lib/api/assertions/cssClassPresent.js
@@ -27,8 +27,7 @@ exports.assertion = function(selector, className, msg) {
   };
 
   this.pass = function(value) {
-    var classes = value.split(' ');
-    return classes.indexOf(className) > -1;
+    return value.indexOf(className) > -1;
   };
 
   this.failure = function(result) {


### PR DESCRIPTION
Actually I think there is a problem.

Try this test page:
```
<html>
<head></head>
  <body>
    <div id="main" class="settings 1">
      <article>
        <span class="btn selected" data-href="dthr1" id="id1">Tetxt1</span> 
        <span class="btn" data-href="dthr2" id="id2">Text2</span>
      </article>
    </div>
  </body>
</html>
```

And this test scenario:

```js
module.exports = {

  after : function(browser) {
    console.log('Closing down...');
    browser
      .end();
  },

  'step one : launch browser' : function (browser) {
    browser
      .url('http://127.0.0.1/test.html')
      .waitForElementVisible('body', 1000)
  },

  'step two : check class present' : function (browser) {
    browser
      .useXpath()
      .verify.cssClassPresent('//*[@id="id2"]', 'btn', 'Checked class btn is present')
      .pause(1000)
      .verify.cssClassPresent('//*[@id="id1"]', 'btn selected', 'Checked class btn selected is present')
  }
};
```

The second test will fail because this code (cssClassPresent.js : l.30)

```
 this.pass = function(value) {
    var classes = value.split(' ');
    return classes.indexOf(className) > -1;
  };
```

I do not understand the split. It makes the test always fail if the class name contains blank separated strings ("btn selected")
Removing the split allow to pass the 'pass' function seems to fix the issue.
I am a little bit confused about the goal of this function anyway ... 

Regards,