### PR TITLE
Fixed #1069 - support for groups with multiple src_folders

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -231,16 +231,47 @@ CliRunner.prototype = {
       if (Array.isArray(this.argv._source) && (this.argv._source.length > 0)) {
         testsource = this.argv._source;
       } else if (this.argv.group) {
+
         // add support for multiple groups
         if (typeof this.argv.group == 'string') {
           this.argv.group = this.argv.group.split(',');
         }
 
-        if (this.argv.group.length == 1) {
-          testsource = this.findGroupPath(this.argv.group[0]);
+        var groupTestsource = this.findGroupPathMultiple(this.argv.group);
+
+        // for a single src folder, we match the group paths created,
+        // but for multiple src folders, we are less strict on enforcing
+        // the existence of each group in each src folder.  If a group
+        // does not exist in the multiple src folder case, it is removed
+        // from the test path list.
+
+        if (this.settings.src_folders.length === 1) {
+
+          // any incorrect path here will result in a run error
+
+          testsource = groupTestsource;
+
         } else {
-          testsource = this.findGroupPathMultiple(this.argv.group);
+
+          // only when all groups fail to match will there be a run error
+
+          testsource = groupTestsource.filter(fs.existsSync);
+
+          // to help with debugging when using groups whose paths may
+          // get lost when the paths don't exist, we can add some
+          // messaging in verbose mode
+
+          if (this.argv.verbose) {
+            var ignoredSource = groupTestsource.filter(function(path) {
+              return testsource.indexOf(path) === -1;
+            });
+
+            if (ignoredSource.length) {
+              ErrorHandler.logWarning('The following group paths were not found and will be excluded from the run:\n - ' + ignoredSource.join('\n - '));
+            }
+          }
         }
+
       } else {
         testsource = this.settings.src_folders;
       }
@@ -250,38 +281,49 @@ CliRunner.prototype = {
   },
 
   /**
-   * Attempting to prepend the base source folder to the group name;
-   * this only works if only one source folder is defined in the src_folders property
+   * Gets test paths from each of the src folders for a single group.
    *
    * @param {string} groupName
    * @return {Array}
    */
   findGroupPath : function(groupName) {
-    if (this.settings.src_folders.length !== 1) {
-      return [groupName];
-    }
-    var srcFolder = this.settings.src_folders[0];
-    var fullPath;
-    var fullSrcFolder = path.resolve(srcFolder);
     var fullGroupPath = path.resolve(groupName);
 
-    if (fullGroupPath.indexOf(fullSrcFolder) === 0) {
-      fullPath = groupName;
-    } else {
-      fullPath = path.join(srcFolder, groupName);
-    }
+    // for each src folder, append the group to the path
+    // to resolve the full test path
 
-    return [fullPath];
+    return this.settings.src_folders.map(function(srcFolder) {
+
+      // check first to see if the group already includes the
+      // src path. If so, use just the group as the path and
+      // skip attempting to include the src path
+
+      var fullSrcFolder = path.resolve(srcFolder);
+      if (fullGroupPath.indexOf(fullSrcFolder) === 0) {
+        return groupName;
+      }
+
+      return path.join(srcFolder, groupName);
+    });
   },
 
   /**
+   * Gets test paths for tests from any number of groups.
    *
    * @param {Array} groups
    */
   findGroupPathMultiple : function(groups) {
-    return groups.map(function(groupName) {
-      return this.findGroupPath(groupName)[0];
+    var paths = [];
+
+    groups.forEach(function(groupName) {
+
+      // findGroupPath will return an array of paths
+
+      paths = paths.concat(this.findGroupPath(groupName));
+
     }.bind(this));
+
+    return paths;
   },
 
   /**

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -61,16 +61,16 @@ CliRunner.prototype = {
       var defaultValue = this.cli.command('config').defaults();
       var localJsValue = path.resolve(SETTINGS_JS_FILE);
 
-      if (fs.existsSync(SETTINGS_JS_FILE)) {
+      if (fileExistsSync(SETTINGS_JS_FILE)) {
         this.argv.config = localJsValue;
-      } else if (fs.existsSync(defaultValue)) {
+      } else if (fileExistsSync(defaultValue)) {
         this.argv.config = path.join(path.resolve('./'), this.argv.config);
-      } else if (fs.existsSync(SETTINGS_DEPRECTED_VAL)) {
+      } else if (fileExistsSync(SETTINGS_DEPRECTED_VAL)) {
         this.argv.config = path.join(path.resolve('./'), SETTINGS_DEPRECTED_VAL);
       } else {
         var binFolder = path.resolve(__dirname + '/../../../bin');
         var defaultFile = path.join(binFolder, this.argv.config);
-        if (fs.existsSync(defaultFile)) {
+        if (fileExistsSync(defaultFile)) {
           this.argv.config = defaultFile;
         } else {
           this.argv.config = path.join(binFolder, SETTINGS_DEPRECTED_VAL);
@@ -255,7 +255,7 @@ CliRunner.prototype = {
 
           // only when all groups fail to match will there be a run error
 
-          testsource = groupTestsource.filter(fs.existsSync);
+          testsource = groupTestsource.filter(fileExistsSync);
 
           // to help with debugging when using groups whose paths may
           // get lost when the paths don't exist, we can add some
@@ -987,5 +987,15 @@ CliRunner.prototype = {
     return running;
   }
 };
+
+// util to replace deprecated fs.existsSync
+function fileExistsSync (path) {
+  try {
+    fs.statSync(path);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
 
 module.exports = CliRunner;

--- a/test/src/runner/cli/testCliRunner.js
+++ b/test/src/runner/cli/testCliRunner.js
@@ -6,11 +6,11 @@ module.exports = {
   'Test CLI Runner' : {
     testInitDefaults : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
+        statSync : function(module) {
           if (module == './settings.json') {
-            return false;
+            throw new Error('Does not exist');
           }
-          return true;
+          return {};
         }
       });
 
@@ -42,12 +42,11 @@ module.exports = {
 
     testSetOutputFolder : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
+        statSync : function(module) {
           if (module == './settings.json' || module == './nightwatch.conf.js') {
-            return false;
+            throw new Error('Does not exist');
           }
-
-          return true;
+          return {};
         }
       });
 
@@ -69,11 +68,11 @@ module.exports = {
       });
 
       mockery.registerMock('fs', {
-        existsSync : function(module) {
+        statSync : function(module) {
           if (module == './settings.json') {
-            return true;
+            return {};
           }
-          return false;
+          throw new Error('Does not exist');
         }
       });
 
@@ -97,11 +96,11 @@ module.exports = {
 
     testCustomSettingsFileAndEnvironment : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
+        statSync : function(module) {
           if (module == './custom.json') {
-            return true;
+            return {};
           }
-          return false;
+          throw new Error('Does not exist');
         }
       });
 
@@ -128,12 +127,6 @@ module.exports = {
     testGetTestSourceSingle : function() {
       var statSyncCalled = false;
       mockery.registerMock('fs', {
-        existsSync : function(module) {
-          if (module == './custom.json') {
-            return true;
-          }
-          return false;
-        },
         statSync : function(file) {
           if (file == 'demoTest') {
             statSyncCalled = true;
@@ -143,7 +136,10 @@ module.exports = {
               }
             };
           }
-          throw new Error('Start error.');
+          if (file == 'demoTest.js' || file == './custom.js') {
+            return {};
+          }
+          throw new Error('Does not exist');
         }
       });
 
@@ -166,12 +162,6 @@ module.exports = {
       var statSyncCalled = false;
 
       mockery.registerMock('fs', {
-        existsSync : function(module) {
-          if (module == './custom.json') {
-            return true;
-          }
-          return false;
-        },
         statSync : function(file) {
           if (file == ABSOLUTE_PATH) {
             statSyncCalled = true;
@@ -181,7 +171,10 @@ module.exports = {
               }
             };
           }
-          throw new Error('Start error.');
+          if (file == ABSOLUTE_SRC_PATH || file == './custom.json') {
+            return {};
+          }
+          throw new Error('Does not exist');
         }
       });
 
@@ -204,12 +197,6 @@ module.exports = {
       var statSyncCalled = false;
 
       mockery.registerMock('fs', {
-        existsSync : function(module) {
-          if (module == './custom.json') {
-            return true;
-          }
-          return false;
-        },
         statSync : function(file) {
           if (file == RELATIVE_PATH) {
             statSyncCalled = true;
@@ -219,7 +206,10 @@ module.exports = {
               }
             };
           }
-          throw new Error('Start error.');
+          if (file == TEST_SRC_PATH || file == './custom.json') {
+            return {};
+          }
+          throw new Error('Does not exist');
         }
       });
 
@@ -237,20 +227,15 @@ module.exports = {
 
     testGetTestSourceAsSecondArgument : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
-          if (module == './custom.json') {
-            return true;
-          }
-          return false;
-        },
         statSync : function(module) {
-          if (module == 'test.js') {
+          if (module == 'test.js' || module == './custom.json') {
             return {
               isFile : function() {
                 return true;
               }
             }
           }
+          throw new Error('Does not exist');
         }
       });
 
@@ -302,21 +287,15 @@ module.exports = {
 
     testRunTestsWithTestcaseOption : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
-          if (module == './custom.json') {
-            return true;
-          }
-          return false;
-        },
         statSync : function(file) {
-          if (file == 'demoTest') {
+          if (file == 'demoTest' || file == './custom.json') {
             return {
               isFile : function() {
                 return true;
               }
             };
           }
-          throw new Error('Start error.');
+          throw new Error('Does not exist');
         }
       });
 
@@ -334,20 +313,15 @@ module.exports = {
 
     testRunTestsWithTestcaseOptionAndSingleTestSource : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
-          if (module == './custom.json') {
-            return true;
-          }
-          return false;
-        },
         statSync : function(file) {
-          if (file == 'demoTest.js') {
+          if (file == 'demoTest.js' || file == './custom.json') {
             return {
               isFile : function() {
                 return true;
               }
             };
           }
+          throw new Error('Does not exist');
         }
       });
 
@@ -365,17 +339,11 @@ module.exports = {
 
     testRunTestsWithTestcaseOptionAndWithoutTest : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
-          if (module == './custom.json') {
-            return true;
-          }
-          return false;
-        },
         statSync : function(file) {
-          if (file == 'demoTest.js') {
-            return true;
+          if (file == 'demoTest.js' || file == './custom.json') {
+            return {};
           }
-          throw new Error('Start error.');
+          throw new Error('Does not exist');
         }
       });
 
@@ -392,14 +360,14 @@ module.exports = {
 
     testGetTestSourceGroup : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
+        statSync : function(module) {
           switch (module) {
           case './custom.json':
           case './multi_test_paths.json':
           case 'tests/demoGroup':
-            return true;
+            return {};
           }
-          return false;
+          throw new Error('Does not exist');
         }
       });
 
@@ -451,7 +419,7 @@ module.exports = {
 
     testGetTestSourceMultipleGroups : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
+        statSync : function(module) {
           switch (module) {
           case './custom.json':
           case './multi_test_paths.json':
@@ -461,9 +429,9 @@ module.exports = {
           case 'tests1/demoGroup2':
           // no tests2/demoGroup1
           case 'tests2/demoGroup2':
-            return true;
+            return {};
           }
-          return false;
+          throw new Error('Does not exist');
         }
       });
 
@@ -498,11 +466,11 @@ module.exports = {
 
     testParseTestSettingsInvalid : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
+        statSync : function(module) {
           if (module == './empty.json') {
-            return true;
+            return {};
           }
-          return false;
+          throw new Error('Does not exist');
         }
       });
 
@@ -517,8 +485,11 @@ module.exports = {
 
     testParseTestSettingsIncorrect : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
-          return module == './incorrect.json';
+        statSync : function(module) {
+          if (module == './incorrect.json') {
+            return {};
+          }
+          throw new Error('Does not exist');
         }
       });
 
@@ -534,11 +505,11 @@ module.exports = {
 
     testReadExternalGlobals : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
+        statSync : function(module) {
           if (module == './custom.json' || module == './globals.json') {
-            return true;
+            return {};
           }
-          return false;
+          throw new Error('Does not exist');
         }
       });
 
@@ -615,11 +586,11 @@ module.exports = {
 
     testStartSeleniumDisabledPerEnvironment : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
+        statSync : function(module) {
           if (module == './sauce.json') {
-            return true;
+            return {};
           }
-          return false;
+          throw new Error('Does not exist');
         }
       });
       var CliRunner = common.require('runner/cli/clirunner.js');
@@ -635,11 +606,11 @@ module.exports = {
 
     testStartSeleniumEnvironmentOverride : function() {
       mockery.registerMock('fs', {
-        existsSync : function(module) {
+        statSync : function(module) {
           if (module == './selenium_override.json') {
-            return true;
+            return {};
           }
-          return false;
+          throw new Error('Does not exist');
         }
       });
       var CliRunner = common.require('runner/cli/clirunner.js');

--- a/test/src/runner/testRunner.js
+++ b/test/src/runner/testRunner.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var fs = require('fs');
 var assert = require('assert');
 var common = require('../../common.js');
 var CommandGlobals = require('../../lib/globals/commands.js');
@@ -104,15 +105,14 @@ module.exports = {
           { name: '', module: 'tags/sampleTags', group : 'tags' }
         ]);
 
-        var fs = require('fs');
         fs.readdir(src_folders[0], function(err, list) {
           try {
             assert.deepEqual(list, ['simple', 'tags'], 'The subfolders have been created.');
             var simpleReportFile = 'output/simple/FIREFOX_TEST_TEST_sample.xml';
             var tagsReportFile = 'output/tags/FIREFOX_TEST_TEST_sampleTags.xml';
 
-            assert.ok(fs.existsSync(simpleReportFile), 'The simple report file was not created.');
-            assert.ok(fs.existsSync(tagsReportFile), 'The tags report file was not created.');
+            assert.ok(fileExistsSync(simpleReportFile), 'The simple report file was not created.');
+            assert.ok(fileExistsSync(tagsReportFile), 'The tags report file was not created.');
             done();
           } catch (err) {
             done(err);
@@ -142,10 +142,9 @@ module.exports = {
       }, function(err, results) {
 
         assert.strictEqual(err, null);
-        var fs = require('fs');
         var sampleReportFile = path.join(__dirname, '../../../output/FIREFOX_TEST_TEST_sample.xml');
 
-        assert.ok(fs.existsSync(sampleReportFile), 'The sample file report file was not created.');
+        assert.ok(fileExistsSync(sampleReportFile), 'The sample file report file was not created.');
         fs.readFile(sampleReportFile, function(err, data) {
           if (err) {
             done(err);
@@ -179,10 +178,9 @@ module.exports = {
       }, function(err, results) {
 
         assert.strictEqual(err, null);
-        var fs = require('fs');
         var sampleReportFile = path.join(__dirname, '../../../output/unittest-failure.xml');
 
-        assert.ok(fs.existsSync(sampleReportFile), 'The sample file report file was not created.');
+        assert.ok(fileExistsSync(sampleReportFile), 'The sample file report file was not created.');
         fs.readFile(sampleReportFile, function(err, data) {
           if (err) {
             done(err);
@@ -257,3 +255,14 @@ module.exports = {
     }
   }
 };
+
+
+// util to replace deprecated fs.existsSync
+function fileExistsSync (path) {
+  try {
+    fs.statSync(path);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
Adds support for groups when you have multiple src_folders specified.

Not all src_folders paths need to include the group(s) specified unless you only have only one src_folders path (you should know whether or not that single path has your group). And if you specify a group that doesn't exist for all src_folders listed, causing no test paths to resolve, you'll get the standard no test path error as per usual.

Any groups not found when using multiple src_folders path will be listed when using `--verbose`.