### PR TITLE
#1152 - Updated selenium cli args for compatibility with selenium standalone server 3

### DIFF
--- a/lib/runner/selenium.js
+++ b/lib/runner/selenium.js
@@ -8,7 +8,6 @@ var util = require('util');
 var Logger = require('../util/logger.js');
 
 var SENTINEL = ['Started org.openqa.jetty.jetty.Server', 'INFO - Selenium Server is up and running'];
-var DEFAULT_HOST = '127.0.0.1';
 var DEFAULT_PORT = 4444;
 var DEFAULT_LOG_FILE = 'selenium-debug.log';
 
@@ -17,7 +16,7 @@ function SeleniumServer(settings, callback) {
   this.onStarted = callback;
 
   this.port = this.settings.selenium.port || DEFAULT_PORT;
-  this.host = this.settings.selenium.host || DEFAULT_HOST;
+  this.host = this.settings.selenium.host;
   this.output = '';
   this.error_out = '';
   this.process = null;
@@ -26,9 +25,11 @@ function SeleniumServer(settings, callback) {
 SeleniumServer.prototype.setCliArgs = function() {
   this.cliOpts = [
     '-jar', this.settings.selenium.server_path,
-    '-port', this.port,
-    '-host', this.host
+    '-port', this.port
   ];
+  if(this.host) {
+    this.cliOpts.push('-host', this.host);
+  }
   if (typeof this.settings.selenium.cli_args == 'object') {
     var cli_args = this.settings.selenium.cli_args;
     for (var keyName in cli_args) {
@@ -38,7 +39,7 @@ SeleniumServer.prototype.setCliArgs = function() {
           property += '-D';
         }
         property += keyName + '=' + cli_args[keyName];
-        this.cliOpts.push(property);
+        this.cliOpts.unshift(property);
       }
     }
   }

--- a/test/src/runner/testRunner.js
+++ b/test/src/runner/testRunner.js
@@ -241,6 +241,7 @@ module.exports = {
 
       var runner = new Runner([testsPath], {
         seleniumPort: 10195,
+        seleniumHost: '127.0.0.1',
         silent: true,
         output: false,
         persist_globals : true,

--- a/test/src/runner/testSelenium.js
+++ b/test/src/runner/testSelenium.js
@@ -61,8 +61,8 @@ module.exports = {
         }
       }, function(error, process) {
         assert.equal(process.command, 'java');
-        assert.deepEqual(process.args, ['-jar', './selenium.jar', '-port', 4444, '-host', '127.0.0.1', '-Dwebdriver.test.property=test', '-DpropName=1']);
-        assert.equal(process.host, '127.0.0.1');
+        assert.deepEqual(process.args, ['-DpropName=1', '-Dwebdriver.test.property=test', '-jar', './selenium.jar', '-port', 4444]);
+        assert.equal(process.host, undefined);
         assert.equal(process.port, 4444);
         assert.equal(error, null);
         done();


### PR DESCRIPTION
Removed default -host arg from runner, because selenium standalone server 3 does not recognise it, so it is not automatically added.

Moved -Dwebdriver cli args before -jar arg for compatibility with selenium standalone server 3