### PR TITLE
Fixed #1046 - adds callback to page object navigate()

### DIFF
--- a/lib/page-object/page.js
+++ b/lib/page-object/page.js
@@ -51,13 +51,13 @@ Page.prototype = {
    * @param {Object} [url=this.url] Url to navigate to.
    * @returns {*}
    */
-  navigate: function(url) {
+  navigate: function(url, callback) {
     var goToUrl = url || this.url;
     if (goToUrl === null) {
       throw new Error('Invalid URL: You must either add a url property to "' +
         this.name + '" or provide a url as an argument');
     }
-    this.api.url(goToUrl);
+    this.api.url(goToUrl, callback);
     return this;
   }
 };

--- a/lib/page-object/page.js
+++ b/lib/page-object/page.js
@@ -49,6 +49,7 @@ Page.prototype = {
    *
    * @method navigate
    * @param {Object} [url=this.url] Url to navigate to.
+   * @param {function} [callback] Optional callback function to be called when the command finishes.
    * @returns {*}
    */
   navigate: function(url, callback) {


### PR DESCRIPTION
Adds a new callback parameter to Page.navigate() which gets forwarded to the internal call made to api.url()