### PR TITLE
Add link to MIT license in README for visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ The [Mailing List/Google Group](https://groups.google.com/forum/#!forum/nightwat
 ### Setup Guides
 Browser specific setup and usage guides along with debugging instructions can be found on the [**Wiki**](https://github.com/nightwatchjs/nightwatch/wiki).
 
+### License
+
+Licensed under [the MIT license](https://opensource.org/licenses/MIT).
+


### PR DESCRIPTION
Just to have the license mentioned in the readme and hence shown in places
