### PR TITLE
Fix silently swallowed exceptions

### DIFF
--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -31,6 +31,8 @@ function processListener() {
 
     if (finishCallback) {
       finishCallback(err);
+    } else {
+      throw err;
     }
   });
 }


### PR DESCRIPTION
When something goes wrong and neither a test suite nor a finishCallback are given,
the processListener in run.js swallows the error. This happens when you are using
mocha as a test runner and have a syntax error or throw an exception outside of
the test suite (e.g. `require('./some-spec-helper')` while the file does not exist)
