### PR TITLE
Fixed JUnit test-by-config reporting

### DIFF
--- a/lib/runner/reporters/junit.js
+++ b/lib/runner/reporters/junit.js
@@ -56,6 +56,13 @@ module.exports = new (function() {
 
     adaptAssertions(module);
 
+    if (pathParts.length) {
+      output_folder = path.join(output_folder, pathParts.join(path.sep));
+    }
+
+    var filename = path.join(output_folder, opts.filename_prefix + moduleName + '.xml');
+    mkpath.sync(path.dirname(filename));
+
     var rendered = ejs.render(data, {
       locals: {
         module     : module,
@@ -64,12 +71,6 @@ module.exports = new (function() {
       }
     });
 
-    if (pathParts.length) {
-      output_folder = path.join(output_folder, pathParts.join(path.sep));
-      mkpath.sync(output_folder);
-    }
-
-    var filename = path.join(output_folder, opts.filename_prefix + moduleName + '.xml');
     fs.writeFile(filename, rendered, function(err) {
       callback(err);
       globalResults.errmessages.length = 0;

--- a/lib/runner/reporters/junit.js
+++ b/lib/runner/reporters/junit.js
@@ -52,12 +52,18 @@ module.exports = new (function() {
     var module = globalResults.modules[moduleKey];
     var pathParts = moduleKey.split(path.sep);
     var moduleName = pathParts.pop();
+    var className = moduleName;
     var output_folder = opts.output_folder;
 
     adaptAssertions(module);
 
     if (pathParts.length) {
       output_folder = path.join(output_folder, pathParts.join(path.sep));
+      className = pathParts.join('.') + '.' + moduleName;
+    }
+
+    if (opts.filename_prefix) {
+      className = opts.filename_prefix.replace(/\./g, '_') + '.' + className;
     }
 
     var filename = path.join(output_folder, opts.filename_prefix + moduleName + '.xml');
@@ -67,6 +73,7 @@ module.exports = new (function() {
       locals: {
         module     : module,
         moduleName : moduleName,
+        className  : className,
         systemerr  : globalResults.errmessages.join('\n')
       }
     });

--- a/lib/runner/reporters/junit.xml.ejs
+++ b/lib/runner/reporters/junit.xml.ejs
@@ -9,7 +9,7 @@
   <% for (var item in module.completed) {
     var testcase = module.completed[item];
     var assertions = testcase.assertions %>
-    <testcase name="<%= item %>" time="<%= testcase.time %>" assertions="<%= assertions.length %>"><%
+    <testcase name="<%= item %>" classname="<%= className %>" time="<%= testcase.time %>" assertions="<%= assertions.length %>"><%
       for (var i = 0; i < assertions.length; i++) { %><% if (assertions[i].failure) { %>  <failure message="<%= assertions[i].message %>"><%= assertions[i].stackTrace %></failure><% } %>
 <% if (assertions[i].screenshots && assertions[i].screenshots.length > 0) { %><system-out><% for (var j = 0; j < assertions[i].screenshots.length; j++) { %>[[ATTACHMENT|<%= assertions[i].screenshots[j] %>]]<% } %></system-out><% } %>
     <% }

--- a/lib/runner/reporters/junit.xml.ejs
+++ b/lib/runner/reporters/junit.xml.ejs
@@ -3,7 +3,7 @@
             failures="<%= module.failures %>"
             tests="<%= module.tests %>">
 
-  <testsuite name="<%= moduleName %>"
+  <testsuite name="<%= className %>"
     errors="<%= module.errors %>" failures="<%= module.failures %>" hostname="" id="" package="<%= module.group || moduleName %>" skipped="<%= (Array.isArray(module.skipped)) ? module.skipped.length : 0 %>"
     tests="<%= module.tests %>" time="<%= module.time %>" timestamp="<%= module.timestamp %>">
   <% for (var item in module.completed) {

--- a/test/src/runner/testRunner.js
+++ b/test/src/runner/testRunner.js
@@ -113,10 +113,33 @@ module.exports = {
 
             assert.ok(fileExistsSync(simpleReportFile), 'The simple report file was not created.');
             assert.ok(fileExistsSync(tagsReportFile), 'The tags report file was not created.');
-            done();
+
+            // checking one of the two files should be enough
+            fs.readFile(simpleReportFile, function(err, data) {
+              if (err) {
+                done(err);
+                return;
+              }
+              var content = data.toString();
+              try {
+                // <testsuite name="sample"
+                //   errors="0" failures="0" hostname="" id="" package="simple" skipped="0"
+                //   tests="1"
+                assert.ok(content.match(/<testsuite[\s]+name="sample"[\s]+errors="0"[\s]+failures="0"[\s]+hostname=""[\s]+id=""[\s]+package="simple"[\s]+skipped="0"[\s]+tests="1"/g) !== null, 'Report does not contain correct testsuite information.')
+                // <testcase name="simpleDemoTest" time="0.007000" assertions="1">
+                assert.ok(content.match(/<testcase[\s]+name="simpleDemoTest"[\s]+time="[.\d]+"[\s]+assertions="1">/g) !== null, 'Report does not contain the correct testcase element.')
+
+                assert.ok(content.indexOf('<failure message="[\s\S]*?">') === -1, 'Report contains failure information.')
+                done();
+              } catch (err) {
+                done(err);
+              }
+            });
+
           } catch (err) {
             done(err);
           }
+
         });
       });
 
@@ -151,8 +174,19 @@ module.exports = {
             return;
           }
           var content = data.toString();
-          assert.ok(content.indexOf('<failure message="Testing if element &lt;#badElement&gt; is present.">') > 0, 'Report contains failure information.')
-          done();
+          try {
+            // <testsuite name="sample"
+            //   errors="0" failures="1" hostname="" id="" package="sample" skipped="1"
+            //   tests="2"
+            assert.ok(content.match(/<testsuite[\s]+name="sample"[\s]+errors="0"[\s]+failures="1"[\s]+hostname=""[\s]+id=""[\s]+package="sample"[\s]+skipped="1"[\s]+tests="2"/g) !== null, 'Report does not contain correct testsuite information.')
+            // <testcase name="demoTest" time="0.002000" assertions="2">
+            assert.ok(content.match(/<testcase[\s]+name="demoTest"[\s]+time="[.\d]+"[\s]+assertions="2">/g) !== null, 'Report does not contain the correct testcase element.')
+
+            assert.ok(content.indexOf('<failure message="Testing if element &lt;#badElement&gt; is present.">') > 0, 'Report contains failure information.')
+            done();
+          } catch (err) {
+            done(err);
+          }
         });
       });
 
@@ -188,7 +222,14 @@ module.exports = {
           }
           var content = data.toString();
           try {
-            assert.ok(content.indexOf('<failure message="AssertionError: 1 == 0 - expected &quot;0&quot; but got: &quot;1&quot;">') > 0, 'Report contains failure information.')
+            // <testsuite name="unittest-failure"
+            //   errors="0" failures="1" hostname="" id="" package="unittest-failure" skipped="0"
+            //   tests="1"
+            assert.ok(content.match(/<testsuite[\s]+name="unittest-failure"[\s]+errors="0"[\s]+failures="1"[\s]+hostname=""[\s]+id=""[\s]+package="unittest-failure"[\s]+skipped="0"[\s]+tests="1"/g) !== null, 'Report does not contain correct testsuite information.')
+            // <testcase name="demoTest" time="0.002000" assertions="0">
+            assert.ok(content.match(/<testcase[\s]+name="demoTest"[\s]+time="[.\d]+"[\s]+assertions="0">/g) !== null, 'Report does not contain the correct testcase element.')
+
+            assert.ok(content.indexOf('<failure message="AssertionError: 1 == 0 - expected &quot;0&quot; but got: &quot;1&quot;">') > 0, 'Report does not contain failure information.')
             done();
           } catch (err) {
             done(err);

--- a/test/src/runner/testRunner.js
+++ b/test/src/runner/testRunner.js
@@ -126,8 +126,8 @@ module.exports = {
                 //   errors="0" failures="0" hostname="" id="" package="simple" skipped="0"
                 //   tests="1"
                 assert.ok(content.match(/<testsuite[\s]+name="sample"[\s]+errors="0"[\s]+failures="0"[\s]+hostname=""[\s]+id=""[\s]+package="simple"[\s]+skipped="0"[\s]+tests="1"/g) !== null, 'Report does not contain correct testsuite information.')
-                // <testcase name="simpleDemoTest" time="0.007000" assertions="1">
-                assert.ok(content.match(/<testcase[\s]+name="simpleDemoTest"[\s]+time="[.\d]+"[\s]+assertions="1">/g) !== null, 'Report does not contain the correct testcase element.')
+                // <testcase name="simpleDemoTest" classname="FIREFOX_TEST_TEST_.simple.sample" time="0.007000" assertions="1">
+                assert.ok(content.match(/<testcase[\s]+name="simpleDemoTest"[\s]+classname="FIREFOX_TEST_TEST_.simple.sample"[\s]+time="[.\d]+"[\s]+assertions="1">/g) !== null, 'Report does not contain the correct testcase element.')
 
                 assert.ok(content.indexOf('<failure message="[\s\S]*?">') === -1, 'Report contains failure information.')
                 done();
@@ -179,8 +179,8 @@ module.exports = {
             //   errors="0" failures="1" hostname="" id="" package="sample" skipped="1"
             //   tests="2"
             assert.ok(content.match(/<testsuite[\s]+name="sample"[\s]+errors="0"[\s]+failures="1"[\s]+hostname=""[\s]+id=""[\s]+package="sample"[\s]+skipped="1"[\s]+tests="2"/g) !== null, 'Report does not contain correct testsuite information.')
-            // <testcase name="demoTest" time="0.002000" assertions="2">
-            assert.ok(content.match(/<testcase[\s]+name="demoTest"[\s]+time="[.\d]+"[\s]+assertions="2">/g) !== null, 'Report does not contain the correct testcase element.')
+            // <testcase name="demoTest" classname="FIREFOX_TEST_TEST_.sample" time="0.002000" assertions="2">
+            assert.ok(content.match(/<testcase[\s]+name="demoTest"[\s]+classname="FIREFOX_TEST_TEST_.sample"[\s]+time="[.\d]+"[\s]+assertions="2">/g) !== null, 'Report does not contain the correct testcase element.')
 
             assert.ok(content.indexOf('<failure message="Testing if element &lt;#badElement&gt; is present.">') > 0, 'Report contains failure information.')
             done();
@@ -226,8 +226,8 @@ module.exports = {
             //   errors="0" failures="1" hostname="" id="" package="unittest-failure" skipped="0"
             //   tests="1"
             assert.ok(content.match(/<testsuite[\s]+name="unittest-failure"[\s]+errors="0"[\s]+failures="1"[\s]+hostname=""[\s]+id=""[\s]+package="unittest-failure"[\s]+skipped="0"[\s]+tests="1"/g) !== null, 'Report does not contain correct testsuite information.')
-            // <testcase name="demoTest" time="0.002000" assertions="0">
-            assert.ok(content.match(/<testcase[\s]+name="demoTest"[\s]+time="[.\d]+"[\s]+assertions="0">/g) !== null, 'Report does not contain the correct testcase element.')
+            // <testcase name="demoTest" classname="unittest-failure" time="0.002000" assertions="0">
+            assert.ok(content.match(/<testcase[\s]+name="demoTest"[\s]+classname="unittest-failure"[\s]+time="[.\d]+"[\s]+assertions="0">/g) !== null, 'Report does not contain the correct testcase element.')
 
             assert.ok(content.indexOf('<failure message="AssertionError: 1 == 0 - expected &quot;0&quot; but got: &quot;1&quot;">') > 0, 'Report does not contain failure information.')
             done();

--- a/test/src/runner/testRunner.js
+++ b/test/src/runner/testRunner.js
@@ -122,14 +122,14 @@ module.exports = {
               }
               var content = data.toString();
               try {
-                // <testsuite name="sample"
+                // <testsuite name="FIREFOX_TEST_TEST_.simple.sample"
                 //   errors="0" failures="0" hostname="" id="" package="simple" skipped="0"
                 //   tests="1"
-                assert.ok(content.match(/<testsuite[\s]+name="sample"[\s]+errors="0"[\s]+failures="0"[\s]+hostname=""[\s]+id=""[\s]+package="simple"[\s]+skipped="0"[\s]+tests="1"/g) !== null, 'Report does not contain correct testsuite information.')
+                assert.ok(content.match(/<testsuite[\s]+name="FIREFOX_TEST_TEST_.simple.sample"[\s]+errors="0"[\s]+failures="0"[\s]+hostname=""[\s]+id=""[\s]+package="simple"[\s]+skipped="0"[\s]+tests="1"/g) !== null, 'Report does not contain correct testsuite information.');
                 // <testcase name="simpleDemoTest" classname="FIREFOX_TEST_TEST_.simple.sample" time="0.007000" assertions="1">
-                assert.ok(content.match(/<testcase[\s]+name="simpleDemoTest"[\s]+classname="FIREFOX_TEST_TEST_.simple.sample"[\s]+time="[.\d]+"[\s]+assertions="1">/g) !== null, 'Report does not contain the correct testcase element.')
+                assert.ok(content.match(/<testcase[\s]+name="simpleDemoTest"[\s]+classname="FIREFOX_TEST_TEST_.simple.sample"[\s]+time="[.\d]+"[\s]+assertions="1">/g) !== null, 'Report does not contain the correct testcase element.');
 
-                assert.ok(content.indexOf('<failure message="[\s\S]*?">') === -1, 'Report contains failure information.')
+                assert.ok(content.indexOf('<failure message="[\s\S]*?">') === -1, 'Report contains failure information.');
                 done();
               } catch (err) {
                 done(err);
@@ -175,14 +175,14 @@ module.exports = {
           }
           var content = data.toString();
           try {
-            // <testsuite name="sample"
+            // <testsuite name="FIREFOX_TEST_TEST_.sample"
             //   errors="0" failures="1" hostname="" id="" package="sample" skipped="1"
             //   tests="2"
-            assert.ok(content.match(/<testsuite[\s]+name="sample"[\s]+errors="0"[\s]+failures="1"[\s]+hostname=""[\s]+id=""[\s]+package="sample"[\s]+skipped="1"[\s]+tests="2"/g) !== null, 'Report does not contain correct testsuite information.')
+            assert.ok(content.match(/<testsuite[\s]+name="FIREFOX_TEST_TEST_.sample"[\s]+errors="0"[\s]+failures="1"[\s]+hostname=""[\s]+id=""[\s]+package="sample"[\s]+skipped="1"[\s]+tests="2"/g) !== null, 'Report does not contain correct testsuite information.');
             // <testcase name="demoTest" classname="FIREFOX_TEST_TEST_.sample" time="0.002000" assertions="2">
-            assert.ok(content.match(/<testcase[\s]+name="demoTest"[\s]+classname="FIREFOX_TEST_TEST_.sample"[\s]+time="[.\d]+"[\s]+assertions="2">/g) !== null, 'Report does not contain the correct testcase element.')
+            assert.ok(content.match(/<testcase[\s]+name="demoTest"[\s]+classname="FIREFOX_TEST_TEST_.sample"[\s]+time="[.\d]+"[\s]+assertions="2">/g) !== null, 'Report does not contain the correct testcase element.');
 
-            assert.ok(content.indexOf('<failure message="Testing if element &lt;#badElement&gt; is present.">') > 0, 'Report contains failure information.')
+            assert.ok(content.indexOf('<failure message="Testing if element &lt;#badElement&gt; is present.">') > 0, 'Report contains failure information.');
             done();
           } catch (err) {
             done(err);
@@ -225,11 +225,11 @@ module.exports = {
             // <testsuite name="unittest-failure"
             //   errors="0" failures="1" hostname="" id="" package="unittest-failure" skipped="0"
             //   tests="1"
-            assert.ok(content.match(/<testsuite[\s]+name="unittest-failure"[\s]+errors="0"[\s]+failures="1"[\s]+hostname=""[\s]+id=""[\s]+package="unittest-failure"[\s]+skipped="0"[\s]+tests="1"/g) !== null, 'Report does not contain correct testsuite information.')
+            assert.ok(content.match(/<testsuite[\s]+name="unittest-failure"[\s]+errors="0"[\s]+failures="1"[\s]+hostname=""[\s]+id=""[\s]+package="unittest-failure"[\s]+skipped="0"[\s]+tests="1"/g) !== null, 'Report does not contain correct testsuite information.');
             // <testcase name="demoTest" classname="unittest-failure" time="0.002000" assertions="0">
-            assert.ok(content.match(/<testcase[\s]+name="demoTest"[\s]+classname="unittest-failure"[\s]+time="[.\d]+"[\s]+assertions="0">/g) !== null, 'Report does not contain the correct testcase element.')
+            assert.ok(content.match(/<testcase[\s]+name="demoTest"[\s]+classname="unittest-failure"[\s]+time="[.\d]+"[\s]+assertions="0">/g) !== null, 'Report does not contain the correct testcase element.');
 
-            assert.ok(content.indexOf('<failure message="AssertionError: 1 == 0 - expected &quot;0&quot; but got: &quot;1&quot;">') > 0, 'Report does not contain failure information.')
+            assert.ok(content.indexOf('<failure message="AssertionError: 1 == 0 - expected &quot;0&quot; but got: &quot;1&quot;">') > 0, 'Report does not contain failure information.');
             done();
           } catch (err) {
             done(err);


### PR DESCRIPTION
Without some way to distinguish between different config runs of the same tests,
Unit reporters will tend to treat multiple results for the same test case of the duplicates.

Jenkins JUnit report will ignore these "duplicates" producing very confusing test results.

The change add a "class path" the results based on configuration and file path. This allows
reporter consumers to process the results correctly as different results instances.
