### PR TITLE
log_screenshot_data should be false by default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -111,8 +111,9 @@ Nightwatch.prototype.setOptions = function(options) {
   this.api.options.skip_testcases_on_fail = this.options.skip_testcases_on_fail ||
     (typeof this.options.skip_testcases_on_fail == 'undefined' && this.options.start_session); // off by default for unit tests
 
-  this.api.options.log_screenshot_data = this.options.log_screenshot_data ||
-    (typeof this.options.log_screenshot_data == 'undefined');
+  // false by default
+  this.api.options.log_screenshot_data = (typeof this.options.log_screenshot_data !== 'undefined') &&
+    this.options.log_screenshot_data;
   var seleniumPort = this.options.seleniumPort || this.options.selenium_port;
   var seleniumHost = this.options.seleniumHost || this.options.selenium_host;
   var useSSL       = this.options.useSsl || this.options.use_ssl;

--- a/test/src/index/testNightwatchIndex.js
+++ b/test/src/index/testNightwatchIndex.js
@@ -255,6 +255,15 @@ module.exports = {
       eq(client.api.options.screenshotsPath, '');
     },
 
+    testSetOptionsScreenshotsDefaults: function () {
+      var client = Nightwatch.createClient();
+      var eq = assert.equal;
+
+      eq(client.api.options.log_screenshot_data, false);
+      eq(client.options.screenshots.on_error, undefined);
+      eq(client.api.options.screenshotsPath, undefined);
+    },
+
     testSetOptionsScreenshotsOnError: function () {
       var client = Nightwatch.createClient({
         screenshots: {


### PR DESCRIPTION
log_screenshot_data should be false by default, according to http://nightwatchjs.org/getingstarted#test-settings

However, it's currently true by default.

This PR makes it false by default and adds a test for the same.

Currently:

value of log_screenshot_data | base64 screenshot data shown in verbose log?
------------ | -------------
true | yes
false | no
default | yes <-- wrong

With this PR:

value of log_screenshot_data | base64 screenshot data shown in verbose log?
------------ | -------------
true | yes
false | no
default | no <-- fixed
