### PR TITLE
Add support for page object-formatted object-based selectors

### DIFF
--- a/lib/api/element-commands.js
+++ b/lib/api/element-commands.js
@@ -2,6 +2,7 @@ var util = require('util');
 var events = require('events');
 var Logger = require('../util/logger.js');
 var Utils = require('../util/utils.js');
+var Element = require('../page-object/element.js');
 
 module.exports = function(client) {
   var Protocol = require('./protocol.js')(client);
@@ -344,7 +345,9 @@ module.exports = function(client) {
     var el = Protocol.element(using, value, function(result) {
       if (result.status !== 0) {
         callback.call(client.api, result);
-        var errorMessage = 'ERROR: Unable to locate element: "' + value + '" using: ' + using;
+
+        var elem = Element.fromSelector(value, using);
+        var errorMessage = 'ERROR: Unable to locate element: "' + elem.selector + '" using: "' + elem.locateStrategy + '"';
         var stack = originalStackTrace.split('\n');
 
         stack.shift();

--- a/lib/api/element-commands/_elementByRecursion.js
+++ b/lib/api/element-commands/_elementByRecursion.js
@@ -21,7 +21,7 @@ ElementByRecursion.prototype.command = function(elements, callback) {
   var allElements = elements.slice();
 
   var topElement = allElements.shift();
-  var el = this.protocol.element(topElement.locateStrategy, topElement.selector, function checkResult(result) {
+  var el = this.protocol.element(null, topElement, function checkResult(result) {
     if (result.status !== 0) {
       callback(result);
       self.emit('complete', el, self);
@@ -29,7 +29,7 @@ ElementByRecursion.prototype.command = function(elements, callback) {
       var nextElement = allElements.shift();
       var parentId = result.value.ELEMENT;
       if (nextElement) {
-        self.protocol.elementIdElement(parentId, nextElement.locateStrategy, nextElement.selector, checkResult);
+        self.protocol.elementIdElement(parentId, null, nextElement, checkResult);
       } else {
         callback(result);
         self.emit('complete', el, self);

--- a/lib/api/element-commands/_elementsByRecursion.js
+++ b/lib/api/element-commands/_elementsByRecursion.js
@@ -65,7 +65,7 @@ ElementsByRecursion.prototype.command = function(elements, callback) {
   var allElements = elements.slice();
   var topElement = allElements.shift();
 
-  var el = this.protocol.elements(topElement.locateStrategy, topElement.selector, function checkResult() {
+  var el = this.protocol.elements(null, topElement, function checkResult() {
     var result = aggregateResults(arguments);
     if (result.value.length === 0) {
       callback(result);
@@ -77,7 +77,7 @@ ElementsByRecursion.prototype.command = function(elements, callback) {
     if (nextElement) {
       var promises = [];
       result.value.forEach(function(el) {
-        var p = deferredElementIdElements(el.ELEMENT, nextElement.locateStrategy, nextElement.selector, checkResult);
+        var p = deferredElementIdElements(el.ELEMENT, null, nextElement, checkResult);
         promises.push(p);
       });
 

--- a/lib/api/expect/_baseAssertion.js
+++ b/lib/api/expect/_baseAssertion.js
@@ -208,7 +208,13 @@ BaseAssertion.prototype.scheduleRetry = function() {
 };
 
 BaseAssertion.prototype.formatMessage = function() {
-  this.message = Utils.format(this.message || this.message, this.selector);
+
+  var selectorStr = String(this.selector);
+  if (selectorStr === '[object Object]') {
+    selectorStr = JSON.stringify(this.selector);
+  }
+
+  this.message = Utils.format(this.message, selectorStr);
   this.message += this.messageParts.join('');
 };
 

--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -1,5 +1,6 @@
 var elementByRecursion = require('./element-commands/_elementByRecursion.js');
 var elementsByRecursion = require('./element-commands/_elementsByRecursion.js');
+var Element = require('../page-object/element.js');
 
 module.exports = function(Nightwatch) {
 
@@ -164,11 +165,12 @@ module.exports = function(Nightwatch) {
    * @api protocol
    */
   Actions.element = function(using, value, callback) {
-    if (using == 'recursion') {
-      return new elementByRecursion(Nightwatch).command(value, callback);
+    var elem = Element.fromSelector(value, using);
+    if (elem.locateStrategy == 'recursion') {
+      return new elementByRecursion(Nightwatch).command(elem.selector, callback);
     }
 
-    return element(using, value, callback);
+    return element(elem, callback);
   };
 
   /*!
@@ -179,20 +181,12 @@ module.exports = function(Nightwatch) {
    * @param {function} callback
    * @private
    */
-  function element(using, value, callback) {
-    var strategies = ['class name', 'css selector', 'id', 'name', 'link text',
-      'partial link text', 'tag name', 'xpath'];
-    using = using.toLocaleLowerCase();
-
-    if (strategies.indexOf(using) === -1) {
-      throw new Error('Provided locating strategy is not supported: ' +
-        using + '. It must be one of the following:\n' +
-        strategies.join(', '));
-    }
+  function element(elem, callback) {
+    validateStrategy(elem.locateStrategy);
 
     return postRequest('/element', {
-      using: using,
-      value: value
+      using: elem.locateStrategy,
+      value: elem.selector
     }, callback);
   }
 
@@ -207,19 +201,12 @@ module.exports = function(Nightwatch) {
    * @api protocol
    */
   Actions.elementIdElement = function(id, using, value, callback) {
-    var strategies = ['class name', 'css selector', 'id', 'name', 'link text',
-      'partial link text', 'tag name', 'xpath'];
-    using = using.toLocaleLowerCase();
-
-    if (strategies.indexOf(using) === -1) {
-      throw new Error('Provided locating strategy is not supported: ' +
-        using + '. It must be one of the following:\n' +
-        strategies.join(', '));
-    }
+    var elem = Element.fromSelector(value, using);
+    validateStrategy(elem.locateStrategy);
 
     return postRequest('/element/' + id + '/element', {
-      using: using,
-      value: value
+      using: elem.locateStrategy,
+      value: elem.selector
     }, callback);
   };
 
@@ -234,11 +221,12 @@ module.exports = function(Nightwatch) {
    * @api protocol
    */
   Actions.elements = function(using, value, callback) {
-    if (using == 'recursion') {
-      return new elementsByRecursion(Nightwatch).command(value, callback);
+    var elem = Element.fromSelector(value, using);
+    if (elem.locateStrategy == 'recursion') {
+      return new elementsByRecursion(Nightwatch).command(elem.selector, callback);
     }
 
-    return elements(using, value, callback);
+    return elements(elem, callback);
   };
 
   /*!
@@ -249,17 +237,14 @@ module.exports = function(Nightwatch) {
    * @param {function} callback
    * @private
    */
-  function elements(using, value, callback) {
-    var check = /class name|css selector|id|name|link text|partial link text|tag name|xpath/gi;
-    if (!check.test(using)) {
-      throw new Error('Please provide any of the following using strings as the first parameter: ' +
-        'class name, css selector, id, name, link text, partial link text, tag name, or xpath. Given: ' + using);
-    }
+  function elements(elem, callback) {
+    validateStrategy(elem.locateStrategy);
 
     return postRequest('/elements', {
-      using: using,
-      value: value
-    }, callback);
+        using: elem.locateStrategy,
+        value: elem.selector
+      }, callback
+    );
   }
 
   /**
@@ -273,21 +258,28 @@ module.exports = function(Nightwatch) {
    * @api protocol
    */
   Actions.elementIdElements = function(id, using, value, callback) {
+    var elem = Element.fromSelector(value, using);
+    validateStrategy(elem.locateStrategy);
+
+    return postRequest('/element/' + id + '/elements', {
+        using: elem.locateStrategy,
+        value: elem.selector
+      }, callback
+    );
+  };
+
+  function validateStrategy(using) {
+
+    var usingLow = String(using).toLocaleLowerCase();
     var strategies = ['class name', 'css selector', 'id', 'name', 'link text',
       'partial link text', 'tag name', 'xpath'];
-    using = using.toLocaleLowerCase();
 
-    if (strategies.indexOf(using) === -1) {
+    if (strategies.indexOf(usingLow) === -1) {
       throw new Error('Provided locating strategy is not supported: ' +
         using + '. It must be one of the following:\n' +
         strategies.join(', '));
     }
-
-    return postRequest('/element/' + id + '/elements', {
-      using: using,
-      value: value
-    }, callback);
-  };
+  }
 
   /**
    * Get the element on the page that currently has focus.

--- a/lib/page-object/command-wrapper.js
+++ b/lib/page-object/command-wrapper.js
@@ -1,3 +1,5 @@
+var Element = require('./element.js');
+
 module.exports = new (function() {
 
   /**
@@ -33,27 +35,6 @@ module.exports = new (function() {
   }
 
   /**
-   * Calls use(Css|Xpath|Recursion) command
-   *
-   * Uses `useXpath`, `useCss`, and `useRecursion` commands.
-   *
-   * @param {Object} client The Nightwatch instance
-   * @param {string} desiredStrategy (css selector|xpath|recursion)
-   * @returns {null}
-   */
-  function setLocateStrategy(client, desiredStrategy) {
-    var methodMap = {
-      xpath : 'useXpath',
-      'css selector' : 'useCss',
-      recursion : 'useRecursion'
-    };
-
-    if (desiredStrategy in methodMap) {
-      client.api[methodMap[desiredStrategy]]();
-    }
-  }
-
-  /**
    * Creates a closure that enables calling commands and assertions on the page or section.
    * For all element commands and assertions, it fetches element's selector and locate strategy
    *  For elements nested under sections, it sets 'recursion' as the locate strategy and passes as its first argument to the command an array of its ancestors + self
@@ -66,119 +47,43 @@ module.exports = new (function() {
    * @returns {function}
    */
   function makeWrappedCommand(parent, commandFn, commandName, isChaiAssertion) {
+
+    var isSectionSelector = isChaiAssertion && commandName === 'section';
+
     return function() {
       var args = Array.prototype.slice.call(arguments);
-      var prevLocateStrategy = parent.client.locateStrategy;
-      var elementCommand = isElementCommand(args);
-
-      if (elementCommand) {
-        var firstArg;
-        var desiredStrategy;
-        var callbackIndex;
-        var originalCallback;
-        var elementOrSectionName = args.shift();
-        var getter = (isChaiAssertion && commandName === 'section') ? getSection : getElement;
-        var elementOrSection = getter(parent, elementOrSectionName);
-        var ancestors = getAncestorsWithElement(elementOrSection);
-
-        if (ancestors.length === 1) {
-          firstArg = elementOrSection.selector;
-          desiredStrategy = elementOrSection.locateStrategy;
-        } else {
-          firstArg = ancestors;
-          desiredStrategy = 'recursion';
-        }
-
-        setLocateStrategy(parent.client, desiredStrategy);
-        args.unshift(firstArg);
-
-        // if a callback is being used with this command, wrap it in
-        // a function that allows us to restore the locate strategy
-        // to its original value before the callback is called
-
-        callbackIndex = findCallbackIndex(args);
-        if (callbackIndex !== -1) {
-          originalCallback = args[callbackIndex];
-
-          args[callbackIndex] = function callbackWrapper() {
-
-            // restore the locate strategy directly through client.locateStrategy.
-            // setLocateStrategy() can't be used since it uses the api commands
-            // which get added to the command queue and will not update the
-            // strategy in time for the callback which is getting immediately
-            // called after
-
-            parent.client.locateStrategy = prevLocateStrategy;
-            return originalCallback.apply(parent.client.api, arguments);
-          };
-        }
-      }
-
-      var c = commandFn.apply(parent.client, args);
-      if (elementCommand) {
-        setLocateStrategy(parent.client, prevLocateStrategy);
-      }
-      return (isChaiAssertion ? c : parent);
+      parseElementSelector(args, parent, isSectionSelector);
+      var result = commandFn.apply(parent.client, args);
+      return isChaiAssertion ? result : parent;
     };
   }
 
   /**
+   * Identifies element references (@-prefixed selectors) within an argument
+   * list and converts it into an element object with the appropriate
+   * selector or recursion chain of selectors.
    *
-   * @param {Array} args
-   * @return {boolean}
+   * @param {Array} args The argument list to check for an element selector.
+   * @param {Object} parent The parent page or section.
+   * @param {boolean} isSectionSelector When true, indicates that the selector references
+   *    a selector within a section rather than an elements definition.
    */
-  function isElementCommand(args) {
-    return (args.length > 0) && (args[0].toString().indexOf('@') === 0);
-  }
+  function parseElementSelector (args, parent, isSectionSelector) {
 
-  /**
-   * Identifies the location of a callback function within an arguments array.
-   *
-   * @param {Array} args Arguments array in which to find the location of a callback.
-   * @returns {number} Index location of the callback in the args array. If not found, -1 is returned.
-   */
-  function findCallbackIndex(args) {
+    // currently only support first argument for @-elements
+    var possibleElementSelector = args[0];
+    var inputElement = possibleElementSelector && Element.fromSelector(possibleElementSelector);
+    if (inputElement && inputElement.hasElementSelector()) {
 
-    if (args.length === 0) {
-      return -1;
+      var getter = isSectionSelector ? getSection : getElement;
+      var elementOrSection = getter(parent, inputElement.selector);
+
+      Element.copyDefaults(inputElement, elementOrSection);
+      inputElement.selector = elementOrSection.selector; // force replacement of @-selector
+
+      inputElement = inputElement.getRecursiveLookupElement() || inputElement;
+      args[0] = inputElement;
     }
-
-    // callbacks will usually be the last argument. waitFor methods allow an additional
-    // message argument to follow the callback which will also need to be checked for.
-
-    // last argument
-
-    var index = args.length - 1;
-    if (typeof args[index] === 'function') {
-      return index;
-    }
-
-    // second to last argument (waitfor calls)
-
-    index--;
-    if (typeof args[index] === 'function') {
-      return index;
-    }
-
-    return -1;
-  }
-
-  /**
-   * Retrieves an array of ancestors of the supplied element. The last element in the array is the element object itself
-   *
-   * @param {Object} element The element
-   * @returns {Array}
-   */
-  function getAncestorsWithElement(element) {
-    var elements = [];
-    function addElement(e) {
-      elements.unshift(e);
-      if (e.parent && e.parent.selector) {
-        addElement(e.parent);
-      }
-    }
-    addElement(element);
-    return elements;
   }
 
   /**

--- a/lib/page-object/element.js
+++ b/lib/page-object/element.js
@@ -1,24 +1,163 @@
 /**
- * Class that all elements subclass from
+ * Class that all elements subclass from.
  *
- * @param {Object} options Element options defined in page object
+ * @param {Object} definition User-defined element options defined in page object.
+ * @param {Object} [options] Additional options to be given to the element.
  * @constructor
  */
-function Element(options) {
-  this.parent = options.parent;
-
-  if (!options.selector) {
-    throw new Error('No selector property for element "' + options.name +
-      '" Instead found properties: ' + Object.keys(options));
-  }
+function Element(definition, options) {
+  options = options || {};
 
   this.name = options.name;
-  this.selector = options.selector;
-  this.locateStrategy = options.locateStrategy || 'css selector';
+
+  if (!definition.selector) {
+    throw new Error('No selector property for ' + getDescription(this) +
+      '. Instead found properties: ' +
+      Object
+        .keys(definition)
+        .filter(hasValidValueIn(definition))
+        .join(', ')
+    );
+  }
+
+  this.selector = definition.selector;
+  this.locateStrategy = definition.locateStrategy || options.locateStrategy;
+  this.parent = options.parent;
 }
 
 Element.prototype.toString = function() {
-  return 'Element[name=@' + this.name + ']';
+  if (Array.isArray(this.selector)) { // recursive
+    return this.selector.join(',');
+  }
+  if (!this.name) { // inline (not defined in page or section)
+    return this.selector;
+  }
+  var classType = this.constructor.name;
+  var prefix = this.constructor === Element ? '@' : '';
+  return classType + '[name=' + prefix + this.name + ']';
 };
+
+/**
+ * Determines whether or not the element contains an @ element reference
+ * for its selector.
+ *
+ * @returns {boolean} True if the selector is an element reference starting with an
+ *    @ symbol, false if it does not.
+ */
+Element.prototype.hasElementSelector = function() {
+  return String(this.selector)[0] === '@';
+};
+
+/**
+ * If the element object requires a recursive lookup to resolve its
+ * selector, a new element containing the recursive lookup values
+ * is created and returned.
+ *
+ * @returns {Object} A new Element object containing the element and its
+ *    parents with a recursive lookup strategy for resolving the element
+ *    if one is needed. If not, null is returned.
+ */
+Element.prototype.getRecursiveLookupElement = function () {
+  var lookupList = getAncestorsWithElement(this);
+
+  if (lookupList.length > 1) {
+    return new Element({
+      selector: lookupList,
+      locateStrategy: 'recursion'
+    });
+  }
+
+  return null;
+};
+
+/**
+ * Copies selector properties to the first object from the second if the first
+ * object has undefined values for any of those properties.
+ *
+ * @param {Object} target The object to assign values to.
+ * @param {Object} source The object to capture values from.
+ */
+Element.copyDefaults = function(target, source) {
+  var props = ['name', 'parent', 'selector', 'locateStrategy'];
+  props.forEach(function(prop) {
+    if (target[prop] === undefined || target[prop] === null) {
+      target[prop] = source[prop];
+    }
+  });
+};
+
+/**
+ * Parses the value/selector parameter of an element command creating a
+ * new Element instance with the values it contains, if any. The standard
+ * format for this is a selector string, but additional, complex formats
+ * in the form of an array or object are also supported.
+ *
+ * @param {string|Object} value Selector value to parse into an Element.
+ * @param {string} [using] The using/locateStrategy to use if the selector
+ *    doesn't provide one of its own.
+ */
+Element.fromSelector = function(value, using) {
+
+  if (!value) {
+    throw new Error('Invalid selector value specified');
+  }
+
+  if (value instanceof Element) {
+    value.locateStrategy = value.locateStrategy || using;
+    return value;
+  }
+
+  var definition;
+  var options = { locateStrategy: using };
+
+  if (using !== 'recursion' && typeof value === 'object') {
+    definition = value;
+  } else {
+    definition = { selector : value };
+  }
+
+  return new Element(definition, options);
+};
+
+/**
+ * Gets a simple description of the element based on whether or not
+ * it is used as an inline selector in a command call or a definition
+ * within a page object or section.
+ */
+function getDescription(instance) {
+  if (instance.name) {
+    var classType = instance.constructor.name.toLowerCase(); // Element, Section or any other subclass's name
+    return classType + ' "' + instance.name + '"';
+  }
+  return 'selector object';
+}
+
+/**
+ * Array filter method removing elements that may be defined (in) but
+ * do not have a recognizable value.
+ */
+function hasValidValueIn (definition) {
+  return function(key) {
+    return definition[key] !== undefined && definition[key] !== null;
+  };
+}
+
+/**
+ * Retrieves an array of ancestors of the supplied element. The last element in the array is the element object itself
+ *
+ * @param {Object} element The element
+ * @returns {Array}
+ */
+function getAncestorsWithElement(element) {
+  var elements = [];
+  function addElement(e) {
+    elements.unshift(e);
+    if (e.parent && e.parent.selector) {
+      addElement(e.parent);
+    }
+  }
+  addElement(element);
+  return elements;
+}
 
 module.exports = Element;

--- a/lib/page-object/page-utils.js
+++ b/lib/page-object/page-utils.js
@@ -25,18 +25,22 @@ module.exports = new (function() {
   this.createElements = function(parent, elements) {
     var Element = require('./element.js');
     var elementObjects = {};
-    var el;
+    var definition;
+    var options;
 
     if (!Array.isArray(elements)) {
       elements = [elements];
     }
 
     elements.forEach(function(els) {
-      Object.keys(els).forEach(function(e) {
-        el = typeof els[e] === 'string' ? { selector: els[e] } : els[e];
-        el.parent = parent;
-        el.name = e;
-        elementObjects[el.name] = new Element(el);
+      Object.keys(els).forEach(function(name) {
+        definition = typeof els[name] === 'string' ? { selector: els[name] } : els[name];
+        options = {
+          name: name,
+          parent: parent,
+          locateStrategy: 'css selector'
+        };
+        elementObjects[name] = new Element(definition, options);
       });
     });
 
@@ -56,13 +60,17 @@ module.exports = new (function() {
   this.createSections = function(parent, sections) {
     var Section = require('./section.js');
     var sectionObjects = {};
-    var sec;
+    var definition;
+    var options;
 
-    Object.keys(sections).forEach(function(s) {
-      sec = sections[s];
-      sec.parent = parent;
-      sec.name = s;
-      sectionObjects[sec.name] = new Section(sec);
+    Object.keys(sections).forEach(function(name) {
+      definition = sections[name];
+      options = {
+        name: name,
+        parent: parent,
+        locateStrategy: 'css selector'
+      };
+      sectionObjects[name] = new Section(definition, options);
     });
 
     parent.section = sectionObjects;

--- a/lib/page-object/section.js
+++ b/lib/page-object/section.js
@@ -1,38 +1,31 @@
+var util = require('util');
+var Element = require('./element.js');
 var PageUtils = require('./page-utils.js');
 var CommandWrapper = require('./command-wrapper.js');
 
 /**
  * Class that all sections subclass from
  *
- * @param {Object} options Section options defined in page object
+ * @param {Object} definition User-defined section options defined in page object
+ * @param {Object} options Additional options to be given to the element.
  * @constructor
  */
-function Section(options) {
-  this.parent = options.parent;
+function Section(definition, options) {
+  Element.call(this, definition, options);
+
   this.client = this.parent.client;
-
-  if(!options.selector) {
-    throw new Error('No selector property for section "' + options.name +
-      '" Instead found properties: ' + Object.keys(options));
-  }
-
-  this.name = options.name;
-  this.selector = options.selector;
-  this.locateStrategy = options.locateStrategy || 'css selector';
   this.api = this.parent.api;
   this.commandLoader = this.parent.commandLoader;
 
   PageUtils
-    .createProps(this, options.props || {})
-    .createElements(this, options.elements || {})
-    .createSections(this, options.sections || {})
-    .addCommands(this, options.commands || []);
+    .createProps(this, definition.props || {})
+    .createElements(this, definition.elements || {})
+    .createSections(this, definition.sections || {})
+    .addCommands(this, definition.commands || []);
 
   CommandWrapper.addWrappedCommands(this, this.commandLoader);
 }
 
-Section.prototype.toString = function() {
-  return 'Section[name=' + this.name + ']';
-};
+util.inherits(Section, Element);
 
 module.exports = Section;

--- a/test/extra/pageobjects/simplePageObj.js
+++ b/test/extra/pageobjects/simplePageObj.js
@@ -9,7 +9,8 @@ module.exports = {
   elements: {
     loginAsString: '#weblogin',
     loginCss: { selector: '#weblogin' },
-    loginXpath: { selector: '//weblogin', locateStrategy: 'xpath' }
+    loginXpath: { selector: '//weblogin', locateStrategy: 'xpath' },
+    loginId: { selector: 'weblogin', locateStrategy: 'id' }
   },
   sections: {
     signUp: {

--- a/test/lib/nockselements.js
+++ b/test/lib/nockselements.js
@@ -1,0 +1,151 @@
+var nock = require('nock');
+
+/**
+ * More granular nocks definitions for element apis
+ */
+module.exports = {
+
+  _requestUri: 'http://localhost:10195',
+  _protocolUri: '/wd/hub/session/1352110219202/',
+
+  elementFound : function(selector, using) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'element', {'using':using || 'css selector','value':selector || '#nock'})
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: { ELEMENT: '0' }
+      });
+    return this;
+  },
+
+  elementsFound : function(selector, foundArray, using) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'elements', {'using':using || 'css selector','value':selector || '.nock'})
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: foundArray || [ { ELEMENT: '0' }, { ELEMENT: '1' }, { ELEMENT: '2' } ]
+      });
+    return this;
+  },
+
+  elementNotFound : function(selector) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'element', {'using':'css selector','value':selector || '#nock-none'})
+      .reply(200, {
+        status: -1,
+        value: {},
+        errorStatus: 7,
+        error: 'An element could not be located on the page using the given search parameters.'
+      });
+    return this;
+  },
+
+  elementsNotFound : function(selector) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'elements', {'using':'css selector','value':selector || '.nock-none'})
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: []
+      });
+    return this;
+  },
+
+  elementByXpath : function(selector) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'element', {'using':'xpath','value':selector || '//[@id="nock"]'})
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: { ELEMENT: '0' }
+      });
+    return this;
+  },
+
+  elementsByXpath : function(selector, foundArray) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'elements', {'using':'xpath','value':selector || '//[@class="nock"]'})
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: foundArray || [ { ELEMENT: '0' }, { ELEMENT: '1' }, { ELEMENT: '2' } ]
+      });
+    return this;
+  },
+
+  elementId : function (id, selector, using) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'element/' + (id || 0) + '/element',
+        {'using':using || 'css selector','value':selector || '#nock'})
+      .reply(200, {
+        status: 0,
+        state : 'success',
+        value: { ELEMENT: '0' }
+      });
+    return this;
+  },
+
+  elementsId : function (id, selector, foundArray, using) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'element/' + (id || 0) + '/elements',
+        {'using':using || 'css selector','value':selector || '.nock'})
+      .reply(200, {
+        status: 0,
+        state : 'success',
+        value: foundArray || [ { ELEMENT: '0' }, { ELEMENT: '1' }, { ELEMENT: '2' } ]
+      });
+    return this;
+  },
+
+  elementIdNotFound : function (id, selector, using) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'element/' + (id || 0) + '/element',
+        {'using':using || 'css selector','value':selector || '#nock'})
+      .reply(200, {
+        status: -1,
+        value: {},
+        errorStatus: 7,
+        error: 'An element could not be located on the page using the given search parameters.'
+      });
+    return this;
+  },
+
+  elementsByTag : function(selector, foundArray) {
+    nock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'elements', {'using':'tag name','value':selector || 'nock'})
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: foundArray || [ { ELEMENT: '0' }, { ELEMENT: '1' }, { ELEMENT: '2' } ]
+      });
+    return this;
+  },
+
+  text : function (id, value) {
+    nock(this._requestUri)
+      .persist()
+      .get(this._protocolUri + 'element/' + (id || 0) + '/text')
+      .reply(200, {
+        status: 0,
+        state : 'success',
+        value: value || 'textValue'
+      });
+    return this;
+  },
+
+  cleanAll: function () {
+    nock.cleanAll();
+  }
+};

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,0 +1,38 @@
+var Nightwatch = require('./nightwatch.js');
+
+module.exports = {
+
+  /**
+   * Monkey-patch run queue run() callbacks to capture errors handled
+   * in the queue after they are sent off to the nightwatch instance.
+   *
+   * @param {function} testCallback The callback used by the test to
+   * capture the error object
+   */
+  catchQueueError: function (testCallback) {
+    var queue = Nightwatch.client().queue;
+
+    // queue is a singleton, not re-instancing with new nightwatch
+    // instances. In order to re-patch it if patched previously, we
+    // restore the original run method from the patch if it exists
+    // (which may happen if a patched run never gets called with err)
+
+    if (queue.run.origRun) {
+      queue.run = queue.run.origRun;
+    }
+
+    function queueRunnerPatched (origCallback) {
+      origCallback = origCallback || function noop () {};
+      origRun.call(queue, function(err) {
+        origCallback(err);
+        if (err) {
+          queue.run = origRun; // once, since errors are fatal to queue execution
+          testCallback(err);
+        }
+      });
+    }
+
+    var origRun = queueRunnerPatched.origRun = queue.run;
+    queue.run = queueRunnerPatched;
+  }
+};

--- a/test/src/api/element-selectors/testCommandsElementSelectors.js
+++ b/test/src/api/element-selectors/testCommandsElementSelectors.js
@@ -1,0 +1,143 @@
+var path = require('path');
+var assert = require('assert');
+var common = require('../../../common.js');
+var Api = common.require('core/api.js');
+var utils = require('../../../lib/utils.js');
+var nocks = require('../../../lib/nockselements.js');
+var MochaTest = require('../../../lib/mochatest.js');
+var Nightwatch = require('../../../lib/nightwatch.js');
+
+module.exports = MochaTest.add('test commands element selectors', {
+
+  beforeEach: function (done) {
+    Nightwatch.init({
+      page_objects_path: [path.join(__dirname, '../../../extra/pageobjects')]
+    }, done);
+  },
+
+  afterEach: function () {
+    nocks.cleanAll();
+  },
+
+  // wrapped selenium command
+
+  'getText(<various>)' : function(done) {
+    nocks
+      .elementFound()
+      .elementNotFound()
+      .elementByXpath()
+      .text(0, 'first')
+      .text(1, 'second');
+
+    Nightwatch.api()
+      .getText('#nock', function callback(result) {
+        assert.equal(result.value, 'first', 'getText string selector value');
+      })
+      .getText({selector: '#nock'}, function callback(result) {
+        assert.equal(result.value, 'first', 'getText selector property');
+      })
+      .getText({selector: '#nock-none'}, function callback(result) {
+        assert.equal(result.status, -1, 'getText not found status');
+      })
+      .getText({selector: '//[@id="nock"]', locateStrategy: 'xpath'}, function callback(result) {
+        assert.equal(result.value, 'first', 'getText xpath locateStrategy');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'getText(<various>) locateStrategy' : function(done) {
+    nocks
+      .elementFound()
+      .elementNotFound()
+      .elementByXpath()
+      .text(0, 'first')
+      .text(1, 'second');
+
+    Nightwatch.api()
+      .useCss()
+      .getText('#nock', function callback(result) {
+        assert.equal(result.value, 'first', 'getText string selector useCss');
+      })
+      .useXpath()
+      .getText('//[@id="nock"]', function callback(result) {
+        assert.equal(result.value, 'first', 'getText string selector useXpath');
+      })
+      .useCss()
+      .getText({selector: '//[@id="nock"]', locateStrategy: 'xpath'}, function callback(result) {
+        assert.equal(result.value, 'first', 'getText useCss override with xpath');
+      })
+      .getText('#nock', function callback(result) {
+        assert.equal(result.value, 'first', 'getText back to css after override with xpath');
+      })
+      .getText('css selector', {selector: '//[@id="nock"]', locateStrategy: 'xpath'}, function callback(result) {
+        assert.equal(result.value, 'first', 'getText using override with xpath');
+      })
+      .getText('xpath', {selector: '//[@id="nock"]'}, function callback(result) {
+        assert.equal(result.value, 'first', 'getText using as xpath');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  // custom command
+
+  'waitForElementPresent(<various>)' : function(done) {
+    nocks
+      .elementsFound()
+      .elementsNotFound()
+      .elementsByXpath();
+
+    Nightwatch.api()
+      .waitForElementPresent('.nock', 1, false, function callback(result) {
+        assert.equal(result.value.length, 3, 'waitforPresent result expected found');
+      })
+      .waitForElementPresent('.nock-none', 1, false, function callback(result) {
+        assert.equal(result.value, false, 'waitforPresent result expected false');
+      })
+      .waitForElementPresent({selector: '.nock'}, 1, false, function callback(result) {
+        assert.equal(result.value.length, 3, 'waitforPresent selector property result expected found');
+      })
+      .waitForElementPresent({selector: '.nock-none'}, 1, false, function callback(result) {
+        assert.equal(result.value, false, 'waitforPresent selector property result expected false');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'waitForElementPresent(<various>) locateStrategy' : function(done) {
+    nocks
+      .elementsFound()
+      .elementsNotFound()
+      .elementsByXpath();
+
+    Nightwatch.api()
+      .useCss()
+      .waitForElementPresent('.nock', 1, false, function callback(result) {
+        assert.equal(result.value.length, 3, 'waitforPresent using css');
+      })
+      .useXpath()
+      .waitForElementPresent('//[@class="nock"]', 1, false, function callback(result) {
+        assert.equal(result.value.length, 3, 'waitforPresent using xpath');
+      })
+      .useCss()
+      .waitForElementPresent({selector: '//[@class="nock"]', locateStrategy: 'xpath'}, 1, false, function callback(result) {
+        assert.equal(result.value.length, 3, 'waitforPresent locateStrategy override to xpath found');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  }
+
+});

--- a/test/src/api/element-selectors/testExpectElementSelectors.js
+++ b/test/src/api/element-selectors/testExpectElementSelectors.js
@@ -1,0 +1,77 @@
+var path = require('path');
+var assert = require('assert');
+var common = require('../../../common.js');
+var Api = common.require('core/api.js');
+var utils = require('../../../lib/utils.js');
+var nocks = require('../../../lib/nockselements.js');
+var MochaTest = require('../../../lib/mochatest.js');
+var Nightwatch = require('../../../lib/nightwatch.js');
+
+module.exports = MochaTest.add('test expect element selectors', {
+
+  beforeEach: function (done) {
+    Nightwatch.init({
+      page_objects_path: [path.join(__dirname, '../../../extra/pageobjects')]
+    }, done);
+  },
+
+  afterEach: function () {
+    nocks.cleanAll();
+  },
+
+  'expect selectors' : function (done) {
+    nocks
+      .elementsFound()
+      .elementsFound('#signupSection', [{ELEMENT: '0'}])
+      .elementsId(0, '#helpBtn', [{ELEMENT: '0'}])
+      .elementsByXpath();
+
+    var client = Nightwatch.client();
+    Api.init(client);
+    var api = client.api;
+    api.globals.abortOnAssertionFailure = false;
+
+    var page = api.page.simplePageObj();
+    var section = page.section.signUp;
+
+    var passes = [
+      api.expect.element('.nock').to.be.present.before(1),
+      api.expect.element({selector: '.nock'}).to.be.present.before(1),
+      api.expect.element({selector: '//[@class="nock"]', locateStrategy: 'xpath'}).to.be.present.before(1),
+      page.expect.section('@signUp').to.be.present.before(1),
+      page.expect.section({selector: '@signUp', locateStrategy: 'css selector'}).to.be.present.before(1),
+      section.expect.element('@help').to.be.present.before(1)
+    ];
+
+    var fails = [
+      [api.expect.element({selector: '.nock', locateStrategy: 'xpath'}).to.be.present.before(1),
+        'element was not found'],
+      [page.expect.section({selector: '@signUp', locateStrategy: 'xpath'}).to.be.present.before(1),
+        'element was not found']
+    ];
+
+    api.perform(function(performDone) {
+      process.nextTick(function(){ // keep assertions from being swallowed by perform
+
+        passes.forEach(function(expect, index) {
+          assert.equal(expect.assertion.passed, true, 'passing [' + index + ']: ' + expect.assertion.message);
+        });
+
+        fails.forEach(function(expectArr, index) {
+          var expect = expectArr[0];
+          var msgPartial = expectArr[1];
+
+          assert.equal(expect.assertion.passed, false, 'failing [' + index + ']: ' + expect.assertion.message);
+          assert.notEqual(expect.assertion.message.indexOf(msgPartial), -1, 'Message contains: ' + msgPartial);
+        });
+        
+        performDone();
+        done();
+
+      });
+    });
+
+    Nightwatch.start();
+  }
+
+});

--- a/test/src/api/element-selectors/testPageObjectElementSelectors.js
+++ b/test/src/api/element-selectors/testPageObjectElementSelectors.js
@@ -1,0 +1,110 @@
+var path = require('path');
+var assert = require('assert');
+var common = require('../../../common.js');
+var Api = common.require('core/api.js');
+var utils = require('../../../lib/utils.js');
+var nocks = require('../../../lib/nockselements.js');
+var MochaTest = require('../../../lib/mochatest.js');
+var Nightwatch = require('../../../lib/nightwatch.js');
+
+module.exports = MochaTest.add('test page object element selectors', {
+
+  beforeEach: function (done) {
+    Nightwatch.init({
+      page_objects_path: [path.join(__dirname, '../../../extra/pageobjects')]
+    }, done);
+  },
+
+  afterEach: function () {
+    nocks.cleanAll();
+  },
+
+  'page elements' : function(done) {
+    nocks
+      .elementFound('#weblogin')
+      .elementFound('weblogin', 'id')
+      .elementByXpath('//weblogin')
+      .elementByXpath('#weblogin', [])
+      .text(0, 'first')
+      .text(1, 'second');
+
+    var client = Nightwatch.client();
+    Api.init(client);
+
+    var page = client.api.page.simplePageObj();
+
+    page
+      .getText('@loginAsString', function callback(result) {
+        assert.equal(result.status, 0, 'element selector string found');
+        assert.equal(result.value, 'first', 'element selector string value');
+      })
+      .getText({selector: '@loginAsString'}, function callback(result) {
+        assert.equal(result.status, 0, 'element selector property found');
+        assert.equal(result.value, 'first', 'element selector property value');
+      })
+      .getText('@loginXpath', function callback(result) {
+        assert.equal(result.status, 0, 'element selector xpath found');
+        assert.equal(result.value, 'first', 'element selector xpath value');
+      })
+      .getText('@loginCss', function callback(result) {
+        assert.equal(result.status, 0, 'element selector css found');
+        assert.equal(result.value, 'first', 'element selector css value');
+      })
+      .getText('@loginId', function callback(result) {
+        assert.equal(result.status, 0, 'element selector id found');
+        assert.equal(result.value, 'first', 'element selector id value');
+      })
+      .api.perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'page section elements' : function(done) {
+    nocks
+      .elementFound('#signupSection')
+      .elementFound('#getStarted')
+      .elementFound('#helpBtn')
+      .elementIdNotFound(0, '#helpBtn', 'xpath')
+      .elementId(0, '#helpBtn')
+      .text(0, 'first')
+      .text(1, 'second');
+
+    var client = Nightwatch.client();
+    Api.init(client);
+
+    var page = client.api.page.simplePageObj();
+    var section = page.section.signUp;
+    var sectionChild = section.section.getStarted;
+
+    section
+      .getText('@help', function callback(result) {
+        assert.equal(result.status, 0, 'section element selector string found');
+        assert.equal(result.value, 'first', 'section element selector string value');
+      })
+      .getText({selector: '@help'}, function callback(result) {
+        assert.equal(result.status, 0, 'section element selector property found');
+        assert.equal(result.value, 'first', 'section element selector property value');
+      })
+      .getText({selector:'@help', locateStrategy:'xpath'}, function callback(result) {
+        assert.equal(result.status, -1, 'section element selector css xpath override not found');
+      });
+
+    sectionChild
+      .getText('#helpBtn', function callback(result) {
+        assert.equal(result.status, 0, 'child section element selector string found');
+        assert.equal(result.value, 'first', 'child section element selector string value');
+      })
+      .getText({selector: '#helpBtn'}, function callback(result) {
+        assert.equal(result.status, 0, 'child section element selector property found');
+        assert.equal(result.value, 'first', 'child section element selector property value');
+      })
+      .api.perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  }
+
+});

--- a/test/src/api/element-selectors/testProtocolElementSelectors.js
+++ b/test/src/api/element-selectors/testProtocolElementSelectors.js
@@ -1,0 +1,239 @@
+var path = require('path');
+var assert = require('assert');
+var common = require('../../../common.js');
+var Api = common.require('core/api.js');
+var utils = require('../../../lib/utils.js');
+var nocks = require('../../../lib/nockselements.js');
+var MochaTest = require('../../../lib/mochatest.js');
+var Nightwatch = require('../../../lib/nightwatch.js');
+
+module.exports = MochaTest.add('test protocol element selectors', {
+
+  beforeEach: function (done) {
+    Nightwatch.init({
+      page_objects_path: [path.join(__dirname, '../../../extra/pageobjects')]
+    }, done);
+  },
+
+  afterEach: function () {
+    nocks.cleanAll();
+  },
+
+  'protocol.element(using, {selector})' : function(done) {
+    nocks
+      .elementFound()
+      .elementNotFound();
+
+    Nightwatch.api()
+      .element('css selector', '#nock', function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element for string selector');
+      })
+      .element('css selector', '#nock-none', function callback(result) {
+        assert.equal(result.status, -1, 'Not found for string selector');
+      })
+      .element('css selector', {selector: '#nock'}, function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element for selector property');
+      })
+      .element('css selector', {selector: '#nock-none'}, function callback(result) {
+        assert.equal(result.status, -1, 'Not found for selector property');
+      })
+      .perform(function() {
+        done(); // done here, not in start(), to make sure all commands complete without error
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.element(using, null)' : function(done) {
+    utils.catchQueueError(function (err) {
+      var msg = 'Invalid selector value specified';
+      assert.equal(err.message, msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .element('css selector', null, function callback(result) {
+        assert.ok(false, 'Null selector object should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.element(using, {})' : function(done) {
+    utils.catchQueueError(function (err) {
+      var msg = 'No selector property for'; // ... rest of error, etc.
+      assert.equal(err.message.slice(0, msg.length), msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .element('css selector', {}, function callback(result) {
+        assert.ok(false, 'Empty selector object should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.element(using, {selector, locateStrategy})' : function(done) {
+    nocks.elementFound();
+
+    Nightwatch.api()
+      .element('css selector', {selector: '#nock', locateStrategy: 'css selector'}, function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element, same locateStrategy');
+      })
+      .element('xpath', {selector: '#nock', locateStrategy: 'css selector'}, function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element, overridden locateStrategy');
+      })
+      .element('css selector', {selector: '#nock', locateStrategy: null}, function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element, null locateStrategy');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.element(using, {locateStrategy})' : function(done) {
+    utils.catchQueueError(function (err) {
+      var msg = 'No selector property for';
+      assert.equal(err.message.slice(0, msg.length), msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .element('css selector', {locateStrategy: 'css selector'}, function callback(result) {
+        assert.ok(false, 'Selector with just locateStrategy should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.element(using, {locateStrategy=invalid})' : function(done) {
+    utils.catchQueueError(function (err) {
+      var msg = 'Provided locating strategy is not supported';
+      assert.equal(err.message.slice(0, msg.length), msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .element('css selector', {selector: '.nock', locateStrategy: 'unsupported'}, function callback(result) {
+        assert.ok(false, 'Selector with invalid locateStrategy should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.elements(using, {selector})' : function(done) {
+    nocks
+      .elementsFound()
+      .elementsNotFound();
+
+    Nightwatch.api()
+      .elements('css selector', '.nock', function callback(result) {
+        assert.equal(result.value[0].ELEMENT, '0', 'Found elements for string selector');
+      })
+      .elements('css selector', '.nock-none', function callback(result) {
+        assert.equal(result.status, 0, 'No error for string selector');
+        assert.equal(result.value.length, 0, 'No results for string selector');
+      })
+      .elements('css selector', {selector: '.nock'}, function callback(result) {
+        assert.equal(result.value[0].ELEMENT, '0', 'Found elements for selector property');
+      })
+      .elements('css selector', {selector: '.nock-none'}, function callback(result) {
+        assert.equal(result.status, 0, 'Not found for selector property');
+        assert.equal(result.value.length, 0, 'No results for selector property');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.elements(using, null)' : function(done) {
+    utils.catchQueueError(function (err) {
+      var msg = 'Invalid selector value specified';
+      assert.equal(err.message, msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .elements('css selector', null, function callback(result) {
+        assert.ok(false, 'Null selector object should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.elements(using, {})' : function(done) {
+    utils.catchQueueError(function (err) {
+      var msg = 'No selector property for';
+      assert.equal(err.message.slice(0, msg.length), msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .elements('css selector', {}, function callback(result) {
+        assert.ok(false, 'Empty selector object should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.elements(using, {selector, locateStrategy})' : function(done) {
+    nocks
+      .elementsFound()
+      .elementsByTag();
+
+    Nightwatch.api()
+      .elements('css selector', {selector: '.nock', locateStrategy: 'css selector'}, function callback(result) {
+        assert.equal(result.value[0].ELEMENT, '0', 'Found element, same locateStrategy');
+      })
+      .elements('xpath', {selector: '.nock', locateStrategy: 'css selector'}, function callback(result) {
+        assert.equal(result.value[0].ELEMENT, '0', 'Found element, overridden locateStrategy');
+      })
+      .elements('xpath', {selector: 'nock', locateStrategy: 'tag name'}, function callback(result) {
+        assert.equal(result.value[0].ELEMENT, '0', 'Found element, by tag name');
+      })
+      .elements('css selector', {selector: '.nock', locateStrategy: null}, function callback(result) {
+        assert.equal(result.value[0].ELEMENT, '0', 'Found element, null locateStrategy');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.elements(using, {locateStrategy})' : function(done) {
+    utils.catchQueueError(function (err) {
+      var msg = 'No selector property for';
+      assert.equal(err.message.slice(0, msg.length), msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .elements('css selector', {locateStrategy: 'css selector'}, function callback(result) {
+        assert.ok(false, 'Selector with just locateStrategy should fail');
+      });
+
+    Nightwatch.start();
+  },
+
+  'protocol.elements(using, {locateStrategy=invalid})' : function(done) {
+    utils.catchQueueError(function (err) {
+      var msg = 'Provided locating strategy is not supported';
+      assert.equal(err.message.slice(0, msg.length), msg);
+      done();
+    });
+
+    Nightwatch.api()
+      .elements('css selector', {selector: '.nock', locateStrategy: 'unsupported'}, function callback(result) {
+        assert.ok(false, 'Selector with invalid locateStrategy should fail');
+      });
+
+    Nightwatch.start();
+  }
+
+});


### PR DESCRIPTION
(Partial implementation of the original #1116)

Adds support for optional, object-based selector values in commands using the format used by page elements.  ex:

```js
// before:
browser.getText('#foo', function(result){});

// now (optionally):
browser.getText({selector:'#foo', locateStrategy:'css selector'}, function(result){});
```

- This new implementation reduces complexity around page command wrapping.  We no longer need to track and restore the locate strategy because its encoded directly within the selector; the callbacks are no longer wrapped.  This should presumably fix (could use verification from submitters): #1142, #1107, #1100, #895
- As a result of the above, page objects can also use any form of supported locate strategy (https://groups.google.com/forum/#!topic/nightwatchjs/ZDuM7TX6fEA)
- It opens the selector format up to being more dynamic, such as having additional properties that could potentially further mutate the resulting selector - not unlike with what other PRs/issues (e.g. #821) are doing/suggesting, trying to encode additional data in the selector string.  This commit is not doing anything other than including `selector` and `locateStrategy`, but it opens up the possibility for additional properties in the future.
- Global locate strategies set with `useCss()` or `useXpath()` can be maintained when writing custom commands, for example, if the custom command uses strategies within the selectors for its requests, preventing interference with the global strategy (users won't have to restore their set strats upon using a custom command that uses other strats).

Also noticed this seems to be an exact implementation of #720.