### PR TITLE
fixed called stack-exceeded bug, when a parameter is null

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -109,7 +109,9 @@ CliRunner.prototype = {
    * @param {Object} [target]
    */
   replaceEnvVariables : function(target) {
-    target = target || this.settings;
+    if(target === undefined) {
+      target = this.settings;
+    }
     for (var key in target) {
       switch(typeof target[key]) {
       case 'object':


### PR DESCRIPTION
`  typeof null === 'object'`  
and in the beginning of the function is a not typesecure check, if a value is given.
This results in an endless recusive function
`  RangeError: Maximum call stack size exceeded
`