### PR TITLE
Fixed #1034 - page urls evaluated at navigate, not init

### DIFF
--- a/lib/page-object/page.js
+++ b/lib/page-object/page.js
@@ -12,7 +12,7 @@ function Page(options, commandLoader, api, client) {
   this.api = api;
   this.client = client;
   this.name = options.name;
-  this.url = this.getUrl(options.url);
+  this.url = options.url;
 
   PageUtils
     .createProps(this, options.props || {})
@@ -53,7 +53,7 @@ Page.prototype = {
    * @returns {*}
    */
   navigate: function(url, callback) {
-    var goToUrl = url || this.url;
+    var goToUrl = this.getUrl(url || this.url);
     if (goToUrl === null) {
       throw new Error('Invalid URL: You must either add a url property to "' +
         this.name + '" or provide a url as an argument');


### PR DESCRIPTION
Changing when page object url values get evaluated for navigate(), now happening when navigate() is called to allow it to be able to pick up any function-based url changes occurring during the test run.