### PR TITLE
Update minimatch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ejs": "~0.8.3",
     "lodash.clone": "^3.0.3",
     "lodash.defaultsdeep": "^4.3.2",
-    "minimatch": "~0.2.14",
+    "minimatch": "^3.0.3",
     "mkpath": ">=0.1.0",
     "mocha-nightwatch": "2.2.9",
     "optimist": ">=0.3.5",


### PR DESCRIPTION
- `minimatch@0.2.14` is deprecated (because of [an identified RegExp DoS issue](https://snyk.io/vuln/npm:minimatch:20160620))
- `minimatch>=3.0.2` has resolved the issue

I may be missing something obvious, but the tests pass and updating minimatch seems like a "slam dunk" improvement.
