### PR TITLE
Readme: Fix git clone install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Nightwatch works with the Selenium standalone server so the first thing you need
 
 Install Node.js and then:
 ```sh
-$ git clone git@github.com:nightwatchjs/nightwatch.git
+$ git clone https://github.com/nightwatchjs/nightwatch.git
 $ cd nightwatch
 $ npm install
 ```


### PR DESCRIPTION
When cloning from Git on Windows using the command provided:
$ git clone git@github.com:nightwatchjs/nightwatch.git

I got the following response:
<details>Cloning into 'nightwatch'...
The authenticity of host 'github.com (192.30.253.112)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,192.30.253.112' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.</details>

However if I use the default clone URL provided by GitHub:
$ git clone https://github.com/nightwatchjs/nightwatch.git

It works as expected:
<details>$ git clone https://github.com/nightwatchjs/nightwatch.git
Cloning into 'nightwatch'...
remote: Counting objects: 7290, done.
remote: Total 7290 (delta 0), reused 0 (delta 0), pack-reused 7290
Receiving objects: 100% (7290/7290), 45.18 MiB | 6.16 MiB/s, done.
Resolving deltas: 100% (4887/4887), done.
Checking connectivity... done.</details>