### PR TITLE
Fixes #1164 - prevent cssClass[Not]Present to throw fatal error

### DIFF
--- a/lib/api/assertions/cssClassNotPresent.js
+++ b/lib/api/assertions/cssClassNotPresent.js
@@ -16,7 +16,7 @@
 
 var util = require('util');
 exports.assertion = function(selector, className, msg) {
-  var DEFAULT_MSG = 'Testing if element <%s> has css class: "%s".';
+  var DEFAULT_MSG = 'Testing if element <%s> does not have css class: "%s".';
   var MSG_ELEMENT_NOT_FOUND = DEFAULT_MSG + ' ' + 'Element could not be located.';
 
   this.message = msg || util.format('Testing if element <%s> does not have css class: "%s".', selector, className);

--- a/lib/api/assertions/cssClassNotPresent.js
+++ b/lib/api/assertions/cssClassNotPresent.js
@@ -16,9 +16,8 @@
 
 var util = require('util');
 exports.assertion = function(selector, className, msg) {
-
-  var MSG_ELEMENT_NOT_FOUND = 'Testing if element <%s> does not have css class: "%s". ' +
-    'Element could not be located.';
+  var DEFAULT_MSG = 'Testing if element <%s> has css class: "%s".';
+  var MSG_ELEMENT_NOT_FOUND = DEFAULT_MSG + ' ' + 'Element could not be located.';
 
   this.message = msg || util.format('Testing if element <%s> does not have css class: "%s".', selector, className);
 
@@ -27,6 +26,10 @@ exports.assertion = function(selector, className, msg) {
   };
 
   this.pass = function(value) {
+    // no class attribute on element anyway, assertion passed
+    if (value === null) {
+      return true;
+    }
     var classes = value.split(' ');
     return classes.indexOf(className) === -1;
   };

--- a/lib/api/assertions/cssClassPresent.js
+++ b/lib/api/assertions/cssClassPresent.js
@@ -16,9 +16,9 @@
 
 var util = require('util');
 exports.assertion = function(selector, className, msg) {
-
-  var MSG_ELEMENT_NOT_FOUND = 'Testing if element <%s> has css class: "%s". ' +
-    'Element could not be located.';
+  var DEFAULT_MSG = 'Testing if element <%s> has css class: "%s".';
+  var MSG_ELEMENT_NOT_FOUND = DEFAULT_MSG + ' ' + 'Element could not be located.';
+  var MSG_ATTR_NOT_FOUND = DEFAULT_MSG + ' ' + 'Element does not have a class attribute.';
 
   this.message = msg || util.format('Testing if element <%s> has css class: "%s".', selector, className);
 
@@ -32,9 +32,16 @@ exports.assertion = function(selector, className, msg) {
   };
 
   this.failure = function(result) {
-    var failed = result === false || result && result.status === -1;
+    var failed = (result === false) ||
+        // no such element or class attribute
+        result && (result.status === -1 || result.value === null);
+
     if (failed) {
-      this.message = msg || util.format(MSG_ELEMENT_NOT_FOUND, selector, className);
+      var defaultMsg = MSG_ELEMENT_NOT_FOUND;
+      if (result && result.value === null) {
+        defaultMsg = MSG_ATTR_NOT_FOUND;
+      }
+      this.message = msg || util.format(defaultMsg, selector, className);
     }
     return failed;
   };


### PR DESCRIPTION
If there is no class attribute on the selected element, assertion must pass in the case of `cssClassNotPresent` and assertion must fail in the case of `cssClassPresent`.
