### PR TITLE
fix edge isLogAvailable

### DIFF
--- a/lib/api/client-commands.js
+++ b/lib/api/client-commands.js
@@ -483,7 +483,7 @@ module.exports = function(client) {
      * @api commands
      * @see getLogTypes
      */
-    isLogAvailable: function (typeString, callback) {
+    isLogAvailable: function(typeString, callback) {
       var self = this;
       if (typeof typeString !== 'string') {
         if (typeof typeString === 'function') {
@@ -492,10 +492,16 @@ module.exports = function(client) {
         typeString = 'browser';
       }
       return this.getLogTypes(function (types) {
-        var isAvailable = types.indexOf(typeString) >= 0;
-        if (callback) {
-          callback.call(self, isAvailable);
-        }
+        try {
+          var isAvailable = types.indexOf(typeString) >= 0;
+          if (callback) {
+            callback.call(self, isAvailable);
+          }
+        } catch (exception) {
+          if (callback) {
+            callback.call(self, false);
+          }
+        }  
       });
     }
 

--- a/lib/api/client-commands.js
+++ b/lib/api/client-commands.js
@@ -492,16 +492,16 @@ module.exports = function(client) {
         typeString = 'browser';
       }
       return this.getLogTypes(function (types) {
-        try {
-          var isAvailable = types.indexOf(typeString) >= 0;
-          if (callback) {
-            callback.call(self, isAvailable);
-          }
+        var isAvailable;
+        try{
+          isAvailable = Array.isArray(types) && types.indexOf(typeString) >= 0;
         } catch (exception) {
-          if (callback) {
-            callback.call(self, false);
-          }
-        }  
+          isAvailable = false;
+        }
+
+        if (callback) {
+          callback.call(self, isAvailable);
+        } 
       });
     }
 

--- a/test/src/api/commands/testIsLogAvailable.js
+++ b/test/src/api/commands/testIsLogAvailable.js
@@ -4,6 +4,12 @@ var Nightwatch = require('../../../lib/nightwatch.js');
 var MochaTest = require('../../../lib/mochatest.js');
 
 module.exports = MochaTest.add('isLogAvailable', {
+  afterEach : function() {
+    MockServer.removeMock({
+      url : '/wd/hub/session/1352110219202/log/types',
+      method: 'GET'
+    });
+  },
 
   'client.isLogAvailable()' : function(done) {
     var client = Nightwatch.api();
@@ -45,6 +51,10 @@ module.exports = MochaTest.add('isLogAvailable', {
     });
 
     client.isLogAvailable( 'unknown', function callback(result) {
+      assert.equal(typeof result === 'boolean', true);
+      assert.equal(result, false);
+    })
+    .isLogAvailable( 'browser', function callback(result) {
       assert.equal(typeof result === 'boolean', true);
       assert.equal(result, false);
       done();

--- a/test/src/api/commands/testIsLogAvailable.js
+++ b/test/src/api/commands/testIsLogAvailable.js
@@ -29,5 +29,27 @@ module.exports = MochaTest.add('isLogAvailable', {
       });
 
     Nightwatch.start();
+  },
+
+  'client.isLogAvailable() failure' : function(done) {
+    var client = Nightwatch.api();
+
+     MockServer.addMock({
+      url : '/wd/hub/session/1352110219202/log/types',
+      method:'GET',
+      response : JSON.stringify({
+        sessionId: '1352110219202',
+        status:0,
+        value : { 'message': 'Session not started or terminated' }
+      })
+    });
+
+    client.isLogAvailable( 'unknown', function callback(result) {
+      assert.equal(typeof result === 'boolean', true);
+      assert.equal(result, false);
+      done();
+    });
+
+    Nightwatch.start();
   }
 });


### PR DESCRIPTION
If an assertion fails and you call `isLogAvailable()` in the `after` hook, you get a `TypeError`. For example:
```javascript
after : function(browser) {
  browser.isLogAvailable('browser', isAvailable => {
    // Code to handle log ouput...
  });
}
```
returns this error:
```bash
  ✖ TypeError: types.indexOf is not a function
```

This is due to the fact that `getLogTypes()` returns `{ message: 'Session not started or terminated'}` because the session was terminated when the assertion failed. This commit fixes the error and returns `false` instead of a `TypeError`.