### PR TITLE
Issue/1141 overwritable request timeout

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -13,7 +13,7 @@ module.exports = (function() {
     credentials   : null,
     use_ssl       : false,
     proxy         : null,
-    timeout       : 120
+    timeout       : 15000
   };
 
   var DO_NOT_LOG_ERRORS = [
@@ -167,8 +167,7 @@ module.exports = (function() {
     });
 
     this.request.setTimeout(Settings.timeout, function(response) {
-      console.log('Warning - Request Timeout')
-      self.emit('success', {}, {});
+      self.emit('timeout');
     });
 
     Logger.info('Request: ' + this.reqOptions.method + ' ' + this.hostname + this.reqOptions.path,

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -211,7 +211,7 @@ module.exports = (function() {
     Settings.default_path = path;
   };
   HttpRequest.setRequestTimeout = function(timeout) {
-    Settings.timeout = timeout
+    Settings.timeout = timeout;
   };
 
   ///////////////////////////////////////////////////////////

--- a/lib/index.js
+++ b/lib/index.js
@@ -466,37 +466,56 @@ Nightwatch.prototype.startSession = function () {
     }
   };
 
-  var request = new HttpRequest(options);
-  request.on('success', function(data, response, isRedirect) {
-    if (data && data.sessionId) {
-      self.sessionId = self.api.sessionId = data.sessionId;
-      if (data.value) {
-        self.api.capabilities = data.value;
-      }
-      Logger.info('Got sessionId from selenium', self.sessionId);
-      self.emit('selenium:session_create', self.sessionId, request, response);
-    } else if (isRedirect) {
-      self.followRedirect(request, response);
+  var retries = 5;
+
+  function createRequest(){
+    if (retries > 0){
+      retries = retries - 1;
+      var request = new HttpRequest(options);
+
+      var successCb = function successCb (data, response, isRedirect) {
+        if (data && data.sessionId) {
+          self.sessionId = self.api.sessionId = data.sessionId;
+          if (data.value) {
+            self.api.capabilities = data.value;
+          }
+          Logger.info('Got sessionId from selenium', self.sessionId);
+          self.emit('selenium:session_create', self.sessionId, request, response);
+        } else if (isRedirect) {
+          self.followRedirect(request, response);
+        } else {
+          request.emit('error', data, null);
+        }
+      };
+
+      var errorCb = function errorCb (data, err) {
+        if (self.options.output) {
+          console.error('\n' + Logger.colors.light_red('Error retrieving a new session from the selenium server'));
+        }
+
+        if (typeof data == 'object' && Object.keys(data).length === 0) {
+          data = '';
+        }
+
+        if (!data && err) {
+          data = err;
+        }
+
+        self.emit('error', data);
+      };
+
+      request
+      .on('success', successCb)
+      .on('error', errorCb)
+      .on('timeout', createRequest) // recursive
+      .send();
+
     } else {
-      request.emit('error', data, null);
+      self.emit('error', {});
     }
-  })
-  .on('error', function(data, err) {
-    if (self.options.output) {
-      console.error('\n' + Logger.colors.light_red('Error retrieving a new session from the selenium server'));
-    }
+  }
 
-    if (typeof data == 'object' && Object.keys(data).length === 0) {
-      data = '';
-    }
-
-    if (!data && err) {
-      data = err;
-    }
-
-    self.emit('error', data);
-  })
-  .send();
+  createRequest();
 
   return this;
 };


### PR DESCRIPTION
This pull request is aim to fix #1141 and #1223 .
It is actually the same solution you can find in @NickStefan's PR https://github.com/nightwatchjs/nightwatch/pull/1232
But adding the timeout to the Settings and making it overwritable from the `nightwatch.json` file

Now you can pass `reqTimeout` in your nightwatch.json and it will overwrite the default value: 
```
  "test_settings" : {
    "default" : {
      "reqTimeout" : 6000,
      }
   ...
```
If not setting is passed the default value is stilll 15000 as @NickStefan suggested.