### PR TITLE
fixes #1115 - adds optional index property to element objects

### DIFF
--- a/examples/pages/nightwatchFeatures.js
+++ b/examples/pages/nightwatchFeatures.js
@@ -1,0 +1,27 @@
+var featuresCommands = {
+  getFeatureCount: function(callback) {
+    this.api.elements(null, this.elements.features, function (result) {
+      if (result.status === 0) {
+        var countResult = {
+          status: 0,
+          value: result.value.length
+        }
+        callback.call(this, countResult);
+      } else {
+        callback.call(this, result);
+      }
+    }.bind(this));
+    return this;
+  }
+};
+
+module.exports = {
+  commands : [featuresCommands],
+  elements : {
+    featuresHeading : {
+      selector : '#index-container h2',
+      index: 1
+    },
+    features : '#index-container .features h3'
+  }
+};

--- a/examples/tests/nightwatchByIndex.js
+++ b/examples/tests/nightwatchByIndex.js
@@ -1,0 +1,25 @@
+module.exports = {
+  'Show getting Nightwatch features using index' : function (client) {
+
+    client.url('http://nightwatchjs.org');
+
+    var featuresPage = client.page.nightwatchFeatures();
+
+    featuresPage
+      .assert.containsText('@featuresHeading', 'Main Features')
+      .getFeatureCount(function (result) {
+
+        client.assert.equal(result.status, 0, 'status counting features');
+        var totalFeatures = result.value;
+        var lastFeatureIndex = totalFeatures - 1;
+
+        featuresPage.getText({selector: '@features', index: lastFeatureIndex}, function (result) {
+          client.assert.equal(result.status, 0, 'status finding last feature text');
+          client.assert.equal(result.value, 'Continous integration support', 'text of last feature');
+        });
+
+      });
+      
+      client.end();
+  }
+};

--- a/lib/api/element-commands.js
+++ b/lib/api/element-commands.js
@@ -341,12 +341,15 @@ module.exports = function(client) {
   function CommandAction(using, value, protocolAction, args, callback, originalStackTrace) {
     events.EventEmitter.call(this);
 
-    var $this = this;
-    var el = Protocol.element(using, value, function(result) {
+    var elem = Element.fromSelector(value, using);
+    var multipleElements = Element.requiresFiltering(elem);
+    var elementAction = multipleElements ? 'elements' : 'element';
+
+    var self = this;
+    var el = Protocol[elementAction](using, value, function(result) {
       if (result.status !== 0) {
         callback.call(client.api, result);
 
-        var elem = Element.fromSelector(value, using);
         var errorMessage = 'ERROR: Unable to locate element: "' + elem.selector + '" using: "' + elem.locateStrategy + '"';
         var stack = originalStackTrace.split('\n');
 
@@ -356,18 +359,18 @@ module.exports = function(client) {
         client.results.errors++;
         client.errors.push(errorMessage + '\n' + stack.join('\n'));
 
-        $this.emit('complete', el, $this);
+        self.emit('complete', el, self);
       } else {
-        result = result.value.ELEMENT;
+        var elemId = multipleElements ? result.value[0].ELEMENT : result.value.ELEMENT;
 
         args.push(function(r) {
           callback.call(client.api, r);
         });
 
-        args.unshift(result);
+        args.unshift(elemId);
 
         var c = Protocol[protocolAction].apply(Protocol, args).once('complete', function() {
-          $this.emit('complete', c, $this);
+          self.emit('complete', c, self);
         });
       }
     });

--- a/lib/api/element-commands/_elementByRecursion.js
+++ b/lib/api/element-commands/_elementByRecursion.js
@@ -1,5 +1,6 @@
 var util = require('util');
 var events = require('events');
+var Element = require('../../page-object/element.js');
 
 /**
  * Search for an element on the page, starting with the first element of the array, and where each element in the passed array is nested under the previous one. The located element will be returned as a WebElement JSON object.
@@ -21,15 +22,26 @@ ElementByRecursion.prototype.command = function(elements, callback) {
   var allElements = elements.slice();
 
   var topElement = allElements.shift();
-  var el = this.protocol.element(null, topElement, function checkResult(result) {
+  var multipleElements = Element.requiresFiltering(topElement);
+  var elementAction = multipleElements ? 'elements' : 'element';
+
+  var el = this.protocol[elementAction](null, topElement, function checkResult(result) {
     if (result.status !== 0) {
       callback(result);
       self.emit('complete', el, self);
     } else {
+
+      if (multipleElements) {
+        result.value = result.value[0];
+      }
+
       var nextElement = allElements.shift();
-      var parentId = result.value.ELEMENT;
+
       if (nextElement) {
-        self.protocol.elementIdElement(parentId, null, nextElement, checkResult);
+        var parentId = result.value.ELEMENT;
+        multipleElements = Element.requiresFiltering(nextElement);
+        elementAction = multipleElements ? 'elementIdElements' : 'elementIdElement';
+        self.protocol[elementAction](parentId, null, nextElement, checkResult);
       } else {
         callback(result);
         self.emit('complete', el, self);

--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -243,7 +243,7 @@ module.exports = function(Nightwatch) {
     return postRequest('/elements', {
         using: elem.locateStrategy,
         value: elem.selector
-      }, callback
+      }, filterElementsForCallback(elem, callback)
     );
   }
 
@@ -264,7 +264,7 @@ module.exports = function(Nightwatch) {
     return postRequest('/element/' + id + '/elements', {
         using: elem.locateStrategy,
         value: elem.selector
-      }, callback
+      }, filterElementsForCallback(elem, callback)
     );
   };
 
@@ -279,6 +279,64 @@ module.exports = function(Nightwatch) {
         using + '. It must be one of the following:\n' +
         strategies.join(', '));
     }
+  }
+
+  /**
+   * Wraps an elements protocol request callback to include logic to select
+   * a subset of elements if that request requires filtering.
+   * 
+   * @param {Object} elem
+   * @param {function} callback
+   * @private
+   */
+  function filterElementsForCallback(elem, callback) {
+    if (!Element.requiresFiltering(elem)) {
+      return callback;
+    }
+
+    return callback && function elementsCallbackWrapper(result) {
+      if (result && result.status === 0) {
+
+        var filtered = Element.applyFiltering(elem, result.value);
+        if (filtered) {
+
+          result.value = filtered;
+
+        } else {
+
+          result.status = -1;
+          result.value = [];
+          var errorId = 'NoSuchElement';
+          var errorInfo = findErrorById(errorId);
+          if (errorInfo) {
+            result.message = errorInfo.message;
+            result.errorStatus = errorInfo.status;
+          }
+        }
+      }
+
+      return callback(result);
+    };
+  }
+
+  /**
+   * Looks up error status info from an id string rather than id number.
+   * 
+   * @param {string} id String id to look up an error with.
+   */
+  function findErrorById(id) {
+    var errorCodes = require('./errors.json');
+    for (var status in errorCodes) {
+      if (errorCodes[status].id === id) {
+        return {
+          status: status,
+          id: id,
+          message: errorCodes[status].message
+        };
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/lib/page-object/element.js
+++ b/lib/page-object/element.js
@@ -22,6 +22,7 @@ function Element(definition, options) {
 
   this.selector = definition.selector;
   this.locateStrategy = definition.locateStrategy || options.locateStrategy;
+  this.index = definition.index;
   this.parent = options.parent;
 }
 
@@ -29,12 +30,17 @@ Element.prototype.toString = function() {
   if (Array.isArray(this.selector)) { // recursive
     return this.selector.join(',');
   }
+
+  var index = parseInt(this.index, 10);
+  var indexStr = isNaN(index) ? '' : '[' + index + ']';
+
   if (!this.name) { // inline (not defined in page or section)
     return this.selector;
   }
+
   var classType = this.constructor.name;
   var prefix = this.constructor === Element ? '@' : '';
-  return classType + '[name=' + prefix + this.name + ']';
+  return classType + '[name=' + prefix + this.name + indexStr + ']';
 };
 
 /**
@@ -78,7 +84,7 @@ Element.prototype.getRecursiveLookupElement = function () {
  * @param {Object} source The object to capture values from.
  */
 Element.copyDefaults = function(target, source) {
-  var props = ['name', 'parent', 'selector', 'locateStrategy'];
+  var props = ['name', 'parent', 'selector', 'locateStrategy', 'index'];
   props.forEach(function(prop) {
     if (target[prop] === undefined || target[prop] === null) {
       target[prop] = source[prop];
@@ -117,6 +123,48 @@ Element.fromSelector = function(value, using) {
   }
 
   return new Element(definition, options);
+};
+
+/**
+ * Returns true when an elements() request is needed to capture
+ * the result of the Element definition.  When false, it means the
+ * Element targets the first result the selector match meaning an
+ * element() (single match only) result can be used.
+ * 
+ * @param {Object} element The Element instance to check to see if
+ *    it will apply filtering.
+ */
+Element.requiresFiltering = function(element) {
+
+  var usingIndex = !isNaN(parseInt(element.index, 10));
+  if (usingIndex) {
+    return true;
+  }
+
+  return false;
+};
+
+/**
+ * Filters an elements() results array to a more specific set based
+ * on an Element object's definition.
+ * 
+ * @param {Object} element The Element instance to check to see if
+ *    it will apply filtering.
+ * @param {Array} resultElements Array of WebElement JSON objects
+ *    returned from a call to elements() or elementIdElements().
+ * @returns {Array} A filtered version of the elements array or, if
+ *    the filter failed (no matches found) null.
+ */
+Element.applyFiltering = function(element, resultElements) {
+
+  var index = parseInt(element.index, 10);
+  var usingIndex = !isNaN(index);
+  if (usingIndex) {
+    var foundElem = resultElements[index];
+    return foundElem ? [foundElem] : null; // null = not found
+  }
+
+  return resultElements;
 };
 
 /**

--- a/lib/page-object/section.js
+++ b/lib/page-object/section.js
@@ -7,7 +7,7 @@ var CommandWrapper = require('./command-wrapper.js');
  * Class that all sections subclass from
  *
  * @param {Object} definition User-defined section options defined in page object
- * @param {Object} options Additional options to be given to the element.
+ * @param {Object} options Additional options to be given to the section.
  * @constructor
  */
 function Section(definition, options) {

--- a/test/extra/pageobjects/simplePageObj.js
+++ b/test/extra/pageobjects/simplePageObj.js
@@ -9,6 +9,7 @@ module.exports = {
   elements: {
     loginAsString: '#weblogin',
     loginCss: { selector: '#weblogin' },
+    loginIndexed: { selector: '#weblogin', index: 1 },
     loginXpath: { selector: '//weblogin', locateStrategy: 'xpath' },
     loginId: { selector: 'weblogin', locateStrategy: 'id' }
   },
@@ -16,7 +17,12 @@ module.exports = {
     signUp: {
       selector: '#signupSection',
       sections: {
-        getStarted: { selector: '#getStarted' }
+        getStarted: {
+          selector: '#getStarted',
+          elements: {
+            start: { selector: '#getStartedStart' }
+          }
+        }
       },
       elements: {
         help: { selector: '#helpBtn' }

--- a/test/lib/nockselements.js
+++ b/test/lib/nockselements.js
@@ -8,14 +8,14 @@ module.exports = {
   _requestUri: 'http://localhost:10195',
   _protocolUri: '/wd/hub/session/1352110219202/',
 
-  elementFound : function(selector, using) {
+  elementFound : function(selector, using, foundElem) {
     nock(this._requestUri)
       .persist()
       .post(this._protocolUri + 'element', {'using':using || 'css selector','value':selector || '#nock'})
       .reply(200, {
         status: 0,
         state: 'success',
-        value: { ELEMENT: '0' }
+        value: foundElem || { ELEMENT: '0' }
       });
     return this;
   },
@@ -57,14 +57,14 @@ module.exports = {
     return this;
   },
 
-  elementByXpath : function(selector) {
+  elementByXpath : function(selector, foundElem) {
     nock(this._requestUri)
       .persist()
       .post(this._protocolUri + 'element', {'using':'xpath','value':selector || '//[@id="nock"]'})
       .reply(200, {
         status: 0,
         state: 'success',
-        value: { ELEMENT: '0' }
+        value: foundElem || { ELEMENT: '0' }
       });
     return this;
   },
@@ -81,7 +81,7 @@ module.exports = {
     return this;
   },
 
-  elementId : function (id, selector, using) {
+  elementId : function (id, selector, using, foundElem) {
     nock(this._requestUri)
       .persist()
       .post(this._protocolUri + 'element/' + (id || 0) + '/element',
@@ -89,7 +89,7 @@ module.exports = {
       .reply(200, {
         status: 0,
         state : 'success',
-        value: { ELEMENT: '0' }
+        value: foundElem || { ELEMENT: '0' }
       });
     return this;
   },

--- a/test/src/api/element-selectors/testIndexedElementSelectors.js
+++ b/test/src/api/element-selectors/testIndexedElementSelectors.js
@@ -1,0 +1,254 @@
+var path = require('path');
+var assert = require('assert');
+var common = require('../../../common.js');
+var Api = common.require('core/api.js');
+var utils = require('../../../lib/utils.js');
+var nocks = require('../../../lib/nockselements.js');
+var MochaTest = require('../../../lib/mochatest.js');
+var Nightwatch = require('../../../lib/nightwatch.js');
+
+module.exports = MochaTest.add('test index in element selectors', {
+
+  beforeEach: function (done) {
+    Nightwatch.init({
+      page_objects_path: [path.join(__dirname, '../../../extra/pageobjects')]
+    }, done);
+  },
+
+  afterEach: function () {
+    nocks.cleanAll();
+  },
+
+  'calling protocol.element(using, {selector, index})' : function(done) {
+    nocks.elementFound();
+
+    Nightwatch.api()
+      .element('css selector', {selector: '#nock', index: 0}, function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element, 0 index ignored');
+      })
+      .element('css selector', {selector: '#nock', index: 1}, function callback(result) {
+        assert.equal(result.value.ELEMENT, '0', 'Found element, 1 index ignored');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'calling protocol.elements(using, {selector, index})' : function(done) {
+    nocks.elementsFound();
+
+    Nightwatch.api()
+      .elements('css selector', {selector: '.nock', index: 0}, function callback(result) {
+        assert.equal(result.value.length, 1, 'found index, one element');
+        assert.equal(result.value[0].ELEMENT, '0', 'Found element 0');
+      })
+      .elements('css selector', {selector: '.nock', index: 1}, function callback(result) {
+        assert.equal(result.value.length, 1, 'found index, one element');
+        assert.equal(result.value[0].ELEMENT, '1', 'Found element 1');
+      })
+      .elements('css selector', {selector: '.nock', index: 2}, function callback(result) {
+        assert.equal(result.value.length, 1, 'found index, one element');
+        assert.equal(result.value[0].ELEMENT, '2', 'Found element 2');
+      })
+      .elements('css selector', {selector: '.nock', index: 999}, function callback(result) {
+        assert.equal(result.value.length, 0, 'Out of range index, empty result set');
+        assert.equal(result.status, -1, 'Not found for out of range index');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  // wrapped selenium command
+
+  'calling getText(<various>, {index})' : function(done) {
+    nocks
+      .elementsFound()
+      .elementsByXpath()
+      .text(0, 'first')
+      .text(1, 'second');
+
+    Nightwatch.api()
+      .getText({selector: '.nock', index: 1}, function callback(result) {
+        assert.equal(result.value, 'second', 'getText index 1');
+      })
+      .getText({selector: '//[@class="nock"]', locateStrategy: 'xpath', index: 1}, function callback(result) {
+        assert.equal(result.value, 'second', 'getText xpath locateStrategy index 1');
+      })
+      .getText({selector: '//[@class="nock"]', locateStrategy: 'xpath', index: 999}, function callback(result) {
+        assert.equal(result.status, -1, 'getText xpath locateStrategy out of range index');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  // custom command
+
+  'calling waitForElementPresent(<various>, {index})' : function(done) {
+    nocks
+      .elementsFound();
+
+    Nightwatch.api()
+      .waitForElementPresent({selector: '.nock', index: 1}, 1, false, function callback(result) {
+        assert.equal(result.value.length, 1, 'waitforPresent index has results');
+        assert.equal(result.value[0].ELEMENT, '1', 'waitforPresent found element 1');
+      })
+      .waitForElementPresent({selector: '.nock', index: 999}, 1, false, function callback(result) {
+        assert.equal(result.value, false, 'waitforPresent out of bounds index expected false');
+      })
+      .perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'using page elements with index' : function(done) {
+    nocks
+      .elementsFound('#weblogin')
+      .text(0, 'first')
+      .text(1, 'second');
+
+    var client = Nightwatch.client();
+    Api.init(client);
+
+    var page = client.api.page.simplePageObj();
+
+    page
+      .getText('@loginIndexed', function callback(result) {
+        assert.equal(result.status, 0, 'status for element indexed found');
+        assert.equal(result.value, 'second', 'element indexed value');
+      })
+      .getText({selector:'@loginIndexed', index: 0}, function callback(result) {
+        assert.equal(result.status, 0, 'status for element index 0 override found');
+        assert.equal(result.value, 'first', 'element index overridde value');
+      })
+      .getText({selector:'@loginCss', index: 1}, function callback(result) {
+        assert.equal(result.status, 0, 'status for element selector index 1 found');
+        assert.equal(result.value, 'second', 'element selector index 1 value');
+      })
+      .getText({selector:'@loginCss', index: 999}, function callback(result) {
+        assert.equal(result.status, -1, 'element selector index out of bounds not found');
+      })
+      .api.perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'using page section elements with index' : function(done) {
+    nocks
+      .elementsFound('#signupSection', [{ELEMENT: '0'}]) // page.section
+      .elementFound('#signupSection', null, {ELEMENT: '0'})
+      .elementsId(0, '#helpBtn', [{ELEMENT: '1'},{ELEMENT: '2'}])
+      .elementId(0, '#helpBtn', null, {ELEMENT: '1'})
+      .text(1, 'help-first')
+      .text(2, 'help-second')
+      .elementsId(0, '#getStarted', [{ELEMENT: '10'}]) // page.section.section
+      .elementId(0, '#getStarted', null, {ELEMENT: '10'})
+      .elementsId(10, '#getStartedStart', [{ELEMENT: '11'}]) // page.section.section.element
+      .elementId(10, '#getStartedStart', null, {ELEMENT: '11'})
+      .text(11, 'start-first')
+
+    var client = Nightwatch.client();
+    Api.init(client);
+
+    var page = client.api.page.simplePageObj();
+    var section = page.section.signUp;
+    var sectionChild = section.section.getStarted;
+
+    section
+      .getText({selector:'@help'}, function callback(result) {
+        assert.equal(result.status, 0, 'section element selector found');
+        assert.equal(result.value, 'help-first', 'section element selector value');
+      })
+      .getText({selector:'@help', index: 1}, function callback(result) {
+        assert.equal(result.status, 0, 'section element selector index 1 found');
+        assert.equal(result.value, 'help-second', 'section element selector index 1 value');
+      })
+      .getText({selector:'@help', index: 999}, function callback(result) {
+        assert.equal(result.status, -1, 'section element selector index out of bounds not found');
+      });
+
+    sectionChild
+      .getText({selector:'@start'}, function callback(result) {
+        assert.equal(result.status, 0, 'child section element selector found');
+        assert.equal(result.value, 'start-first', 'child section element selector value');
+      })
+      .getText({selector:'@start', index: 0}, function callback(result) {
+        assert.equal(result.status, 0, 'child section element selector index 0 found');
+        assert.equal(result.value, 'start-first', 'child section element selector index 0 value');
+      })
+      .getText({selector:'@start', index: 999}, function callback(result) {
+        assert.equal(result.status, -1, 'child section element selector index out of bounds not found');
+      })
+      .api.perform(function() {
+        done();
+      });
+
+    Nightwatch.start();
+  },
+
+  'using expect selectors with index' : function (done) {
+    nocks
+      .elementsFound()
+      .elementsFound('#signupSection', [{ELEMENT: '0'}])
+      .elementsId(0, '#helpBtn', [{ELEMENT: '0'}])
+      .elementsByXpath();
+
+    var client = Nightwatch.client();
+    Api.init(client);
+    var api = client.api;
+    api.globals.abortOnAssertionFailure = false;
+
+    var page = api.page.simplePageObj();
+    var section = page.section.signUp;
+
+    var passes = [
+      api.expect.element({selector: '.nock', index: 2}).to.be.present.before(1),
+      page.expect.section({selector: '@signUp', locateStrategy: 'css selector', index: 0}).to.be.present.before(1),
+      section.expect.element({selector: '@help', index: 0}).to.be.present.before(1)
+    ];
+
+    var fails = [
+      [api.expect.element({selector: '.nock', index: 999}).to.be.present.before(1),
+        'element was not found'],
+      [section.expect.element({selector: '@help', index: 999}).to.be.present.before(1),
+        'element was not found']
+    ];
+
+    api
+      .perform(function(performDone) {
+        process.nextTick(function() { // keep assertions from being swallowed by perform
+
+          passes.forEach(function(expect, index) {
+            assert.equal(expect.assertion.passed, true, 'passing [' + index + ']: ' + expect.assertion.message);
+          });
+
+          fails.forEach(function(expectArr, index) {
+            var expect = expectArr[0];
+            var msgPartial = expectArr[1];
+
+            assert.equal(expect.assertion.passed, false, 'failing [' + index + ']: ' + expect.assertion.message);
+            assert.notEqual(expect.assertion.message.indexOf(msgPartial), -1, 'Message contains: ' + msgPartial);
+          });
+          
+          performDone();
+        });
+      })
+      .perform(function(){
+        done();
+      });
+
+    Nightwatch.start();
+  }
+
+});


### PR DESCRIPTION
Allows the option of specifying an `index` property in element objects for pages or element commands (when objects are used as their selector value).  The `index` is used to target a specific element in a query that results in multiple elements returned.  Normally, only the first element is used (`index = 0`) but using the `index` property, you can specify any element within the result by its index within that result.

In element command selectors:

``` js
// targets 3rd div in document
browser.getText({selector:'div', index:3}, function(result){});
```

In page object definitions:

``` js
module.exports = {
  commands: [],
  elements: {
    mydiv: {
      selector: 'div',
      index: 3 
    }
  }
};
```

``` js
// targets 3rd div in document
page.getText('@mydiv', function(result){});
```

Object selectors in commands can be used to override what the page element defined:

``` js
page.getText('@mydiv', function(result){}); // 3rd div
page.getText({selector:'@mydiv', index:6}, function(result){}); // 6th div
```
---

About the code: The `index` property is captured from user-defined page object element/section selectors and objects used in element command selectors.

New, static Element methods `requiresFiltering` and `applyFiltering` are used to both detect and apply this "filter" - a term used as a generic encapsulation that explains what the `index` property, and potentially others in the future, is [would be] doing.  These methods are static because otherwise it would further pollute the Element instance namespace, which is shared by Section, which can be given custom commands.  So every additional instance member added is a potential collision with user-defined section commands.  Even by adding `index` there's already the potential for a collision with an existing user's custom section command.  But with `index`, the code does isNaN checks which should protect against this... to an extent.

`CommandAction` in element-commands.js is where filtering is first checked to know if we need to use `element` or `elements` for the protocol command to fetch elements.  We could always use `elements` but using `element` when multiple elements aren't needed is done as a performance optimization.  After requesting elements, the results are filtered in the results callback reducing the element to a single result for those protocol commands that return element lists (`elements` and `elementIdElements`).

Due to the element/elements optimization, recursion in _elementByRecursion.js also needed to be updated to, on an a recursive `element` call, be able to switch over to using `elements`/`elementIdElements` as needed when an index is specified in one of the Element objects in the recursive list.
