### PR TITLE
Updated implementation for getting the test source for single files (#1096)

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -187,7 +187,11 @@ CliRunner.prototype = {
   },
 
   singleSourceFile: function() {
-    return Array.isArray(this.argv._source) && this.argv._source.length == 1 && fs.statSync(this.argv._source[0]).isFile();
+    if (this.singleTestRun()) {
+      return fs.statSync(this.argv.test).isFile();
+    }
+
+    return (Array.isArray(this.argv._source) && this.argv._source.length == 1) && fs.statSync(this.argv._source[0]).isFile();
   },
 
   getTestSourceForSingle: function(targetPath) {
@@ -213,16 +217,10 @@ CliRunner.prototype = {
   getTestSource : function() {
     var testsource;
 
-    if (this.singleTestRun()) {
-      testsource = this.getTestSourceForSingle(this.argv.test);
-
-      try {
-        fs.statSync(testsource);
-      } catch (err) {
-        throw new Error('There was a problem reading the test file: ' + testsource);
-      }
+    if (this.singleSourceFile()) {
+      testsource = this.getTestSourceForSingle(this.argv.test || this.argv._source[0]);
     } else {
-      if (this.argv.testcase && !this.singleSourceFile()) {
+      if (this.argv.testcase) {
         this.argv.testcase = null;
 
         if (this.test_settings.output) {
@@ -395,7 +393,7 @@ CliRunner.prototype = {
     try {
       source = this.getTestSource();
     } catch (err) {
-      fn(err, []);
+      fn(err, {});
       return;
     }
 
@@ -427,7 +425,7 @@ CliRunner.prototype = {
 
         Runner.readPaths(source, this.test_settings, function(error, modulePaths) {
           if (error) {
-            fn(error, []);
+            fn(error, {});
             return;
           }
           modulePaths.forEach(function(file) {
@@ -687,7 +685,7 @@ CliRunner.prototype = {
   },
 
   parallelModeWorkers: function () {
-    return !this.isParallelMode() && !this.singleTestRun() && !this.singleSourceFile() && (this.settings.test_workers === true ||
+    return !this.isParallelMode() && !this.singleSourceFile() && (this.settings.test_workers === true ||
       Utils.isObject(this.settings.test_workers) && this.settings.test_workers.enabled);
   },
 

--- a/test/src/runner/cli/testCliRunner.js
+++ b/test/src/runner/cli/testCliRunner.js
@@ -135,9 +135,13 @@ module.exports = {
           return false;
         },
         statSync : function(file) {
-          if (file == 'demoTest.js') {
+          if (file == 'demoTest') {
             statSyncCalled = true;
-            return true;
+            return {
+              isFile : function() {
+                return true;
+              }
+            };
           }
           throw new Error('Start error.');
         }
@@ -169,9 +173,14 @@ module.exports = {
           return false;
         },
         statSync : function(file) {
-          if (file == ABSOLUTE_SRC_PATH) {
+          console.log('statSync', file)
+          if (file == ABSOLUTE_PATH) {
             statSyncCalled = true;
-            return true;
+            return {
+              isFile : function() {
+                return true;
+              }
+            };
           }
           throw new Error('Start error.');
         }
@@ -203,9 +212,13 @@ module.exports = {
           return false;
         },
         statSync : function(file) {
-          if (file == TEST_SRC_PATH) {
+          if (file == RELATIVE_PATH) {
             statSyncCalled = true;
-            return true;
+            return {
+              isFile : function() {
+                return true;
+              }
+            };
           }
           throw new Error('Start error.');
         }
@@ -250,26 +263,24 @@ module.exports = {
       }).init();
 
       var testSource = runner.getTestSource();
-      assert.deepEqual(testSource, ['test.js']);
+      assert.deepEqual(testSource, 'test.js');
     },
 
     testRunTestsWithTestSourceSingleInvalid : function(done) {
+      var invalidTestFile = 'doesnotexist.js';
+      var errorMessage = 'ENOENT: no such file or directory, stat \'' + invalidTestFile + '\'';
       mockery.registerMock('fs', {
         existsSync : function(module) {
           if (module == './custom.json') {
             return true;
           }
           return false;
-        }
-      });
-
-      var invalidTestFile = 'doesnotexist.js';
-      var errorMessage = 'There was a problem reading the test file: ' + invalidTestFile;
-
-      mockery.registerMock('./errorhandler.js', {
-        handle : function(err) {
-          assert.equal(err.message, errorMessage);
-          done();
+        },
+        statSync : function(module) {
+          if (module == invalidTestFile) {
+            throw new Error(errorMessage);
+          }
+          throw new Error('Start error.');
         }
       });
 
@@ -278,10 +289,16 @@ module.exports = {
         config : './custom.json',
         env : 'default',
         test: invalidTestFile
-      }).init();
+      });
 
       runner.manageSelenium = true;
-      runner.runTests();
+
+      try {
+        runner.init();
+      } catch (err) {
+        assert.equal(err.message, errorMessage);
+        done();
+      }
     },
 
     testRunTestsWithTestcaseOption : function() {
@@ -293,8 +310,12 @@ module.exports = {
           return false;
         },
         statSync : function(file) {
-          if (file == 'demoTest.js') {
-            return true;
+          if (file == 'demoTest') {
+            return {
+              isFile : function() {
+                return true;
+              }
+            };
           }
           throw new Error('Start error.');
         }


### PR DESCRIPTION
This is based on #1096 and consolidates the error response in situations when the specified test file doesn't exist/cannot be loaded. The behaviour is the same in these 2 situations:

```sh
$ nightwatch --test /path/to/invalid-file.js

$ nightwatch /path/to/invalid-file.js
```

The error message though may be somewhat less user friendly.

@senocular would you mind having a look?