### PR TITLE
Fixes #1115 - Support for object-based selectors in page elements format

### DIFF
--- a/lib/api/element-commands.js
+++ b/lib/api/element-commands.js
@@ -368,7 +368,7 @@ module.exports = function(client) {
         // but ignore it otherwise since its optional and only extra
         // noise if not used
 
-        if (elem.index != undefined) {
+        if (elem.index !== undefined && elem.index !== null) {
           errorMessage += ' at index: ' + elem.index;
         }
 

--- a/lib/api/element-commands.js
+++ b/lib/api/element-commands.js
@@ -2,6 +2,7 @@ var util = require('util');
 var events = require('events');
 var Logger = require('../util/logger.js');
 var Utils = require('../util/utils.js');
+var Element = require('../page-object/element.js');
 
 module.exports = function(client) {
   var Protocol = require('./protocol.js')(client);
@@ -341,10 +342,36 @@ module.exports = function(client) {
     events.EventEmitter.call(this);
 
     var $this = this;
-    var el = Protocol.element(using, value, function(result) {
+
+    // element commands support a single element but we use elements() to capture
+    // a full list of matching elements for the selector so that we can support
+    // the use of element.index if available.  If no index is used, the first
+    // element is matched
+
+    var el = Protocol.elements(using, value, function(result) {
+
+      // if the request was successful but no elements were returned, that's an error
+      // since we expect at least one to exist, so we change the status to failing.
+
+      if (result.status === 0 && result.value.length === 0) {
+        result.status = -1;
+      }
+
       if (result.status !== 0) {
+
         callback.call(client.api, result);
-        var errorMessage = 'ERROR: Unable to locate element: "' + value + '" using: ' + using;
+
+        var elem = Element.fromSelector(value, using);
+        var errorMessage = 'ERROR: Unable to locate element: "' + elem.selector + '" using: "' + elem.locateStrategy + '"';
+
+        // when an index is specified, include it in the error message
+        // but ignore it otherwise since its optional and only extra
+        // noise if not used
+
+        if (elem.index != undefined) {
+          errorMessage += ' at index: ' + elem.index;
+        }
+
         var stack = originalStackTrace.split('\n');
 
         stack.shift();
@@ -354,8 +381,14 @@ module.exports = function(client) {
         client.errors.push(errorMessage + '\n' + stack.join('\n'));
 
         $this.emit('complete', el, $this);
+
       } else {
-        result = result.value.ELEMENT;
+
+        // we only care about the first element. If an index was used, it would
+        // have already been applied to the result and first element ([0])
+        // would be that element
+
+        result = result.value[0].ELEMENT;
 
         args.push(function(r) {
           callback.call(client.api, r);

--- a/lib/api/element-commands/_elementByRecursion.js
+++ b/lib/api/element-commands/_elementByRecursion.js
@@ -8,7 +8,6 @@ var events = require('events');
  * @param {function} [callback] Optional callback function to be called when the command finishes.
  * @api protocol
  */
-
 function ElementByRecursion(client) {
   events.EventEmitter.call(this);
   this.protocol = require('../protocol.js')(client);
@@ -18,10 +17,15 @@ util.inherits(ElementByRecursion, events.EventEmitter);
 
 ElementByRecursion.prototype.command = function(elements, callback) {
   var self = this;
-  var allElements = elements.slice();
 
+  var allElements = elements.slice();
   var topElement = allElements.shift();
-  var el = this.protocol.element(topElement.locateStrategy, topElement.selector, function checkResult(result) {
+
+  // since we're dealing with an array of element objects the using
+  // parameter (null) in the protocol commands is redundant since
+  // its already encoded in the element object (topElement)
+
+  var el = this.protocol.element(null, topElement, function checkResult(result) {
     if (result.status !== 0) {
       callback(result);
       self.emit('complete', el, self);
@@ -29,7 +33,7 @@ ElementByRecursion.prototype.command = function(elements, callback) {
       var nextElement = allElements.shift();
       var parentId = result.value.ELEMENT;
       if (nextElement) {
-        self.protocol.elementIdElement(parentId, nextElement.locateStrategy, nextElement.selector, checkResult);
+        self.protocol.elementIdElement(parentId, null, nextElement, checkResult);
       } else {
         callback(result);
         self.emit('complete', el, self);

--- a/lib/api/element-commands/_elementsByRecursion.js
+++ b/lib/api/element-commands/_elementsByRecursion.js
@@ -9,7 +9,6 @@ var Q = require('q');
  * @param {function} [callback] Optional callback function to be called when the command finishes.
  * @api protocol
  */
-
 function ElementsByRecursion(client) {
   events.EventEmitter.call(this);
   this.protocol = require('../protocol.js')(client);
@@ -65,7 +64,11 @@ ElementsByRecursion.prototype.command = function(elements, callback) {
   var allElements = elements.slice();
   var topElement = allElements.shift();
 
-  var el = this.protocol.elements(topElement.locateStrategy, topElement.selector, function checkResult() {
+  // since we're dealing with an array of element objects the using
+  // parameter (null) in the protocol commands is redundant since
+  // its already encoded in the element object (topElement)
+
+  var el = this.protocol.elements(null, topElement, function checkResult() {
     var result = aggregateResults(arguments);
     if (result.value.length === 0) {
       callback(result);
@@ -77,7 +80,7 @@ ElementsByRecursion.prototype.command = function(elements, callback) {
     if (nextElement) {
       var promises = [];
       result.value.forEach(function(el) {
-        var p = deferredElementIdElements(el.ELEMENT, nextElement.locateStrategy, nextElement.selector, checkResult);
+        var p = deferredElementIdElements(el.ELEMENT, null, nextElement, checkResult);
         promises.push(p);
       });
 

--- a/lib/api/element-commands/_waitForElement.js
+++ b/lib/api/element-commands/_waitForElement.js
@@ -204,7 +204,7 @@ WaitForElement.prototype.checkElement = function() {
   this.getProtocolCommand(function(result) {
     var now = new Date().getTime();
 
-    if (result.value && result.value.length > 0) {
+    if (result.status === 0 && result.value && result.value.length > 0) {
       if (result.value.length > 1) {
         var message = 'WaitForElement found ' + result.value.length + ' elements for selector "' + self.selector + '".';
         if (self.throwOnMultipleElementsReturned) {

--- a/lib/api/expect/_baseAssertion.js
+++ b/lib/api/expect/_baseAssertion.js
@@ -208,7 +208,16 @@ BaseAssertion.prototype.scheduleRetry = function() {
 };
 
 BaseAssertion.prototype.formatMessage = function() {
-  this.message = Utils.format(this.message || this.message, this.selector);
+
+  // selector may be a simple string or an object. If an
+  // object, show a more meaningful string representation
+
+  var selectorStr = String(this.selector);
+  if (selectorStr === '[object Object]') {
+    selectorStr = JSON.stringify(this.selector);
+  }
+
+  this.message = Utils.format(this.message, selectorStr);
   this.message += this.messageParts.join('');
 };
 

--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -296,7 +296,7 @@ module.exports = function(Nightwatch) {
   function createIndexedElementCallback(elem, callback) {
     return function (result) {
 
-      var usingIndex = elem.index != undefined;
+      var usingIndex = (elem.index !== undefined && elem.index !== null);
       if (usingIndex && result && result.status === 0) {
 
         // if an element index is specified, we need to make sure its

--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -1,5 +1,6 @@
 var elementByRecursion = require('./element-commands/_elementByRecursion.js');
 var elementsByRecursion = require('./element-commands/_elementsByRecursion.js');
+var Element = require('../page-object/element.js');
 
 module.exports = function(Nightwatch) {
 
@@ -164,35 +165,35 @@ module.exports = function(Nightwatch) {
    * @api protocol
    */
   Actions.element = function(using, value, callback) {
-    if (using == 'recursion') {
-      return new elementByRecursion(Nightwatch).command(value, callback);
+
+    var elem = Element.fromSelector(value, using);
+
+    if (elem.locateStrategy == 'recursion') {
+
+      // when using recursion, the selector of the element is an
+      // array of elements which each need to individually
+      // and sequentially get resolved on top of each other
+
+      return new elementByRecursion(Nightwatch).command(elem.selector, callback);
     }
 
-    return element(using, value, callback);
+    return element(elem, callback);
   };
 
   /*!
    * element protocol action
    *
-   * @param {string} using
-   * @param {string} value
+   * @param {Object} elem
    * @param {function} callback
    * @private
    */
-  function element(using, value, callback) {
-    var strategies = ['class name', 'css selector', 'id', 'name', 'link text',
-      'partial link text', 'tag name', 'xpath'];
-    using = using.toLocaleLowerCase();
+  function element(elem, callback) {
 
-    if (strategies.indexOf(using) === -1) {
-      throw new Error('Provided locating strategy is not supported: ' +
-        using + '. It must be one of the following:\n' +
-        strategies.join(', '));
-    }
+    validateStrategy(elem.locateStrategy);
 
     return postRequest('/element', {
-      using: using,
-      value: value
+      using: elem.locateStrategy,
+      value: elem.selector
     }, callback);
   }
 
@@ -207,19 +208,14 @@ module.exports = function(Nightwatch) {
    * @api protocol
    */
   Actions.elementIdElement = function(id, using, value, callback) {
-    var strategies = ['class name', 'css selector', 'id', 'name', 'link text',
-      'partial link text', 'tag name', 'xpath'];
-    using = using.toLocaleLowerCase();
 
-    if (strategies.indexOf(using) === -1) {
-      throw new Error('Provided locating strategy is not supported: ' +
-        using + '. It must be one of the following:\n' +
-        strategies.join(', '));
-    }
+    var elem = Element.fromSelector(value, using);
+
+    validateStrategy(elem.locateStrategy);
 
     return postRequest('/element/' + id + '/element', {
-      using: using,
-      value: value
+      using: elem.locateStrategy,
+      value: elem.selector
     }, callback);
   };
 
@@ -234,32 +230,37 @@ module.exports = function(Nightwatch) {
    * @api protocol
    */
   Actions.elements = function(using, value, callback) {
-    if (using == 'recursion') {
-      return new elementsByRecursion(Nightwatch).command(value, callback);
+
+    var elem = Element.fromSelector(value, using);
+
+    if (elem.locateStrategy == 'recursion') {
+
+      // when using recursion, the selector of the element is an
+      // array of elements which each need to individually
+      // and sequentially get resolved on top of each other
+
+      return new elementsByRecursion(Nightwatch).command(elem.selector, callback);
     }
 
-    return elements(using, value, callback);
+    return elements(elem, callback);
   };
 
   /*!
    * elements protocol action
    *
-   * @param {string} using
-   * @param {string} value
+   * @param {Object} elem
    * @param {function} callback
    * @private
    */
-  function elements(using, value, callback) {
-    var check = /class name|css selector|id|name|link text|partial link text|tag name|xpath/gi;
-    if (!check.test(using)) {
-      throw new Error('Please provide any of the following using strings as the first parameter: ' +
-        'class name, css selector, id, name, link text, partial link text, tag name, or xpath. Given: ' + using);
-    }
+  function elements(elem, callback) {
+
+    validateStrategy(elem.locateStrategy);
 
     return postRequest('/elements', {
-      using: using,
-      value: value
-    }, callback);
+        using: elem.locateStrategy,
+        value: elem.selector
+      }, createIndexedElementCallback(elem, callback)
+    );
   }
 
   /**
@@ -273,21 +274,89 @@ module.exports = function(Nightwatch) {
    * @api protocol
    */
   Actions.elementIdElements = function(id, using, value, callback) {
+
+    var elem = Element.fromSelector(value, using);
+
+    validateStrategy(elem.locateStrategy);
+
+    return postRequest('/element/' + id + '/elements', {
+        using: elem.locateStrategy,
+        value: elem.selector
+      }, createIndexedElementCallback(elem, callback)
+    );
+  };
+
+  /**
+   * Wraps an elements protocol request callback to include logic to select
+   * a single element with an index if one was specified.
+   * @param {Object} elem
+   * @param {function} callback
+   * @private
+   */
+  function createIndexedElementCallback(elem, callback) {
+    return function (result) {
+
+      var usingIndex = elem.index != undefined;
+      if (usingIndex && result && result.status === 0) {
+
+        // if an element index is specified, we need to make sure its
+        // within the range of elements found. If not, we patch the
+        // result to show a failure
+
+        if (result.value.length <= elem.index) {
+
+          result.status = -1;
+
+          var errorId = 'NoSuchElement';
+          var errorInfo = errorById(errorId);
+          if (errorInfo) {
+            result.message = errorInfo.message;
+            result.errorStatus = errorInfo.status;
+          }
+
+        } else {
+
+          // with a valid element index, make the results that element
+          // as the first and only result
+
+          result.value = [result.value[elem.index]];
+        }
+      }
+
+      return callback(result);
+    };
+  }
+
+  /**
+   * Looks up error status info from an id string rather than id number
+   */
+  function errorById(id) {
+    var errorCodes = require('./errors.json');
+    for (var status in errorCodes) {
+      if (errorCodes[status].id === id) {
+        return {
+          status: status,
+          id: id,
+          message: errorCodes[status].message
+        };
+      }
+    }
+
+    return null;
+  }
+
+  function validateStrategy(using) {
+
+    var usingLow = String(using).toLocaleLowerCase();
     var strategies = ['class name', 'css selector', 'id', 'name', 'link text',
       'partial link text', 'tag name', 'xpath'];
-    using = using.toLocaleLowerCase();
 
-    if (strategies.indexOf(using) === -1) {
+    if (strategies.indexOf(usingLow) === -1) {
       throw new Error('Provided locating strategy is not supported: ' +
         using + '. It must be one of the following:\n' +
         strategies.join(', '));
     }
-
-    return postRequest('/element/' + id + '/elements', {
-      using: using,
-      value: value
-    }, callback);
-  };
+  }
 
   /**
    * Get the element on the page that currently has focus.

--- a/lib/core/queue.js
+++ b/lib/core/queue.js
@@ -158,6 +158,7 @@ AsyncTree.prototype.runCommand = function(node, callback) {
     }
     return node.context;
   } catch (err) {
+    err.originalStack = err.stack;
     err.stack = node.stackTrace;
     err.name = 'Error while running ' + node.name + ' command';
     this.emit('error', err);

--- a/lib/page-object/command-wrapper.js
+++ b/lib/page-object/command-wrapper.js
@@ -1,4 +1,74 @@
+var Element = require('./element.js');
+
 module.exports = new (function() {
+
+  /**
+   * Creates a closure that enables calling commands and assertions on the page or section.
+   * For all element commands and assertions, it fetches element's selector and locate strategy
+   *  For elements nested under sections, it sets 'recursion' as the locate strategy and passes as its first argument to the command an array of its ancestors + self
+   *  If the command or assertion is not on an element, it calls it with the untouched passed arguments
+   *
+   * @param {Object} parent The parent page or section
+   * @param {function} commandFn The actual command function
+   * @param {string} commandName The name of the command ("click", "containsText", etc)
+   * @param {Boolean} [isChaiAssertion]
+   * @returns {parent}
+   */
+  function makeWrappedCommand(parent, commandFn, commandName, isChaiAssertion) {
+
+    var isSectionSelector = isChaiAssertion && commandName === 'section';
+
+    return function() {
+      var args = Array.prototype.slice.call(arguments);
+      parseElementSelector(args, parent, isSectionSelector);
+      var result = commandFn.apply(parent.client, args);
+      return (isChaiAssertion ? result : parent);
+    };
+  }
+
+  /**
+   * Identifies element references (@-prefixed selectors) within an argument
+   * list and converts it into an element object with the appropriate
+   * selector or recursion chain of selectors.
+   *
+   * @param {Array} args The argument list to check for an element selector.
+   * @param {Object} parent The parent page or section.
+   * @param {boolean} isSectionSelector When true, indicates that the selector references
+   *    a selector within a section rather than an elements definition.
+   */
+  function parseElementSelector (args, parent, isSectionSelector) {
+
+    // check the first argument for an element selector (using @ prefix). The only pattern
+    // supported for element selectors is when they're used as the first argument.
+
+    var maybeSelector = args[0];
+    var inputElement = maybeSelector && Element.fromSelector(maybeSelector);
+    if (inputElement && inputElement.hasElementSelector()) {
+
+      // find the element definition the element selector references
+
+      var getter = isSectionSelector ? getSection : getElement;
+      var elementOrSection = getter(parent, inputElement.selector);
+
+      // copy over the reference's selector (replacing the @ - value) and
+      // copy over any other defaults from the reference if not defined
+      // in the input element
+
+      inputElement.selector = elementOrSection.selector;
+      Element.copyDefaults(inputElement, elementOrSection);
+
+      // check to see if the element requires a recursive query to
+      // locate.  If so, a new element object is created to represent the
+      // lookup with the recursive locate strategy needed to resolve it
+
+      inputElement = inputElement.getRecursiveLookup() || inputElement;
+
+      // the final element representation gets sent back into args
+      // array to replace the original selector value
+
+      args[0] = inputElement;
+    }
+  }
 
   /**
    * Given an element name, returns that element object
@@ -30,155 +100,6 @@ module.exports = new (function() {
         '". Available sections: ' + Object.keys(parent.sections));
     }
     return parent.section[sectionName];
-  }
-
-  /**
-   * Calls use(Css|Xpath|Recursion) command
-   *
-   * Uses `useXpath`, `useCss`, and `useRecursion` commands.
-   *
-   * @param {Object} client The Nightwatch instance
-   * @param {string} desiredStrategy (css selector|xpath|recursion)
-   * @returns {null}
-   */
-  function setLocateStrategy(client, desiredStrategy) {
-    var methodMap = {
-      xpath : 'useXpath',
-      'css selector' : 'useCss',
-      recursion : 'useRecursion'
-    };
-
-    if (desiredStrategy in methodMap) {
-      client.api[methodMap[desiredStrategy]]();
-    }
-  }
-
-  /**
-   * Creates a closure that enables calling commands and assertions on the page or section.
-   * For all element commands and assertions, it fetches element's selector and locate strategy
-   *  For elements nested under sections, it sets 'recursion' as the locate strategy and passes as its first argument to the command an array of its ancestors + self
-   *  If the command or assertion is not on an element, it calls it with the untouched passed arguments
-   *
-   * @param {Object} parent The parent page or section
-   * @param {function} commandFn The actual command function
-   * @param {string} commandName The name of the command ("click", "containsText", etc)
-   * @param {Boolean} [isChaiAssertion]
-   * @returns {function}
-   */
-  function makeWrappedCommand(parent, commandFn, commandName, isChaiAssertion) {
-    return function() {
-      var args = Array.prototype.slice.call(arguments);
-      var prevLocateStrategy = parent.client.locateStrategy;
-      var elementCommand = isElementCommand(args);
-
-      if (elementCommand) {
-        var firstArg;
-        var desiredStrategy;
-        var callbackIndex;
-        var originalCallback;
-        var elementOrSectionName = args.shift();
-        var getter = (isChaiAssertion && commandName === 'section') ? getSection : getElement;
-        var elementOrSection = getter(parent, elementOrSectionName);
-        var ancestors = getAncestorsWithElement(elementOrSection);
-
-        if (ancestors.length === 1) {
-          firstArg = elementOrSection.selector;
-          desiredStrategy = elementOrSection.locateStrategy;
-        } else {
-          firstArg = ancestors;
-          desiredStrategy = 'recursion';
-        }
-
-        setLocateStrategy(parent.client, desiredStrategy);
-        args.unshift(firstArg);
-
-        // if a callback is being used with this command, wrap it in
-        // a function that allows us to restore the locate strategy
-        // to its original value before the callback is called
-
-        callbackIndex = findCallbackIndex(args);
-        if (callbackIndex !== -1) {
-          originalCallback = args[callbackIndex];
-
-          args[callbackIndex] = function callbackWrapper() {
-
-            // restore the locate strategy directly through client.locateStrategy.
-            // setLocateStrategy() can't be used since it uses the api commands
-            // which get added to the command queue and will not update the
-            // strategy in time for the callback which is getting immediately
-            // called after
-
-            parent.client.locateStrategy = prevLocateStrategy;
-            return originalCallback.apply(parent.client.api, arguments);
-          };
-        }
-      }
-
-      var c = commandFn.apply(parent.client, args);
-      if (elementCommand) {
-        setLocateStrategy(parent.client, prevLocateStrategy);
-      }
-      return (isChaiAssertion ? c : parent);
-    };
-  }
-
-  /**
-   *
-   * @param {Array} args
-   * @return {boolean}
-   */
-  function isElementCommand(args) {
-    return (args.length > 0) && (args[0].toString().indexOf('@') === 0);
-  }
-
-  /**
-   * Identifies the location of a callback function within an arguments array.
-   *
-   * @param {Array} args Arguments array in which to find the location of a callback.
-   * @returns {number} Index location of the callback in the args array. If not found, -1 is returned.
-   */
-  function findCallbackIndex(args) {
-
-    if (args.length === 0) {
-      return -1;
-    }
-
-    // callbacks will usually be the last argument. waitFor methods allow an additional
-    // message argument to follow the callback which will also need to be checked for.
-
-    // last argument
-
-    var index = args.length - 1;
-    if (typeof args[index] === 'function') {
-      return index;
-    }
-
-    // second to last argument (waitfor calls)
-
-    index--;
-    if (typeof args[index] === 'function') {
-      return index;
-    }
-
-    return -1;
-  }
-
-  /**
-   * Retrieves an array of ancestors of the supplied element. The last element in the array is the element object itself
-   *
-   * @param {Object} element The element
-   * @returns {Array}
-   */
-  function getAncestorsWithElement(element) {
-    var elements = [];
-    function addElement(e) {
-      elements.unshift(e);
-      if (e.parent && e.parent.selector) {
-        addElement(e.parent);
-      }
-    }
-    addElement(element);
-    return elements;
   }
 
   /**

--- a/lib/page-object/element.js
+++ b/lib/page-object/element.js
@@ -79,7 +79,7 @@ Element.prototype.getRecursiveLookup = function () {
 Element.copyDefaults = function(target, source) {
   var props = ['name', 'parent', 'selector', 'locateStrategy', 'index'];
   props.forEach(function(prop) {
-    if (target[prop] == undefined && source[prop]) {
+    if ((target[prop] === undefined || target[prop] === null) && source[prop]) {
       target[prop] = source[prop];
     }
   });

--- a/lib/page-object/element.js
+++ b/lib/page-object/element.js
@@ -1,24 +1,179 @@
 /**
  * Class that all elements subclass from
  *
- * @param {Object} options Element options defined in page object
+ * @param {Object} definition Element options defined in page object
+ * @param {Object} options Additional options to be given to the element
  * @constructor
  */
-function Element(options) {
-  this.parent = options.parent;
+function Element(definition, options) {
+  options = options || {};
+  this.name = options.name;
 
-  if (!options.selector) {
-    throw new Error('No selector property for element "' + options.name +
-      '" Instead found properties: ' + Object.keys(options));
+  if (!definition.selector) {
+    throw new Error('No selector property for element "' + this.getName() +
+      '" Instead found properties: ' +
+      Object
+        .keys(definition)
+        .filter(function(key) { return definition[key]; })
+        .join(', ')
+    );
   }
 
-  this.name = options.name;
-  this.selector = options.selector;
-  this.locateStrategy = options.locateStrategy || 'css selector';
+  this.selector = definition.selector;
+  this.locateStrategy = definition.locateStrategy || options.locateStrategy;
+  this.index = definition.index;
+  this.parent = options.parent;
 }
 
 Element.prototype.toString = function() {
-  return 'Element[name=@' + this.name + ']';
+  return 'Element[name=@' + this.getName() + ']';
 };
+
+Element.prototype.getName = function() {
+  return this.name || '(anonymous)';
+};
+
+/**
+ * Determines whether or not the element contians an @ element reference
+ * for its selector.
+ *
+ * @returns {boolean} True if the selector is an element reference starting with an
+ *    @ symbol, false if it does not.
+ */
+Element.prototype.hasElementSelector = function() {
+  return String(this.selector)[0] === '@';
+};
+
+/**
+ * If the element object requires a recursive lookup to resolve its
+ * selector, a new element containing the recursive lookup values
+ * is created and returned.
+ *
+ * @returns {Object} A new Element object containing the element and its
+ *    parents with a recursive lookup strategy for resolving the element
+ *    if one is needed. If not, null is returned.
+ */
+Element.prototype.getRecursiveLookup = function () {
+  var lookupList = getAncestorsWithElement(this);
+
+  // the lookup list will have at least the current element in it
+  // if it has more, a recursive lookup is needed
+
+  if (lookupList.length > 1) {
+    return new Element({
+      selector: lookupList,
+      locateStrategy: 'recursion'
+    });
+  }
+
+  return null;
+};
+
+/**
+ * Copies selector properties from one object to object if the first
+ * object has undefined values for any of those properties.
+ *
+ * @param {Object} target The object to assign values to.
+ * @param {Object} source The object to capture values from.
+ */
+Element.copyDefaults = function(target, source) {
+  var props = ['name', 'parent', 'selector', 'locateStrategy', 'index'];
+  props.forEach(function(prop) {
+    if (target[prop] == undefined && source[prop]) {
+      target[prop] = source[prop];
+    }
+  });
+};
+
+/**
+ * Parses the value/selector parameter of an element command creating a
+ * new Element instance with the values it contains, if any. The standard
+ * format for this is a selector string, but additional, complex formats
+ * in the form of an array or object are also supported, allowing you to also
+ * specify a locate strategy (using) and/or an element index for targeting
+ * a specific element in a query that matches multiple.
+ *
+ * @param {string|Object} value Selector value to parse into an Element.
+ * @param {string} [using] The using/locateStrategy to use if the selector
+ *    doesn't provide one of its own.
+ */
+Element.fromSelector = function(value, using) {
+
+  // selector values are required
+
+  if (!value) {
+    throw new Error('Invalid selector value specified');
+  }
+
+  // if the selector value is already an element, return it
+
+  if (value instanceof Element) {
+    value.locateStrategy = value.locateStrategy || using;
+    return value;
+  }
+
+  // recursion values don't get parsed here. They're an array of values
+  // which get parsed individually in the recursive search process
+
+  if (using === 'recursion') {
+    return new Element({
+      selector: value,
+      locateStrategy: 'recursion'
+    });
+  }
+
+  var definition = {};
+
+  // object value format, e.g.:
+  // { selector: 'div', index (opt): 0, locateStrategy (opt): 'css selector' }
+
+  if (value && typeof value === 'object') {
+
+    definition.selector = value.selector;
+
+    if ('locateStrategy' in value) {
+      definition.locateStrategy = value.locateStrategy;
+    }
+
+    if ('index' in value) {
+      definition.index = value.index;
+    }
+
+  // default string value format as selector, e.g.:
+  // '#my-id div.my-class'
+
+  } else {
+    definition.selector = value;
+  }
+
+  // parameter using is a fallback for if a
+  // locateStrategy wasn't in the selector value
+
+  if (using && !definition.locateStrategy) {
+    definition.locateStrategy = using;
+  }
+
+  return new Element(definition);
+};
+
+
+
+/**
+ * Retrieves an array of ancestors of the supplied element. The last element in the array is the element object itself
+ *
+ * @param {Object} element The element
+ * @returns {Array}
+ */
+function getAncestorsWithElement(element) {
+  var elements = [];
+  function addElement(e) {
+    elements.unshift(e);
+    if (e.parent && e.parent.selector) {
+      addElement(e.parent);
+    }
+  }
+  addElement(element);
+  return elements;
+}
 
 module.exports = Element;

--- a/lib/page-object/page-utils.js
+++ b/lib/page-object/page-utils.js
@@ -25,18 +25,23 @@ module.exports = new (function() {
   this.createElements = function(parent, elements) {
     var Element = require('./element.js');
     var elementObjects = {};
-    var el;
+    var el, options;
 
     if (!Array.isArray(elements)) {
       elements = [elements];
     }
 
     elements.forEach(function(els) {
-      Object.keys(els).forEach(function(e) {
-        el = typeof els[e] === 'string' ? { selector: els[e] } : els[e];
-        el.parent = parent;
-        el.name = e;
-        elementObjects[el.name] = new Element(el);
+      Object.keys(els).forEach(function(name) {
+        el = typeof els[name] === 'string' ? { selector: els[name] } : els[name];
+
+        options = {
+          parent: parent,
+          name: name,
+          locateStrategy: el.locateStrategy || 'css selector'
+        };
+
+        elementObjects[name] = new Element(el, options);
       });
     });
 
@@ -62,6 +67,7 @@ module.exports = new (function() {
       sec = sections[s];
       sec.parent = parent;
       sec.name = s;
+      sec.locateStrategy = sec.locateStrategy || 'css selector';
       sectionObjects[sec.name] = new Section(sec);
     });
 

--- a/lib/page-object/section.js
+++ b/lib/page-object/section.js
@@ -8,17 +8,20 @@ var CommandWrapper = require('./command-wrapper.js');
  * @constructor
  */
 function Section(options) {
-  this.parent = options.parent;
-  this.client = this.parent.client;
+  this.name = options.name;
 
   if(!options.selector) {
-    throw new Error('No selector property for section "' + options.name +
+    throw new Error('No selector property for section "' + this.name +
       '" Instead found properties: ' + Object.keys(options));
   }
 
-  this.name = options.name;
+  // selector properties
+  this.parent = options.parent;
   this.selector = options.selector;
-  this.locateStrategy = options.locateStrategy || 'css selector';
+  this.locateStrategy = options.locateStrategy;
+  this.index = options.index;
+
+  this.client = this.parent.client;
   this.api = this.parent.api;
   this.commandLoader = this.parent.commandLoader;
 

--- a/test/extra/pageobjects/simplePageObj.js
+++ b/test/extra/pageobjects/simplePageObj.js
@@ -9,6 +9,7 @@ module.exports = {
   elements: {
     loginAsString: '#weblogin',
     loginCss: { selector: '#weblogin' },
+    loginIndexed: { selector: '#weblogin', index: 1 },
     loginXpath: { selector: '//weblogin', locateStrategy: 'xpath' }
   },
   sections: {

--- a/test/src/api/protocol/testElementSelectors.js
+++ b/test/src/api/protocol/testElementSelectors.js
@@ -1,0 +1,731 @@
+var nock = require('nock');
+var path = require('path');
+var assert = require('assert');
+var MochaTest = require('../../../lib/mochatest.js');
+var Nightwatch = require('../../../lib/nightwatch.js');
+var common = require('../../../common.js');
+var Api = common.require('core/api.js');
+
+module.exports = MochaTest.add('test element selectors', {
+
+  beforeEach: function (done) {
+    Nightwatch.init({
+      page_objects_path: [path.join(__dirname, '../../../extra/pageobjects')]
+    }, done);
+  },
+
+  afterEach: function () {
+    nock.cleanAll();
+  },
+
+
+  'protocol.element(using, {selector})' : function(done) {
+    nocks
+      .elementFound()
+      .elementNotFound();
+
+    Nightwatch.api()
+      .element('css selector', '#nock', function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element for string selector');
+      })
+      .element('css selector', '#nock-none', function callback(result) {
+        assert.equal(result.status, -1, 'Not found for string selector');
+      })
+      .element('css selector', {selector: '#nock'}, function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element for selector property');
+      })
+      .element('css selector', {selector: '#nock-none'}, function callback(result) {
+        assert.equal(result.status, -1, 'Not found for selector property');
+      })
+      .perform(function() {
+        done(); // done here, not in start(), to make sure all commands complete without error
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.element(using, null)' : function(done) {
+    catchQueueError(function (err) {
+      var msg = 'Invalid selector value specified';
+      assert.equal(err.message, msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .element('css selector', null, function callback(result) {
+        assert.ok(false, 'Null selector object should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.element(using, {})' : function(done) {
+    catchQueueError(function (err) {
+      var msg = 'No selector property for element'; // ... rest of error, etc.
+      assert.equal(err.message.slice(0, msg.length), msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .element('css selector', {}, function callback(result) {
+        assert.ok(false, 'Empty selector object should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.element(using, {selector, locateStrategy})' : function(done) {
+    nocks.elementFound();
+
+    Nightwatch.api()
+      .element('css selector', {selector: '#nock', locateStrategy: 'css selector'}, function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element, same locateStrategy');
+      })
+      .element('xpath', {selector: '#nock', locateStrategy: 'css selector'}, function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element, overridden locateStrategy');
+      })
+      .element('css selector', {selector: '#nock', locateStrategy: null}, function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element, null locateStrategy');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.element(using, {locateStrategy})' : function(done) {
+    catchQueueError(function (err) {
+      var msg = 'No selector property for element';
+      assert.equal(err.message.slice(0, msg.length), msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .element('css selector', {locateStrategy: 'css selector'}, function callback(result) {
+        assert.ok(false, 'Selector with just locateStrategy should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.element(using, {locateStrategy=invalid})' : function(done) {
+    catchQueueError(function (err) {
+      var msg = 'Provided locating strategy is not supported';
+      assert.equal(err.message.slice(0, msg.length), msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .element('css selector', {selector: '.nock', locateStrategy: 'unsupported'}, function callback(result) {
+        assert.ok(false, 'Selector with invalid locateStrategy should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.element(using, {selector, index})' : function(done) {
+    nocks.elementFound();
+
+    Nightwatch.api()
+      .element('css selector', {selector: '#nock', index: 0}, function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element, 0 index ignored');
+      })
+      .element('css selector', {selector: '#nock', index: 1}, function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element, 1 index ignored');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.elements(using, {selector})' : function(done) {
+    nocks
+      .elementsFound()
+      .elementsNotFound();
+
+    Nightwatch.api()
+      .elements('css selector', '.nock', function callback(result) {
+        assert.equal(result.value[0].ELEMENT, '0', 'Found elements for string selector');
+      })
+      .elements('css selector', '.nock-none', function callback(result) {
+        assert.equal(result.status, 0, 'No error for string selector');
+        assert.equal(result.value.length, 0, 'No results for string selector');
+      })
+      .elements('css selector', {selector: '.nock'}, function callback(result) {
+        assert.equal(result.value[0].ELEMENT, '0', 'Found elements for selector property');
+      })
+      .elements('css selector', {selector: '.nock-none'}, function callback(result) {
+        assert.equal(result.status, 0, 'Not found for selector property');
+        assert.equal(result.value.length, 0, 'No results for selector property');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.elements(using, null)' : function(done) {
+    catchQueueError(function (err) {
+      var msg = 'Invalid selector value specified';
+      assert.equal(err.message, msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .elements('css selector', null, function callback(result) {
+        assert.ok(false, 'Null selector object should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.elements(using, {})' : function(done) {
+    catchQueueError(function (err) {
+      var msg = 'No selector property for element';
+      assert.equal(err.message.slice(0, msg.length), msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .elements('css selector', {}, function callback(result) {
+        assert.ok(false, 'Empty selector object should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.elements(using, {selector, locateStrategy})' : function(done) {
+    nocks
+      .elementsFound()
+      .elementsByTag();
+
+    Nightwatch.api()
+      .elements('css selector', {selector: '.nock', locateStrategy: 'css selector'}, function callback(result) {
+        assert.equal(result.value[0].ELEMENT, '0', 'Found element, same locateStrategy');
+      })
+      .elements('xpath', {selector: '.nock', locateStrategy: 'css selector'}, function callback(result) {
+        assert.equal(result.value[0].ELEMENT, '0', 'Found element, overridden locateStrategy');
+      })
+      .elements('xpath', {selector: 'nock', locateStrategy: 'tag name'}, function callback(result) {
+        assert.equal(result.value[0].ELEMENT, '0', 'Found element, by tag name');
+      })
+      .elements('css selector', {selector: '.nock', locateStrategy: null}, function callback(result) {
+        assert.equal(result.value[0].ELEMENT, '0', 'Found element, null locateStrategy');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.elements(using, {locateStrategy})' : function(done) {
+    catchQueueError(function (err) {
+      var msg = 'No selector property for element';
+      assert.equal(err.message.slice(0, msg.length), msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .elements('css selector', {locateStrategy: 'css selector'}, function callback(result) {
+        assert.ok(false, 'Selector with just locateStrategy should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.elements(using, {locateStrategy=invalid})' : function(done) {
+    catchQueueError(function (err) {
+      var msg = 'Provided locating strategy is not supported';
+      assert.equal(err.message.slice(0, msg.length), msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .elements('css selector', {selector: '.nock', locateStrategy: 'unsupported'}, function callback(result) {
+        assert.ok(false, 'Selector with invalid locateStrategy should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.elements(using, {selector, index})' : function(done) {
+    nocks.elementsFound();
+
+    Nightwatch.api()
+      .elements('css selector', {selector: '.nock', index: 0}, function callback(result) {
+        assert.equal(result.value.length, 1, 'found index, one element');
+        assert.equal(result.value[0].ELEMENT, '0', 'Found element 0');
+      })
+      .elements('css selector', {selector: '.nock', index: 1}, function callback(result) {
+        assert.equal(result.value.length, 1, 'found index, one element');
+        assert.equal(result.value[0].ELEMENT, '1', 'Found element 1');
+      })
+      .elements('css selector', {selector: '.nock', index: 2}, function callback(result) {
+        assert.equal(result.value.length, 1, 'found index, one element');
+        assert.equal(result.value[0].ELEMENT, '2', 'Found element 2');
+      })
+      .elements('css selector', {selector: '.nock', index: 999}, function callback(result) {
+        assert.equal(result.value.length, 3, 'Out of range index, keep elements query result');
+        assert.equal(result.status, -1, 'Not found for out of range index');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  // wrapped selenium command
+
+  'getText(<various>)' : function(done) {
+    nocks
+      .elementsFound()
+      .elementsNotFound()
+      .elementsByXpath()
+      .text(0, 'first')
+      .text(1, 'second');
+
+    Nightwatch.api()
+      .getText('.nock', function callback(result) {
+        assert.equal(result.value, 'first', 'getText string selector value');
+      })
+      .getText({selector: '.nock'}, function callback(result) {
+        assert.equal(result.value, 'first', 'getText selector property');
+      })
+      .getText({selector: '.nock-none'}, function callback(result) {
+        assert.equal(result.status, -1, 'getText not found status');
+        assert.equal(result.value.length, 0, 'No results for getText selector');
+      })
+      .getText({selector: '.nock', index: 1}, function callback(result) {
+        assert.equal(result.value, 'second', 'getText index 1');
+      })
+      .getText({selector: '//[@class="nock"]', locateStrategy: 'xpath'}, function callback(result) {
+        assert.equal(result.value, 'first', 'getText xpath locateStrategy');
+      })
+      .getText({selector: '//[@class="nock"]', locateStrategy: 'xpath', index: 1}, function callback(result) {
+        assert.equal(result.value, 'second', 'getText xpath locateStrategy index 1');
+      })
+      .getText({selector: '//[@class="nock"]', locateStrategy: 'xpath', index: 999}, function callback(result) {
+        assert.equal(result.status, -1, 'getText xpath locateStrategy out of range index');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'getText(<various>) locateStrategy' : function(done) {
+    nocks
+      .elementsFound()
+      .elementsNotFound()
+      .elementsByXpath()
+      .text(0, 'first')
+      .text(1, 'second');
+
+    Nightwatch.api()
+      .useCss()
+      .getText('.nock', function callback(result) {
+        assert.equal(result.value, 'first', 'getText string selector useCss');
+      })
+      .useXpath()
+      .getText('//[@class="nock"]', function callback(result) {
+        assert.equal(result.value, 'first', 'getText string selector useXpath');
+      })
+      .useCss()
+      .getText({selector: '//[@class="nock"]', locateStrategy: 'xpath'}, function callback(result) {
+        assert.equal(result.value, 'first', 'getText useCss override with xpath');
+      })
+      .getText('.nock', function callback(result) {
+        assert.equal(result.value, 'first', 'getText back to css after override with xpath');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  // custom command
+
+  'waitForElementPresent(<various>)' : function(done) {
+    nocks
+      .elementsFound()
+      .elementsNotFound()
+      .elementsByXpath();
+
+    Nightwatch.api()
+      .waitForElementPresent('.nock', 1, false, function callback(result) {
+        assert.equal(result.value.length, 3, 'waitforPresent result expected found');
+      })
+      .waitForElementPresent('.nock-none', 1, false, function callback(result) {
+        assert.equal(result.value, false, 'waitforPresent result expected false');
+      })
+      .waitForElementPresent({selector: '.nock'}, 1, false, function callback(result) {
+        assert.equal(result.value.length, 3, 'waitforPresent selector property result expected found');
+      })
+      .waitForElementPresent({selector: '.nock-none'}, 1, false, function callback(result) {
+        assert.equal(result.value, false, 'waitforPresent selector property result expected false');
+      })
+      .waitForElementPresent({selector: '.nock', index: 1}, 1, false, function callback(result) {
+        assert.equal(result.value.length, 1, 'waitforPresent index has results');
+        assert.equal(result.value[0].ELEMENT, '1', 'waitforPresent found element 1');
+      })
+      .waitForElementPresent({selector: '.nock', index: 999}, 1, false, function callback(result) {
+        assert.equal(result.value, false, 'waitforPresent out of bounds index expected false');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'waitForElementPresent(<various>) locateStrategy' : function(done) {
+    nocks
+      .elementsFound()
+      .elementsNotFound()
+      .elementsByXpath();
+
+    Nightwatch.api()
+      .useCss()
+      .waitForElementPresent('.nock', 1, false, function callback(result) {
+        assert.equal(result.value.length, 3, 'waitforPresent using css');
+      })
+      .useXpath()
+      .waitForElementPresent('//[@class="nock"]', 1, false, function callback(result) {
+        assert.equal(result.value.length, 3, 'waitforPresent using xpath');
+      })
+      .useCss()
+      .waitForElementPresent({selector: '//[@class="nock"]', locateStrategy: 'xpath'}, 1, false, function callback(result) {
+        assert.equal(result.value.length, 3, 'waitforPresent locateStrategy override to xpath found');
+      })
+      .waitForElementPresent({selector: '.nock', index: 1}, 1, false, function callback(result) {
+        assert.equal(result.value.length, 1, 'waitforPresent back to css index has results');
+        assert.equal(result.value[0].ELEMENT, '1', 'waitforPresent found element 1');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'page elements' : function(done) {
+    nocks
+      .elementsFound('#weblogin')
+      .elementsByXpath('//weblogin')
+      .elementsByXpath('#weblogin', [])
+      .text(0, 'first')
+      .text(1, 'second');
+
+    var client = Nightwatch.client();
+    Api.init(client);
+
+    var page = client.api.page.simplePageObj();
+
+    page
+      .getText('@loginAsString', function callback(result) {
+        assert.equal(result.status, 0, 'element selector string found');
+        assert.equal(result.value, 'first', 'element selector string value');
+      })
+      .getText({selector: '@loginAsString'}, function callback(result) {
+        assert.equal(result.status, 0, 'element selector property found');
+        assert.equal(result.value, 'first', 'element selector property value');
+      })
+      .getText('@loginXpath', function callback(result) {
+        assert.equal(result.status, 0, 'element selector xpath found');
+        assert.equal(result.value, 'first', 'element selector xpath value');
+      })
+      .getText('@loginCss', function callback(result) {
+        assert.equal(result.status, 0, 'element selector css found');
+        assert.equal(result.value, 'first', 'element selector css value');
+      })
+      .getText('@loginIndexed', function callback(result) {
+        assert.equal(result.status, 0, 'element indexed found');
+        assert.equal(result.value, 'second', 'element indexed value');
+      })
+      .getText({selector:'@loginIndexed', index:0}, function callback(result) {
+        assert.equal(result.status, 0, 'element indexed overridden found');
+        assert.equal(result.value, 'first', 'element indexed overridden value');
+      })
+      .getText({selector:'@loginCss', locateStrategy:'xpath'}, function callback(result) {
+        assert.equal(result.status, -1, 'element selector css xpath override not found');
+      })
+      .getText({selector:'@loginCss', index: 1}, function callback(result) {
+        assert.equal(result.status, 0, 'element selector index 1 found');
+        assert.equal(result.value, 'second', 'element selector index 1 value');
+      })
+      .getText({selector:'@loginCss', index: 999}, function callback(result) {
+        assert.equal(result.status, -1, 'element selector index out of bounds not found');
+      })
+      .api.perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'page section elements' : function(done) {
+    nocks
+      .elementsFound('#signupSection', [{ELEMENT: '0'}])
+      .elementsFound('#getStarted', [{ELEMENT: '0'}])
+      .elementsFound('#helpBtn')
+      .elementsId(0, '#helpBtn', [], 'xpath')
+      .elementsId(0, '#helpBtn')
+      .text(0, 'first')
+      .text(1, 'second');
+
+    var client = Nightwatch.client();
+    Api.init(client);
+
+    var page = client.api.page.simplePageObj();
+    var section = page.section.signUp;
+    var sectionChild = section.section.getStarted;
+
+    section
+      .getText('@help', function callback(result) {
+        assert.equal(result.status, 0, 'section element selector string found');
+        assert.equal(result.value, 'first', 'section element selector string value');
+      })
+      .getText({selector: '@help'}, function callback(result) {
+        assert.equal(result.status, 0, 'section element selector property found');
+        assert.equal(result.value, 'first', 'section element selector property value');
+      })
+      .getText({selector:'@help', locateStrategy:'xpath'}, function callback(result) {
+        assert.equal(result.status, -1, 'section element selector css xpath override not found');
+      })
+      .getText({selector:'@help', index: 1}, function callback(result) {
+        assert.equal(result.status, 0, 'section element selector index 1 found');
+        assert.equal(result.value, 'second', 'section element selector index 1 value');
+      })
+      .getText({selector:'@help', index: 999}, function callback(result) {
+        assert.equal(result.status, -1, 'section element selector index out of bounds not found');
+      });
+
+    sectionChild
+      .getText('#helpBtn', function callback(result) {
+        assert.equal(result.status, 0, 'child section element selector string found');
+        assert.equal(result.value, 'first', 'child section element selector string value');
+      })
+      .getText({selector: '#helpBtn'}, function callback(result) {
+        assert.equal(result.status, 0, 'child section element selector property found');
+        assert.equal(result.value, 'first', 'child section element selector property value');
+      })
+      .getText({selector:'#helpBtn', index: 1}, function callback(result) {
+        assert.equal(result.status, 0, 'child section element selector index 1 found');
+        assert.equal(result.value, 'second', 'child section element selector index 1 value');
+      })
+      .api.perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'expect selectors' : function (done) {
+    nocks
+      .elementsFound()
+      .elementsFound('#signupSection', [{ELEMENT: '0'}])
+      .elementsId(0, '#helpBtn', [{ELEMENT: '0'}])
+      .elementsByXpath();
+
+    var client = Nightwatch.client();
+    Api.init(client);
+    var api = client.api;
+    api.globals.abortOnAssertionFailure = false;
+
+    var page = api.page.simplePageObj();
+    var section = page.section.signUp;
+
+    var passes = [
+      api.expect.element('.nock').to.be.present.before(1),
+      api.expect.element({selector: '.nock'}).to.be.present.before(1),
+      api.expect.element({selector: '//[@class="nock"]', locateStrategy: 'xpath'}).to.be.present.before(1),
+      api.expect.element({selector: '.nock', index: 2}).to.be.present.before(1),
+      page.expect.section('@signUp').to.be.present.before(1),
+      page.expect.section({selector: '@signUp', locateStrategy: 'css selector'}).to.be.present.before(1),
+      section.expect.element('@help').to.be.present.before(1),
+      section.expect.element({selector: '@help', index: 0}).to.be.present.before(1)
+    ];
+
+    var fails = [
+      [api.expect.element({selector: '.nock', locateStrategy: 'xpath'}).to.be.present.before(1),
+        'element was not found'],
+      [api.expect.element({selector: '.nock', index: 999}).to.be.present.before(1),
+        'element was not found'],
+      [page.expect.section({selector: '@signUp', locateStrategy: 'xpath'}).to.be.present.before(1),
+        'element was not found'],
+      [section.expect.element({selector: '@help', index: 999}).to.be.present.before(1),
+        'element was not found']
+    ];
+
+    api.perform(function(performDone) {
+      process.nextTick(function(){ // keep assertions from being swallowed by perform
+
+        passes.forEach(function(expect, index) {
+          assert.equal(expect.assertion.passed, true, 'passing [' + index + ']: ' + expect.assertion.message);
+        });
+
+        fails.forEach(function(expectArr, index) {
+          var expect = expectArr[0];
+          var msgPartial = expectArr[1];
+
+          assert.equal(expect.assertion.passed, false, 'failing [' + index + ']: ' + expect.assertion.message);
+          assert.notEqual(expect.assertion.message.indexOf(msgPartial), -1, 'Message contains: ' + msgPartial);
+        });
+        
+        performDone();
+        done();
+
+      });
+    });
+
+    Nightwatch.start();
+  }
+
+});
+
+// internal nocks mappings (disambiguation between element/elements)
+
+var nocks = {
+
+  _requestUri: 'http://localhost:10195',
+  _protocolUri: '/wd/hub/session/1352110219202/',
+
+  elementFound : function(selector) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'element', {'using':'css selector','value':selector || '#nock'})
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: { ELEMENT: '0' }
+      });
+    return this;
+  },
+
+  elementNotFound : function(selector) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'element', {'using':'css selector','value':selector || '#nock-none'})
+      .reply(200, {
+        status: -1,
+        value: {},
+        errorStatus: 7,
+        error: 'An element could not be located on the page using the given search parameters.'
+      });
+    return this;
+  },
+
+  elementsFound : function(selector, foundArray) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'elements', {'using':'css selector','value':selector || '.nock'})
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: foundArray || [ { ELEMENT: '0' }, { ELEMENT: '1' }, { ELEMENT: '2' } ]
+      });
+    return this;
+  },
+
+  elementsNotFound : function(selector) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'elements', {'using':'css selector','value':selector || '.nock-none'})
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: []
+      });
+    return this;
+  },
+
+  elementsByTag : function(selector, foundArray) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'elements', {'using':'tag name','value':selector || 'nock'})
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: foundArray || [ { ELEMENT: '0' }, { ELEMENT: '1' }, { ELEMENT: '2' } ]
+      });
+    return this;
+  },
+
+  elementsByXpath : function(selector, foundArray) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'elements', {'using':'xpath','value':selector || '//[@class="nock"]'})
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: foundArray || [ { ELEMENT: '0' }, { ELEMENT: '1' }, { ELEMENT: '2' } ]
+      });
+    return this;
+  },
+
+  elementsId : function (id, selector, foundArray, using) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'element/' + (id || 0) + '/elements',
+        {'using':using || 'css selector','value':selector || '.nock'})
+      .reply(200, {
+        status: 0,
+        state : 'success',
+        value: foundArray || [ { ELEMENT: '0' }, { ELEMENT: '1' }, { ELEMENT: '2' } ]
+      });
+    return this;
+  },
+
+  text : function (id, value) {
+    nock(this._requestUri)
+      .persist()
+      .get(this._protocolUri + 'element/' + (id || 0) + '/text')
+      .reply(200, {
+        status: 0,
+        state : 'success',
+        value: value || 'textValue'
+      });
+    return this;
+  }
+};
+
+/**
+ * Monkey-patch run queue run() callbacks to capture errors handled
+ * in the queue after they are sent off to the nightwatch instance.
+ *
+ * @param {function} testCallback The callback used by the test to
+ * capture the error object
+ */
+function catchQueueError(testCallback) {
+  var queue = Nightwatch.client().queue;
+
+  // queue is a singleton, not re-instancing with new nightwatch
+  // instances. In order to re-patch it if patched previously, we
+  // restore the original run method from the patch if it exists
+  // (which may happen if a patched run never gets called with err)
+
+  if (queue.run.origRun) {
+    queue.run = queue.run.origRun;
+  }
+
+  function queueRunnerPatched (origCallback) {
+    origRun.call(queue, function(err) {
+      origCallback(err);
+      if (err) {
+        queue.run = origRun; // once, since errors are fatal to queue execution
+        testCallback(err);
+      }
+    });
+  }
+
+  var origRun = queueRunnerPatched.origRun = queue.run;
+  queue.run = queueRunnerPatched;
+}


### PR DESCRIPTION
Adds support for optional, object-based selector values in commands using the format used by page elements.  ex:

```js
// before:
browser.getText('#foo', function(result){});

// now (optionally):
browser.getText({selector:'#foo', locateStrategy:'css selector'}, function(result){});
```

A new `index` property has been added:

```js
// targets 3rd div in document
browser.getText({selector:'div', index:3}, function(result){});
```

Also works in page definitions

```js
module.exports = {
  commands: [],
  elements: {
    mydiv: {
      selector: 'div',
      index: 3
    }
  }
};
```

And the format can be used to override what the page element is using:


```js
page.getText('@mydiv', function(result){}); // 3rd div
page.getText({selector:'@mydiv', index:6}, function(result){}); // 6th div
```

Additionally:

- This new implementation reduces complexity around page command wrapping.  We no longer need to track and restore the locate strategy because its encoded directly within the selector; the callbacks are no longer wrapped.
- It opens the selector format up to being more dynamic, such as having additional properties that could potentially further mutate the resulting selector - not unlike with what other PRs/issues (e.g. #821) are doing/suggesting, trying to encode additional data in the selector string.  This is not doing it now, but it wouldn't be hard to add in.
- People can avoid complications with toggling between useCss() or useXpath() if they use locateStrategy directly in selectors as needed (css selector, or whatever the NW client has defined for it, is still the default). For example maybe you're writing a custom command using xpath but don't want it to interfere with the strategy being used before the command was used. Do you restore it with useCss()? How do you know it wasn't xpath already?

Everything should be fully backwards compatible.  Some error messaging will be slightly different, but nothing that should have an impact on existing workflows.  I tried to be pretty thorough with the tests, covering the situations I thought this would impact.  Documentation isn't there, but I figured not to bother unless this actually gets in.