### PR TITLE
Set "lastError" on exception

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -199,6 +199,7 @@ Nightwatch.prototype.start = function() {
       }
 
       self.results.errors++;
+      self.results.lastError = error;
       self.errors.push(error.name + ': ' + error.message + '\n' + stackTrace);
       if (self.options.output) {
         Utils.showStackTraceWithHeadline(error.name + ': ' + error.message, stackTrace, true);
@@ -330,7 +331,7 @@ Nightwatch.prototype.handleException = function(err) {
   if (this.options.output) {
     Utils.showStackTraceWithHeadline(firstLine, stack);
   }
-  
+
   if (err.name == 'AssertionError') {
     this.results.failed++;
     this.results.stackTrace = err.stack;


### PR DESCRIPTION
When the test failed due to exception (not assertion), the test result has `errors++` but not setting `lastError`.

Using `ClientManager` directly is recommended when combined with Mocha, see "Using the standard Mocha" section under  http://nightwatchjs.org/guide#using-mocha.

When running a test with [`ClientManager.start(callback)`](https://github.com/nightwatchjs/nightwatch/blob/master/lib/runner/clientmanager.js#L34) and one of the tests throw an exception, the `callback` will not receive the error. See [`clientmanger.js:43`](https://github.com/nightwatchjs/nightwatch/blob/master/lib/runner/clientmanager.js#L43).
