### PR TITLE
Fixed #1091 - now catching not found --test error

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -386,7 +386,18 @@ CliRunner.prototype = {
   runner : function(fn) {
     var testRunner = this.settings.test_runner || 'default';
     var testRunnerType = testRunner.type ? testRunner.type : testRunner;
-    var source = this.getTestSource();
+
+    // getTestSource() will throw on an error, so we need
+    // to wrap and pass along any error that does occur
+    // to the callback fn
+
+    var source;
+    try {
+      source = this.getTestSource();
+    } catch (err) {
+      fn(err, []);
+      return;
+    }
 
     switch (testRunnerType) {
       case 'default':

--- a/test/src/runner/cli/testCliRunner.js
+++ b/test/src/runner/cli/testCliRunner.js
@@ -253,6 +253,37 @@ module.exports = {
       assert.deepEqual(testSource, ['test.js']);
     },
 
+    testRunTestsWithTestSourceSingleInvalid : function(done) {
+      mockery.registerMock('fs', {
+        existsSync : function(module) {
+          if (module == './custom.json') {
+            return true;
+          }
+          return false;
+        }
+      });
+
+      var invalidTestFile = 'doesnotexist.js';
+      var errorMessage = 'There was a problem reading the test file: ' + invalidTestFile;
+
+      mockery.registerMock('./errorhandler.js', {
+        handle : function(err) {
+          assert.equal(err.message, errorMessage);
+          done();
+        }
+      });
+
+      var CliRunner = common.require('runner/cli/clirunner.js');
+      var runner = new CliRunner({
+        config : './custom.json',
+        env : 'default',
+        test: invalidTestFile
+      }).init();
+
+      runner.manageSelenium = true;
+      runner.runTests();
+    },
+
     testRunTestsWithTestcaseOption : function() {
       mockery.registerMock('fs', {
         existsSync : function(module) {


### PR DESCRIPTION
Figured out where the cannot find --test file error was getting lost.  The error needed to be handled and sent off to the callback function that is used to catch the other errors being reported (like a missing src_folders setting). The other errors get handled in the runner which handles that callback action internally there. The --test path was throwing outside of the runner so that's now getting handled and passed to the callback on error.