### PR TITLE
add test for new command

### DIFF
--- a/test/src/api/commands/testSaveParentScreenshot.js
+++ b/test/src/api/commands/testSaveParentScreenshot.js
@@ -1,0 +1,38 @@
+var MockServer  = require('../../../lib/mockserver.js');
+var assert = require('assert');
+var Nightwatch = require('../../../lib/nightwatch.js');
+var MochaTest = require('../../../lib/mochatest.js');
+
+module.exports = MochaTest.add('saveParentScreenshot', {
+
+    'client.saveParentScreenshot()' : function(done) {
+      var client = Nightwatch.client();
+      var api = Nightwatch.api();
+
+      MockServer.addMock({
+        url : '/wd/hub/session/1352110219202/screenshot',
+        method:'GET',
+        response : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0,
+          value:'screendata'
+        })
+      });
+
+      api.options.log_screenshot_data = false;
+
+      client.saveParentScreenshot = function(fileName, data, cb) {
+        assert.equal(fileName, 'screenshot.png');
+        assert.equal(data, 'screendata');
+        cb();
+      };
+
+      api.saveParentScreenshot('screenshot.png', function(result) {
+        assert.equal(result.value, 'screendata');
+        assert.equal(result.suppressBase64Data, true);
+        done();
+      });
+
+      Nightwatch.start();
+    }
+  });


### PR DESCRIPTION
Adding a new option "capture_parent" in "screenshots" test settings to allow capturing parent when browser is in an iFrame when a test fails.

Current behavior is ; capture the current iFrame only
New behavior is : capture the parent of the iFrame if "capture_parent" is set to 'true' (default behavior is not changed)

Test has also been added in "test\src\api\commands". 
Doc is to update but i don't know how to to this so, here is the content i suggest, to update "http://nightwatchjs.org/guide#test-settings", section 'screenshots' in the table :

_Since v0.9.9 you can force to take screenshot of the parent element by setting "capture_parent" to true._ 

Thx


