### PR TITLE
Added in a new command 'tags' this takes multiple parameters (',' sep…

### DIFF
--- a/lib/runner/cli/cli.js
+++ b/lib/runner/cli/cli.js
@@ -145,6 +145,11 @@ module.exports = new (function() {
       .defaults('')
       .alias('a');
 
+    // $ nightwatch --tags
+    this.command('tags')
+        .description('Only run tests which have all of the associated tags (comma separated).')
+        .defaults('');
+
     // $ nightwatch --skiptags
     this.command('skiptags')
       .description('Skips tests that have the specified tag or tags (comma separated).');

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -594,6 +594,10 @@ CliRunner.prototype = {
       this.test_settings.tag_filter = this.argv.tag;
     }
 
+    if (this.argv.tags) {
+      this.test_settings.tags_filter = this.argv.tags.split(',');
+    }
+
     if (typeof this.argv.skiptags == 'string') {
       this.test_settings.skiptags = this.argv.skiptags.split(',');
     }

--- a/lib/runner/filematcher.js
+++ b/lib/runner/filematcher.js
@@ -62,6 +62,9 @@ module.exports = {
         if (opts.tag_filter) {
           match = this.containsTag(moduleTags, this.convertTagsToString(opts.tag_filter));
         }
+        if (opts.tags_filter) {
+          match = this.containsMultipleTags(moduleTags, opts.tags_filter);
+        }
         if (opts.skiptags) {
           match = this.excludesTag(moduleTags, this.convertTagsToString(opts.skiptags));
         }
@@ -79,6 +82,12 @@ module.exports = {
     containsTag : function(moduleTags, tags) {
       return moduleTags.some(function (testTag) {
         return (tags.indexOf(testTag) > -1);
+      });
+    },
+
+    containsMultipleTags: function(moduleTags, tags) {
+      return tags.every(function (testTag) {
+        return (moduleTags.indexOf(testTag) > -1);
       });
     },
 

--- a/lib/runner/walk.js
+++ b/lib/runner/walk.js
@@ -141,7 +141,7 @@ module.exports = {
                 return minimatch(filename, opts.filename_filter);
               }
 
-              if (opts.tag_filter || opts.skiptags) {
+              if (opts.tag_filter || opts.tags_filter || opts.skiptags) {
                 return fileMatcher.tags.match(filePath, opts);
               }
 


### PR DESCRIPTION
Hello good people of Night Watch,

When developing using your tool we found a feature requirement that we've dev'd in and thought you might be interested in including into the master. Our problem was that tag's weren't as powerful as we needed, we wanted to run a set of tags against tests, that knew what that feature was, as well as what users that could utilise those features (and so have tests focused on those two requirements).  So that feature 'a' of the user admin widget would run when we also specified 'super user' as a tag but feature 'a' wouldn't be tested when running against a different user type. 

I've added that in under a new command 'tags', below is a brief commit message. If you have any questions or think this is either a great/ terrible idea, please let me know.

Cheers,

Lee 

Added in a new command 'tags' this takes multiple parameters (',' separated) and checks if those tags are all present in the test file. If they are all present then that file is included.

This is useful for feature testing, i.e if a  part of the user admin widget ( tag:'user-admin-widget') can only be seen super users (tag: super-users') you can specify only these tests at run time using --tag user-admin-widget,super-users