### PR TITLE
add page_objects_path to config

### DIFF
--- a/bin/nightwatch.json
+++ b/bin/nightwatch.json
@@ -2,6 +2,7 @@
   "src_folders" : ["./examples/tests"],
   "output_folder" : "./examples/reports",
   "custom_commands_path" : "./examples/custom-commands",
+  "page_objects_path" : "./examples/pages",
   "custom_assertions_path" : "",
   "globals_path" : "",
   "live_output" : false,


### PR DESCRIPTION
This allows sample tests with Page Object Model example to be executed via `./bin/nightwatch -t examples/tests/googlePageObject.js`