### PR TITLE
Expands capabilities of Element object; Sections inherit from Element

### DIFF
--- a/lib/page-object/element.js
+++ b/lib/page-object/element.js
@@ -113,7 +113,7 @@ Element.fromSelector = function(value, using) {
     locateStrategy : using
   };
 
-  if (using !== 'recursion' && value && typeof value === 'object') {
+  if (using !== 'recursion' && typeof value === 'object') {
     definition.selector = value.selector;
     if (value.locateStrategy) {
       definition.locateStrategy = value.locateStrategy;

--- a/lib/page-object/element.js
+++ b/lib/page-object/element.js
@@ -2,7 +2,7 @@
  * Class that all elements subclass from.
  *
  * @param {Object} definition User-defined element options defined in page object.
- * @param {Object} options Additional options to be given to the element.
+ * @param {Object} [options] Additional options to be given to the element.
  * @constructor
  */
 function Element(definition, options) {
@@ -11,7 +11,8 @@ function Element(definition, options) {
   this.name = options.name;
 
   if (!definition.selector) {
-    throw new Error('No selector property for ' + this.constructor.name.toLowerCase() + ' "' + getName(this) +
+    var classType = this.constructor.name.toLowerCase(); // Element, Section or any other subclass's name
+    throw new Error('No selector property for ' + classType + ' "' + getName(this) +
       '". Instead found properties: ' +
       Object
         .keys(definition)
@@ -26,15 +27,19 @@ function Element(definition, options) {
 }
 
 Element.prototype.toString = function() {
-  if (Array.isArray(this.selector)) {
+  if (Array.isArray(this.selector)) { // recursive
     return this.selector.join(',');
   }
+  if (!this.name) { // inline (not defined in page or section)
+    return this.selector;
+  }
+  var classType = this.constructor.name;
   var prefix = this.constructor === Element ? '@' : '';
-  return this.constructor.name + '[name=' + prefix + getName(this) + ']';
+  return classType + '[name=' + prefix + getName(this) + ']';
 };
 
 /**
- * Determines whether or not the element contians an @ element reference
+ * Determines whether or not the element contains an @ element reference
  * for its selector.
  *
  * @returns {boolean} True if the selector is an element reference starting with an
@@ -103,27 +108,17 @@ Element.fromSelector = function(value, using) {
     return value;
   }
 
-  if (using === 'recursion') {
-    return new Element({
-      selector: value,
-      locateStrategy: 'recursion'
-    });
-  }
+  var definition = {
+    selector : value,
+    locateStrategy : using
+  };
 
-  var definition = {};
-
-  if (value && typeof value === 'object') {
-
+  if (using !== 'recursion' && value && typeof value === 'object') {
     definition.selector = value.selector;
-    if ('locateStrategy' in value) {
+    if (value.locateStrategy) {
       definition.locateStrategy = value.locateStrategy;
     }
-
-  } else {
-    definition.selector = value;
   }
-
-  definition.locateStrategy = definition.locateStrategy || using;
 
   return new Element(definition);
 };

--- a/lib/page-object/element.js
+++ b/lib/page-object/element.js
@@ -1,24 +1,169 @@
 /**
- * Class that all elements subclass from
+ * Class that all elements subclass from.
  *
- * @param {Object} options Element options defined in page object
+ * @param {Object} definition User-defined element options defined in page object.
+ * @param {Object} options Additional options to be given to the element.
  * @constructor
  */
-function Element(options) {
-  this.parent = options.parent;
-
-  if (!options.selector) {
-    throw new Error('No selector property for element "' + options.name +
-      '" Instead found properties: ' + Object.keys(options));
-  }
+function Element(definition, options) {
+  options = options || {};
 
   this.name = options.name;
-  this.selector = options.selector;
-  this.locateStrategy = options.locateStrategy || 'css selector';
+
+  if (!definition.selector) {
+    throw new Error('No selector property for ' + this.constructor.name.toLowerCase() + ' "' + getName(this) +
+      '". Instead found properties: ' +
+      Object
+        .keys(definition)
+        .filter(hasValidValueIn(definition))
+        .join(', ')
+    );
+  }
+
+  this.selector = definition.selector;
+  this.locateStrategy = definition.locateStrategy || options.locateStrategy;
+  this.parent = options.parent;
 }
 
 Element.prototype.toString = function() {
-  return 'Element[name=@' + this.name + ']';
+  if (Array.isArray(this.selector)) {
+    return this.selector.join(',');
+  }
+  var prefix = this.constructor === Element ? '@' : '';
+  return this.constructor.name + '[name=' + prefix + getName(this) + ']';
 };
+
+/**
+ * Determines whether or not the element contians an @ element reference
+ * for its selector.
+ *
+ * @returns {boolean} True if the selector is an element reference starting with an
+ *    @ symbol, false if it does not.
+ */
+Element.prototype.hasElementSelector = function() {
+  return String(this.selector)[0] === '@';
+};
+
+/**
+ * If the element object requires a recursive lookup to resolve its
+ * selector, a new element containing the recursive lookup values
+ * is created and returned.
+ *
+ * @returns {Object} A new Element object containing the element and its
+ *    parents with a recursive lookup strategy for resolving the element
+ *    if one is needed. If not, null is returned.
+ */
+Element.prototype.getRecursiveLookupElement = function () {
+  var lookupList = getAncestorsWithElement(this);
+
+  if (lookupList.length > 1) {
+    return new Element({
+      selector: lookupList,
+      locateStrategy: 'recursion'
+    });
+  }
+
+  return null;
+};
+
+/**
+ * Copies selector properties to the first object from the second if the first
+ * object has undefined values for any of those properties.
+ *
+ * @param {Object} target The object to assign values to.
+ * @param {Object} source The object to capture values from.
+ */
+Element.copyDefaults = function(target, source) {
+  var props = ['name', 'parent', 'selector', 'locateStrategy'];
+  props.forEach(function(prop) {
+    if (target[prop] === undefined || target[prop] === null) {
+      target[prop] = source[prop];
+    }
+  });
+};
+
+/**
+ * Parses the value/selector parameter of an element command creating a
+ * new Element instance with the values it contains, if any. The standard
+ * format for this is a selector string, but additional, complex formats
+ * in the form of an array or object are also supported.
+ *
+ * @param {string|Object} value Selector value to parse into an Element.
+ * @param {string} [using] The using/locateStrategy to use if the selector
+ *    doesn't provide one of its own.
+ */
+Element.fromSelector = function(value, using) {
+
+  if (!value) {
+    throw new Error('Invalid selector value specified');
+  }
+
+  if (value instanceof Element) {
+    value.locateStrategy = value.locateStrategy || using;
+    return value;
+  }
+
+  if (using === 'recursion') {
+    return new Element({
+      selector: value,
+      locateStrategy: 'recursion'
+    });
+  }
+
+  var definition = {};
+
+  if (value && typeof value === 'object') {
+
+    definition.selector = value.selector;
+    if ('locateStrategy' in value) {
+      definition.locateStrategy = value.locateStrategy;
+    }
+
+  } else {
+    definition.selector = value;
+  }
+
+  definition.locateStrategy = definition.locateStrategy || using;
+
+  return new Element(definition);
+};
+
+/**
+ * Gets the name of an element instance using "(anonymous)"
+ * if a name was not defined - the case when the element was
+ * created anonymously for a command rather than being a
+ * named element in a page or section definition.
+ */
+function getName(instance) {
+  return instance.name || '(anonymous)';
+}
+
+/**
+ * Array filter method removing elements that may be defined (in) but
+ * do not have a recognizable value.
+ */
+function hasValidValueIn (definition) {
+  return function(key) {
+    return definition[key] !== undefined && definition[key] !== null;
+  };
+}
+
+/**
+ * Retrieves an array of ancestors of the supplied element. The last element in the array is the element object itself
+ *
+ * @param {Object} element The element
+ * @returns {Array}
+ */
+function getAncestorsWithElement(element) {
+  var elements = [];
+  function addElement(e) {
+    elements.unshift(e);
+    if (e.parent && e.parent.selector) {
+      addElement(e.parent);
+    }
+  }
+  addElement(element);
+  return elements;
+}
 
 module.exports = Element;

--- a/lib/page-object/page-utils.js
+++ b/lib/page-object/page-utils.js
@@ -25,18 +25,22 @@ module.exports = new (function() {
   this.createElements = function(parent, elements) {
     var Element = require('./element.js');
     var elementObjects = {};
-    var el;
+    var definition;
+    var options;
 
     if (!Array.isArray(elements)) {
       elements = [elements];
     }
 
     elements.forEach(function(els) {
-      Object.keys(els).forEach(function(e) {
-        el = typeof els[e] === 'string' ? { selector: els[e] } : els[e];
-        el.parent = parent;
-        el.name = e;
-        elementObjects[el.name] = new Element(el);
+      Object.keys(els).forEach(function(name) {
+        definition = typeof els[name] === 'string' ? { selector: els[name] } : els[name];
+        options = {
+          name: name,
+          parent: parent,
+          locateStrategy: 'css selector'
+        };
+        elementObjects[name] = new Element(definition, options);
       });
     });
 
@@ -56,13 +60,17 @@ module.exports = new (function() {
   this.createSections = function(parent, sections) {
     var Section = require('./section.js');
     var sectionObjects = {};
-    var sec;
+    var definition;
+    var options;
 
-    Object.keys(sections).forEach(function(s) {
-      sec = sections[s];
-      sec.parent = parent;
-      sec.name = s;
-      sectionObjects[sec.name] = new Section(sec);
+    Object.keys(sections).forEach(function(name) {
+      definition = sections[name];
+      options = {
+        name: name,
+        parent: parent,
+        locateStrategy: 'css selector'
+      };
+      sectionObjects[name] = new Section(definition, options);
     });
 
     parent.section = sectionObjects;

--- a/lib/page-object/section.js
+++ b/lib/page-object/section.js
@@ -1,38 +1,31 @@
+var util = require('util');
+var Element = require('./element.js');
 var PageUtils = require('./page-utils.js');
 var CommandWrapper = require('./command-wrapper.js');
 
 /**
  * Class that all sections subclass from
  *
- * @param {Object} options Section options defined in page object
+ * @param {Object} definition User-defined section options defined in page object
+ * @param {Object} options Additional options to be given to the element.
  * @constructor
  */
-function Section(options) {
-  this.parent = options.parent;
+function Section(definition, options) {
+  Element.call(this, definition, options);
+
   this.client = this.parent.client;
-
-  if(!options.selector) {
-    throw new Error('No selector property for section "' + options.name +
-      '" Instead found properties: ' + Object.keys(options));
-  }
-
-  this.name = options.name;
-  this.selector = options.selector;
-  this.locateStrategy = options.locateStrategy || 'css selector';
   this.api = this.parent.api;
   this.commandLoader = this.parent.commandLoader;
 
   PageUtils
-    .createProps(this, options.props || {})
-    .createElements(this, options.elements || {})
-    .createSections(this, options.sections || {})
-    .addCommands(this, options.commands || []);
+    .createProps(this, definition.props || {})
+    .createElements(this, definition.elements || {})
+    .createSections(this, definition.sections || {})
+    .addCommands(this, definition.commands || []);
 
   CommandWrapper.addWrappedCommands(this, this.commandLoader);
 }
 
-Section.prototype.toString = function() {
-  return 'Section[name=' + this.name + ']';
-};
+util.inherits(Section, Element);
 
 module.exports = Section;


### PR DESCRIPTION
Partial of #1116 (2 of 4) 
_this is not dependent on 1 of 4, but the remaining are dependent on each other_

Refactoring the Element class to include some additional methods for working with and creating elements (not used just yet).  This also includes having Section inherit from Element as it also uses the same selector API and can also be targeted with @-element references (e.g. `google.expect.section('@menu').to.be.visible;`)

Note: 
- https://github.com/senocular/nightwatch/blob/element-section-refactor/lib/page-object/page-utils.js#L41
- https://github.com/senocular/nightwatch/blob/element-section-refactor/lib/page-object/page-utils.js#L71

represent defaults for the locate strategy. As per #759, if that test setting represents a global default, then that would need to be saved somewhere persistent and then get referenced here to be applied as the default rather than using `css selector`.  Currently `use_xpath` only sets the initial client strategy.  Grepping the code for instances of "css selector" would identify these places if/when that gets changed.