### PR TITLE
[Do not merge] Fixes #884 - experimenting with full command API in page objects for chaining

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -454,6 +454,7 @@ module.exports = new (function() {
       if (useEnhancedModel(pageFnOrObject)) {
         var loadOntoPageObject = function(parent) {
           if (client.options.start_session) {
+            loadProtocolActions(parent);
             loadAllCommands(parent);
             loadExpectAssertions(parent);
             // Alias

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -183,9 +183,11 @@ module.exports = new (function() {
    * Loads all the composite commands defined by nightwatch
    */
   function loadAllCommands(parent) {
+    loadProtocolActions(parent);
     loadElementCommands(parent);
     loadClientCommands(parent);
     loadCommandFiles(client.api, parent, true);
+    loadExpectAssertions();
   }
 
   /**
@@ -454,9 +456,7 @@ module.exports = new (function() {
       if (useEnhancedModel(pageFnOrObject)) {
         var loadOntoPageObject = function(parent) {
           if (client.options.start_session) {
-            loadProtocolActions(parent);
             loadAllCommands(parent);
-            loadExpectAssertions(parent);
             // Alias
             parent.expect.section = parent.expect.element;
           }
@@ -549,10 +549,8 @@ module.exports = new (function() {
    */
   this.load = function() {
     if (client.options.start_session) {
-      loadProtocolActions();
       loadAllCommands();
       loadPageObjects();
-      loadExpectAssertions();
     }
     loadAssertions();
     loadCustomCommands();

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -187,7 +187,7 @@ module.exports = new (function() {
     loadElementCommands(parent);
     loadClientCommands(parent);
     loadCommandFiles(client.api, parent, true);
-    loadExpectAssertions();
+    loadExpectAssertions(parent);
   }
 
   /**

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -454,8 +454,7 @@ module.exports = new (function() {
       if (useEnhancedModel(pageFnOrObject)) {
         var loadOntoPageObject = function(parent) {
           if (client.options.start_session) {
-            loadElementCommands(parent);
-            loadCommandFiles(client.api, parent, false);
+            loadAllCommands(parent);
             loadExpectAssertions(parent);
             // Alias
             parent.expect.section = parent.expect.element;

--- a/lib/page-object/command-wrapper.js
+++ b/lib/page-object/command-wrapper.js
@@ -9,11 +9,12 @@ module.exports = new (function() {
    */
   function getElement(parent, elementName) {
     elementName = elementName.substring(1);
-    if (!(elementName in parent.elements)) {
+    var elements = parent.settings.elements;
+    if (!(elementName in elements)) {
       throw new Error(elementName + ' was not found in "' + parent.name +
-        '". Available elements: ' + Object.keys(parent.elements));
+        '". Available elements: ' + Object.keys(elements));
     }
-    return parent.elements[elementName];
+    return elements[elementName];
   }
 
   /**
@@ -59,20 +60,30 @@ module.exports = new (function() {
    *  For elements nested under sections, it sets 'recursion' as the locate strategy and passes as its first argument to the command an array of its ancestors + self
    *  If the command or assertion is not on an element, it calls it with the untouched passed arguments
    *
-   * @param {Object} parent The parent page or section
+   * @param {Object} target The object being assigned the command
    * @param {function} commandFn The actual command function
    * @param {string} commandName The name of the command ("click", "containsText", etc)
+   * @param {Object} parent The parent page or section
    * @param {Boolean} [isChaiAssertion]
    * @returns {parent}
    */
-  function makeWrappedCommand(parent, commandFn, commandName, isChaiAssertion) {
-    return function() {
+  function addWrappedCommand(target, commandFn, commandName, parent, isChaiAssertion) {
+    
+    // do not overwrite a property with a wrapped command
+    // (other commands (functions) are ok to overwrite)
+
+    if (target.hasOwnProperty(commandName) && typeof target[commandName] !== 'function') {
+      // TODO: issue a warning?
+      return;
+    }
+
+    target[commandName] = function() {
       var args = Array.prototype.slice.call(arguments);
       var isElementCommand = typeof args[0] !== 'undefined' && args[0].toString().indexOf('@') === 0;
       var prevLocateStrategy = parent.client.locateStrategy;
 
       if (isElementCommand) {
-        var firstArg, desiredStrategy, callback;
+        var firstArg, desiredStrategy;
         var elementOrSectionName = args.shift();
         var getter = (isChaiAssertion && commandName === 'section') ? getSection : getElement;
         var elementOrSection = getter(parent, elementOrSectionName);
@@ -91,7 +102,7 @@ module.exports = new (function() {
       }
 
       if (typeof args[args.length-1] === 'function') {
-        callback = args.pop();
+        var callback = args.pop();
         args.push(function() {
           if (isElementCommand) {
             parent.client.locateStrategy = prevLocateStrategy;
@@ -144,16 +155,12 @@ module.exports = new (function() {
         var assertions = commands[commandName];
 
         Object.keys(assertions).forEach(function(assertionName) {
-          target[commandName][assertionName] = addCommand(target[commandName], assertions[assertionName], assertionName, parent, isChaiAssertion);
+          addWrappedCommand(target[commandName], assertions[assertionName], assertionName, parent, isChaiAssertion);
         });
       } else {
-        target[commandName] = addCommand(target, commands[commandName], commandName, parent, false);
+        addWrappedCommand(target, commands[commandName], commandName, parent, false);
       }
     });
-  }
-
-  function addCommand(target, commandFn, commandName, parent, isChaiAssertion) {
-    return makeWrappedCommand(parent, commandFn, commandName, isChaiAssertion);
   }
 
   function isValidAssertion(commandName) {

--- a/lib/page-object/command-wrapper.js
+++ b/lib/page-object/command-wrapper.js
@@ -73,13 +73,27 @@ module.exports = new (function() {
     // (other commands (functions) are ok to overwrite)
 
     if (target.hasOwnProperty(commandName) && typeof target[commandName] !== 'function') {
+
       // TODO: issue a warning?
+
+      // DEBUG:
+      console.warn('[DEBUG] Command "' + commandName + '" not added to ' + target.name + ' because it would overwrite an existing property.');
+
       return;
     }
 
     target[commandName] = function() {
       var args = Array.prototype.slice.call(arguments);
-      var isElementCommand = typeof args[0] !== 'undefined' && args[0].toString().indexOf('@') === 0;
+
+      // TODO: Do we only apply this to commands following this 
+      // selector pattern (selector as first param)?  Should the
+      // selenium protocol commands support elements? Examples:
+      // (locStrat, selector, ...)
+      // (id, locStrat, selector, ...)
+      // Arbitrarily find any @-prefixed string in a command?
+
+      var isElementCommand = String(args[0]).indexOf('@') === 0;
+      
       var prevLocateStrategy = parent.client.locateStrategy;
 
       if (isElementCommand) {

--- a/lib/page-object/command-wrapper.js
+++ b/lib/page-object/command-wrapper.js
@@ -88,16 +88,16 @@ module.exports = new (function() {
 
         setLocateStrategy(parent.client, desiredStrategy);
         args.unshift(firstArg);
+      }
 
-        if (typeof args[args.length-1] === 'function') {
-          callback = args.pop();
-          args.push(function() {
+      if (typeof args[args.length-1] === 'function') {
+        callback = args.pop();
+        args.push(function() {
+          if (isElementCommand) {
             parent.client.locateStrategy = prevLocateStrategy;
-            if (callback) {
-              callback.apply(parent.client, arguments);
-            }
-          });
-        }
+          }
+          return callback.apply(parent, arguments);
+        });
       }
 
       var c = commandFn.apply(parent.client, args);
@@ -153,13 +153,6 @@ module.exports = new (function() {
   }
 
   function addCommand(target, commandFn, commandName, parent, isChaiAssertion) {
-    if (target[commandName]) {
-      parent.client.results.errors++;
-      var error = new Error('The command "' + commandName + '" is already defined!');
-      parent.client.errors.push(error.stack);
-      throw error;
-    }
-
     return makeWrappedCommand(parent, commandFn, commandName, isChaiAssertion);
   }
 

--- a/lib/page-object/page-utils.js
+++ b/lib/page-object/page-utils.js
@@ -40,7 +40,7 @@ module.exports = new (function() {
       });
     });
 
-    parent.elements = elementObjects;
+    parent.settings.elements = elementObjects;
 
     return this;
   };
@@ -78,9 +78,20 @@ module.exports = new (function() {
    * @returns {null}
    */
   this.addCommands = function(parent, commands) {
-    commands.forEach(function(m) {
-      Object.keys(m).forEach(function(k) {
-        parent[k] = m[k];
+    commands.forEach(function(commandGroup) {
+      Object.keys(commandGroup).forEach(function(commandName) {
+
+        // do not overwrite a property with a wrapped command
+        // (other commands (functions) are ok to overwrite)
+
+        if (!parent.hasOwnProperty(commandName) || typeof parent[commandName] === 'function') {
+          parent[commandName] = commandGroup[commandName];
+        }
+
+        // TODO: issue a warning (or fatal error)? 2 cases:
+        //       - overwriting an existing command function (not fatal)
+        //       - skipping adding the command because it would override a property
+
       });
     });
 

--- a/lib/page-object/page-utils.js
+++ b/lib/page-object/page-utils.js
@@ -56,14 +56,14 @@ module.exports = new (function() {
   this.createSections = function(parent, sections, commandLoader) {
     var Section = require('./section.js');
     var sectionObjects = {};
-    var sec;
 
-    Object.keys(sections).forEach(function(s) {
-      sec = sections[s];
-      sec.parent = parent;
-      sec.name = s;
-      sec.commandLoader = commandLoader;
-      sectionObjects[sec.name] = new Section(sec);
+    Object.keys(sections).forEach(function(sectionName) {
+      var options = {
+        parent: parent,
+        name: sectionName,
+        commandLoader: commandLoader
+      };
+      sectionObjects[sectionName] = new Section(sections[sectionName], options);
     });
 
     parent.section = sectionObjects;

--- a/lib/page-object/page-utils.js
+++ b/lib/page-object/page-utils.js
@@ -85,13 +85,24 @@ module.exports = new (function() {
         // do not overwrite a property with a wrapped command
         // (other commands (functions) are ok to overwrite)
 
-        if (!parent.hasOwnProperty(commandName) || typeof parent[commandName] === 'function') {
-          parent[commandName] = commandGroup[commandName];
-        }
-
         // TODO: issue a warning (or fatal error)? 2 cases:
         //       - overwriting an existing command function (not fatal)
         //       - skipping adding the command because it would override a property
+
+        if (!parent.hasOwnProperty(commandName) || typeof parent[commandName] === 'function') {
+
+          // DEBUG:
+          if (typeof parent[commandName] === 'function') {
+            console.warn('[DEBUG] Page command "' + commandName + '" overwriting original command of the same name.');
+          }
+
+          parent[commandName] = commandGroup[commandName];
+
+        } else {
+
+          // DEBUG:
+          console.warn('[DEBUG] Page command "' + commandName + '" not added to ' + parent.name + ' because it would overwrite an existing property.');
+        }
 
       });
     });

--- a/lib/page-object/page-utils.js
+++ b/lib/page-object/page-utils.js
@@ -53,14 +53,16 @@ module.exports = new (function() {
    * @param {Array} sections Array of objects to become section objects
    * @returns {null}
    */
-  this.createSections = function(parent, sections, commandLoader) {
+  this.createSections = function(parent, sections, commandLoader, parentCommands) {
     var Section = require('./section.js');
     var sectionObjects = {};
+    var self = this;
 
     Object.keys(sections).forEach(function(sectionName) {
       var options = {
         parent: parent,
         name: sectionName,
+        commands: parentCommands,
         commandLoader: commandLoader
       };
       sectionObjects[sectionName] = new Section(sections[sectionName], options);

--- a/lib/page-object/page-utils.js
+++ b/lib/page-object/page-utils.js
@@ -53,7 +53,7 @@ module.exports = new (function() {
    * @param {Array} sections Array of objects to become section objects
    * @returns {null}
    */
-  this.createSections = function(parent, sections) {
+  this.createSections = function(parent, sections, commandLoader) {
     var Section = require('./section.js');
     var sectionObjects = {};
     var sec;
@@ -62,6 +62,7 @@ module.exports = new (function() {
       sec = sections[s];
       sec.parent = parent;
       sec.name = s;
+      sec.commandLoader = commandLoader;
       sectionObjects[sec.name] = new Section(sec);
     });
 

--- a/lib/page-object/page.js
+++ b/lib/page-object/page.js
@@ -8,45 +8,31 @@ var CommandWrapper = require('./command-wrapper.js');
  * @constructor
  */
 function Page(options, commandLoader, api, client) {
-  this.commandLoader = commandLoader;
+  this.parent = null;
   this.api = api;
   this.client = client;
   this.name = options.name;
+  this.props = {};
+  this.section = {};
+  this.settings = {
+    url: options.url,
+    elements: {}
+  };
+
+  // API commands are added to the page instance first, followed by
+  // the other page methods (PageUtils.addCommands) which may
+  // override the API commands if they have the same name
+
+  CommandWrapper.addWrappedCommands(this, commandLoader);
 
   PageUtils
     .createProps(this, options.props || {})
     .createElements(this, options.elements || {})
-    .createSections(this, options.sections || {})
+    .createSections(this, options.sections || {}, commandLoader)
     .addCommands(this, options.commands || []);
-
-  CommandWrapper.addWrappedCommands(this, this.commandLoader);
-
-  // overwrite the added, wrapped url() method with the internal url
-  // property as defined by the page definition.  This is an exception
-  // where for url(), you have to go through .api because of the naming
-  // collision unless we rename thw property here on the page object
-
-  this.url = this.getUrl(options.url);
 }
 
 Page.prototype = {
-  /**
-   * Returns the url passed as an argument (or null if no arguments are passed).
-   *  If the supplied url is a function, it invokes that function with the page as its context.
-   *
-   * @method getUrl
-   * @param {string} url
-   * @returns {string|null}
-   */
-  getUrl: function(url) {
-    if (typeof url === 'function') {
-      return url.call(this);
-    } else if (typeof url === 'string') {
-      return url;
-    }
-
-    return null;
-  },
 
   /**
    * This command is an alias to url and also a convenience method because when called without any arguments
@@ -58,7 +44,7 @@ Page.prototype = {
    * @returns {*}
    */
   navigate: function(url) {
-    var goToUrl = url || this.url;
+    var goToUrl = getUrl(url || this.settings.url);
     if (goToUrl === null) {
       throw new Error('Invalid URL: You must either add a url property to "' +
         this.name + '" or provide a url as an argument');
@@ -67,5 +53,23 @@ Page.prototype = {
     return this;
   }
 };
+
+/**
+ * Returns the url passed as an argument (or null if no arguments are passed).
+ *  If the supplied url is a function, it invokes that function with the page as its context.
+ *
+ * @method getUrl
+ * @param {string} url
+ * @returns {string|null}
+ */
+function getUrl(url) {
+  if (typeof url === 'function') {
+    return url.call(this);
+  } else if (typeof url === 'string') {
+    return url;
+  }
+
+  return null;
+}
 
 module.exports = Page;

--- a/lib/page-object/page.js
+++ b/lib/page-object/page.js
@@ -12,7 +12,6 @@ function Page(options, commandLoader, api, client) {
   this.api = api;
   this.client = client;
   this.name = options.name;
-  this.url = this.getUrl(options.url);
 
   PageUtils
     .createProps(this, options.props || {})
@@ -21,6 +20,13 @@ function Page(options, commandLoader, api, client) {
     .addCommands(this, options.commands || []);
 
   CommandWrapper.addWrappedCommands(this, this.commandLoader);
+
+  // overwrite the added, wrapped url() method with the internal url
+  // property as defined by the page definition.  This is an exception
+  // where for url(), you have to go through .api because of the naming
+  // collision unless we rename thw property here on the page object
+
+  this.url = this.getUrl(options.url);
 }
 
 Page.prototype = {

--- a/lib/page-object/page.js
+++ b/lib/page-object/page.js
@@ -28,7 +28,7 @@ function Page(options, commandLoader, api, client) {
   PageUtils
     .createProps(this, options.props || {})
     .createElements(this, options.elements || {})
-    .createSections(this, options.sections || {}, commandLoader)
+    .createSections(this, options.sections || {}, commandLoader, options.commands || [])
     .addCommands(this, options.commands || []);
 }
 

--- a/lib/page-object/page.js
+++ b/lib/page-object/page.js
@@ -8,10 +8,10 @@ var CommandWrapper = require('./command-wrapper.js');
  * @constructor
  */
 function Page(options, commandLoader, api, client) {
+  this.name = options.name;
   this.parent = null;
   this.api = api;
   this.client = client;
-  this.name = options.name;
   this.props = {};
   this.section = {};
   this.settings = {

--- a/lib/page-object/section.js
+++ b/lib/page-object/section.js
@@ -18,6 +18,9 @@ function Section(definition, options) {
   this.parent = options.parent;
   this.api = this.parent.api;
   this.client = this.parent.client;
+  this.settings = {
+    elements: {}
+  };
 
   this.selector = definition.selector;
   this.locateStrategy = definition.locateStrategy || 'css selector';

--- a/lib/page-object/section.js
+++ b/lib/page-object/section.js
@@ -7,11 +7,11 @@ var CommandWrapper = require('./command-wrapper.js');
  * @param {Object} options Section options defined in page object
  * @constructor
  */
-function Section(options) {
+function Section(definition, options) {
 
-  if(!options.selector) {
+  if(!definition.selector) {
     throw new Error('No selector property for section "' + options.name +
-      '" Instead found properties: ' + Object.keys(options));
+      '" Instead found properties: ' + Object.keys(definition));
   }
 
   this.name = options.name;
@@ -19,16 +19,16 @@ function Section(options) {
   this.api = this.parent.api;
   this.client = this.parent.client;
 
-  this.selector = options.selector;
-  this.locateStrategy = options.locateStrategy || 'css selector';
+  this.selector = definition.selector;
+  this.locateStrategy = definition.locateStrategy || 'css selector';
 
   CommandWrapper.addWrappedCommands(this, options.commandLoader);
 
   PageUtils
-    .createProps(this, options.props || {})
-    .createElements(this, options.elements || {})
-    .createSections(this, options.sections || {}, options.commandLoader)
-    .addCommands(this, options.commands || []);
+    .createProps(this, definition.props || {})
+    .createElements(this, definition.elements || {})
+    .createSections(this, definition.sections || {}, options.commandLoader)
+    .addCommands(this, definition.commands || []);
 }
 
 Section.prototype.toString = function() {

--- a/lib/page-object/section.js
+++ b/lib/page-object/section.js
@@ -30,7 +30,7 @@ function Section(definition, options) {
   PageUtils
     .createProps(this, definition.props || {})
     .createElements(this, definition.elements || {})
-    .createSections(this, definition.sections || {}, options.commandLoader)
+    .createSections(this, definition.sections || {}, options.commandLoader, options.commands || [])
     .addCommands(this, definition.commands || []);
 }
 

--- a/lib/page-object/section.js
+++ b/lib/page-object/section.js
@@ -8,8 +8,6 @@ var CommandWrapper = require('./command-wrapper.js');
  * @constructor
  */
 function Section(options) {
-  this.parent = options.parent;
-  this.client = this.parent.client;
 
   if(!options.selector) {
     throw new Error('No selector property for section "' + options.name +
@@ -17,17 +15,20 @@ function Section(options) {
   }
 
   this.name = options.name;
+  this.parent = options.parent;
+  this.api = this.parent.api;
+  this.client = this.parent.client;
+
   this.selector = options.selector;
   this.locateStrategy = options.locateStrategy || 'css selector';
-  this.api = this.parent.api;
+
+  CommandWrapper.addWrappedCommands(this, options.commandLoader);
 
   PageUtils
     .createProps(this, options.props || {})
     .createElements(this, options.elements || {})
     .createSections(this, options.sections || {}, options.commandLoader)
     .addCommands(this, options.commands || []);
-
-  CommandWrapper.addWrappedCommands(this, options.commandLoader, true);
 }
 
 Section.prototype.toString = function() {

--- a/lib/page-object/section.js
+++ b/lib/page-object/section.js
@@ -20,15 +20,14 @@ function Section(options) {
   this.selector = options.selector;
   this.locateStrategy = options.locateStrategy || 'css selector';
   this.api = this.parent.api;
-  this.commandLoader = this.parent.commandLoader;
 
   PageUtils
     .createProps(this, options.props || {})
     .createElements(this, options.elements || {})
-    .createSections(this, options.sections || {})
+    .createSections(this, options.sections || {}, options.commandLoader)
     .addCommands(this, options.commands || []);
 
-  CommandWrapper.addWrappedCommands(this, this.commandLoader);
+  CommandWrapper.addWrappedCommands(this, options.commandLoader, true);
 }
 
 Section.prototype.toString = function() {

--- a/test/src/core/testPageObjectApi.js
+++ b/test/src/core/testPageObjectApi.js
@@ -34,19 +34,19 @@ module.exports = {
 
       assert.equal(typeof page.api, 'object');
       assert.equal(typeof page.client, 'object');
-      assert.equal(typeof page.elements, 'object');
+      assert.equal(typeof page.settings.elements, 'object');
       assert.equal(page.name, 'simplePageObj');
-      assert.equal(page.url, 'http://localhost.com');
+      assert.equal(page.settings.url, 'http://localhost.com');
       assert.equal(page.testCommand(), page);
 
-      assert.ok('loginCss' in page.elements);
-      assert.ok('loginXpath' in page.elements);
+      assert.ok('loginCss' in page.settings.elements);
+      assert.ok('loginXpath' in page.settings.elements);
       assert.ok('signUp' in page.section);
 
-      assert.ok('help' in page.section.signUp.elements);
+      assert.ok('help' in page.section.signUp.settings.elements);
       assert.ok('getStarted' in page.section.signUp.section);
 
-      var elements = page.elements;
+      var elements = page.settings.elements;
       assert.equal(elements.loginCss.selector, '#weblogin');
       assert.equal(elements.loginCss.locateStrategy, 'css selector');
       assert.equal(elements.loginXpath.selector, '//weblogin');
@@ -59,10 +59,10 @@ module.exports = {
       var page = this.client.api.page.pageObjElementsArray();
       assert.ok('elements' in page);
 
-      assert.ok('someElement' in page.elements);
-      assert.ok('otherElement' in page.elements);
-      assert.equal(page.elements.someElement.selector, '#element');
-      assert.equal(page.elements.otherElement.selector, '#otherElement');
+      assert.ok('someElement' in page.settings.elements);
+      assert.ok('otherElement' in page.settings.elements);
+      assert.equal(page.settings.elements.someElement.selector, '#element');
+      assert.equal(page.settings.elements.otherElement.selector, '#otherElement');
     },
 
     testPageObjectSubDirectory : function() {
@@ -97,8 +97,8 @@ module.exports = {
 
       assert.ok('click' in page);
       assert.ok('waitForElementPresent' in page);
-      assert.ok(!('end' in page));
-      assert.ok(!('switchWindow' in page));
+      assert.ok(('end' in page));
+      assert.ok(('switchWindow' in page));
     }
   }
 };


### PR DESCRIPTION
Page objects will now have the full gamut of commands like `pause()` and `perform()` that would normally require you to go through `page.api` changing the context of the chain to the api object rather than still being with the page. Now all commands work on page objects.

Relavant issue: #884