### PR TITLE
Page object selectors as functions

### DIFF
--- a/lib/page-object/command-wrapper.js
+++ b/lib/page-object/command-wrapper.js
@@ -23,7 +23,7 @@ module.exports = new (function() {
     var theSelector = parent.elements[fnName].selector(param);
     var newEle = makeClone(parent.elements[fnName]);
     newEle.selector = theSelector;
-    parent.elements[pageIdentifier] = newEle;
+    return newEle;
   }
 
   /**
@@ -37,7 +37,7 @@ module.exports = new (function() {
     elementName = elementName.substring(1);
 
     if (elementName.indexOf('(') > -1){
-      getSelectorFromFunction(parent, elementName);
+      return getSelectorFromFunction(parent, elementName);
     }
 
     if (!(elementName in parent.elements)) {
@@ -103,11 +103,6 @@ module.exports = new (function() {
       var prevLocateStrategy = parent.client.locateStrategy;
 
       if (isElementCommand) {
-        var command = args[0].toString();
-        if(command.indexOf('(') > -1) {
-          getSelectorFromFunction(parent, command.substring(1));
-        }
-
         var firstArg, desiredStrategy, callback;
         var elementOrSectionName = args.shift();
         var getter = (isChaiAssertion && commandName === 'section') ? getSection : getElement;

--- a/lib/page-object/command-wrapper.js
+++ b/lib/page-object/command-wrapper.js
@@ -1,4 +1,30 @@
+var makeClone = require('lodash.clone');
 module.exports = new (function() {
+
+  /**
+   * getSelectorFromFunction is used to convert a n element selector for an element
+   * that is defined as a function
+   *  EXAMPLE:
+   *  namedInputElement: function(id) { return '.nameOfParent-' + id + ' input'; },
+   *  inSelector: function(selectionVal){ return '.actionsSelect select option[value="' + selectionVal + '"]'}
+   *
+   *  In a test this would look like:
+   *   multiResults.expect.element('@namedInputElement(' + secondAssetIdGood + ')').to.be.selected;
+   *  OR
+   *   inSelector.click('@withSelectedActionComboOption(EDIT_KEYWORDS)');
+   *
+   * At present only a single String is supported as a parameter
+   * @param {Object} parent The parent page or section
+   * @param {string} pageIdentifier name that needs to be converted to a string from a function
+   */
+  function getSelectorFromFunction(parent, pageIdentifier) {
+    var fnName = pageIdentifier.substring(0, pageIdentifier.indexOf('('));
+    var param = pageIdentifier.substring(pageIdentifier.indexOf('(') + 1, pageIdentifier.indexOf(')')) || null;
+    var theSelector = parent.elements[fnName].selector(param);
+    var newEle = makeClone(parent.elements[fnName]);
+    newEle.selector = theSelector;
+    parent.elements[pageIdentifier] = newEle;
+  }
 
   /**
    * Given an element name, returns that element object
@@ -9,6 +35,11 @@ module.exports = new (function() {
    */
   function getElement(parent, elementName) {
     elementName = elementName.substring(1);
+
+    if (elementName.indexOf('(') > -1){
+      getSelectorFromFunction(parent, elementName);
+    }
+
     if (!(elementName in parent.elements)) {
       throw new Error(elementName + ' was not found in "' + parent.name +
         '". Available elements: ' + Object.keys(parent.elements));
@@ -72,6 +103,11 @@ module.exports = new (function() {
       var prevLocateStrategy = parent.client.locateStrategy;
 
       if (isElementCommand) {
+        var command = args[0].toString();
+        if(command.indexOf('(') > -1) {
+          getSelectorFromFunction(parent, command.substring(1));
+        }
+
         var firstArg, desiredStrategy, callback;
         var elementOrSectionName = args.shift();
         var getter = (isChaiAssertion && commandName === 'section') ? getSection : getElement;

--- a/lib/page-object/page-utils.js
+++ b/lib/page-object/page-utils.js
@@ -33,7 +33,12 @@ module.exports = new (function() {
 
     elements.forEach(function(els) {
       Object.keys(els).forEach(function(e) {
-        el = typeof els[e] === 'string' ? { selector: els[e] } : els[e];
+        if(typeof els[e] === 'string' || typeof els[e] === 'function' ) {
+          el = { selector: els[e] };
+        }
+        else {
+          el = els[e];
+        }
         el.parent = parent;
         el.name = e;
         elementObjects[el.name] = new Element(el);

--- a/test/extra/pageobjects/simplePageObj.js
+++ b/test/extra/pageobjects/simplePageObj.js
@@ -18,7 +18,7 @@ module.exports = {
         getStarted: { selector: '#getStarted' }
       },
       elements: {
-        help: { selector: '#helpBtn' }
+        help: { selector: function() { return '#helpBtn'; } }
       }
     },
     propTest: {

--- a/test/src/page-object/testPageObjectCommands.js
+++ b/test/src/page-object/testPageObjectCommands.js
@@ -59,7 +59,7 @@ module.exports = {
       }, this);
       var client = this.client;
       var section = client.api.page.simplePageObj().section.signUp;
-      section.click('@help', function callback(result) {
+      section.click('@help()', function callback(result) {
         assert.equal(result.status, 0);
       });
 
@@ -72,7 +72,7 @@ module.exports = {
 
     testPageObjectPluralElementRecursion : function(done) {
       var section = this.client.api.page.simplePageObj().section.signUp;
-      section.waitForElementPresent('@help', 1000, true, function callback(result) {
+      section.waitForElementPresent('@help()', 1000, true, function callback(result) {
         assert.equal(result.status, 0);
         assert.equal(result.value.length, 1);
         assert.equal(result.value[0].ELEMENT, '1');


### PR DESCRIPTION
Support for single value functions in page selectors to allow parameterization of page object selectors.
This will allow a selector for a page to be defined as a function with a single method:

multiResults: {
      selector: '.ui-lookup',
      elements: {
        withSelectedActionComboOption: function(selectionVal){ return '.actionsSelect select option[value="' + selectionVal + '"]'}
      }

This allows the test to have a parameterized string for lookup, that uses simple parentheses as delimiters:
multiResults.click('@withSelectedActionComboOption(EDIT_KEYWORDS)');
