### PR TITLE
Fixed #1111 - add output to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage.html
 selenium-debug.log
 phantomjsdriver.log
 tests_output
+output
 *~
 \#*
 \.#*


### PR DESCRIPTION
Keeps the output folder where test run results are stored from being committed back in the repo by adding it to .gitignore.  Now, when people run the tests as part of their due diligence in submitting a new PR (like this one!), they won't have to worry about the output folder getting caught up in that PR anymore (and it wasn't!).