### PR TITLE
log all uncaught errors even though the finishCallback hasn't been set

### DIFF
--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -31,6 +31,8 @@ function processListener() {
 
     if (finishCallback) {
       finishCallback(err);
+    } else {
+      console.error(err);
     }
   });
 }


### PR DESCRIPTION
This PR solves an issue we spent a lot of time with. Suppose you have a test with an error in syntax and you run `./node_modules/.bin/nightwatch`. It fails immediately without any message/non-zero status code.
