### PR TITLE
Fix walk not calling done() if the last path is an excluded dir

### DIFF
--- a/lib/runner/walk.js
+++ b/lib/runner/walk.js
@@ -59,6 +59,9 @@ function walk(dir, done, opts) {
 
           if (isExcluded || isSkipped) {
             pending = pending-1;
+            if (!pending) {
+              done(null, results);
+            }
           } else {
             walk(resource, function(err, res) {
               results = results.concat(res);


### PR DESCRIPTION
If the last path looked at in a given directory was an ignored/excluded directory, script execution would end silently.