### PR TITLE
Element commands finding elments with elements instead of element

### DIFF
--- a/lib/api/element-commands.js
+++ b/lib/api/element-commands.js
@@ -340,8 +340,13 @@ module.exports = function(client) {
   function CommandAction(using, value, protocolAction, args, callback, originalStackTrace) {
     events.EventEmitter.call(this);
 
-    var $this = this;
-    var el = Protocol.element(using, value, function(result) {
+    var self = this;
+    var el = Protocol.elements(using, value, function(result) {
+
+      if (result.status === 0 && result.value.length === 0) {
+        result.status = -1;
+      }
+
       if (result.status !== 0) {
         callback.call(client.api, result);
         var errorMessage = 'ERROR: Unable to locate element: "' + value + '" using: ' + using;
@@ -353,9 +358,9 @@ module.exports = function(client) {
         client.results.errors++;
         client.errors.push(errorMessage + '\n' + stack.join('\n'));
 
-        $this.emit('complete', el, $this);
+        self.emit('complete', el, self);
       } else {
-        result = result.value.ELEMENT;
+        result = result.value[0].ELEMENT;
 
         args.push(function(r) {
           callback.call(client.api, r);
@@ -364,7 +369,7 @@ module.exports = function(client) {
         args.unshift(result);
 
         var c = Protocol[protocolAction].apply(Protocol, args).once('complete', function() {
-          $this.emit('complete', c, $this);
+          self.emit('complete', c, self);
         });
       }
     });

--- a/lib/api/element-commands/_waitForElement.js
+++ b/lib/api/element-commands/_waitForElement.js
@@ -204,7 +204,7 @@ WaitForElement.prototype.checkElement = function() {
   this.getProtocolCommand(function(result) {
     var now = new Date().getTime();
 
-    if (result.value && result.value.length > 0) {
+    if (result.status === 0 && result.value && result.value.length > 0) {
       if (result.value.length > 1) {
         var message = 'WaitForElement found ' + result.value.length + ' elements for selector "' + self.selector + '".';
         if (self.throwOnMultipleElementsReturned) {


### PR DESCRIPTION
Partial of #1116 (1 of 4)

This changes the initial element search command used by element commands to use `elements()` instead of `element()`.  This means the full list of selector-matching elements are returned rather than just the first.  This allows for the potential of additional filtering on those results rather than being limited to only the one. 