### PR TITLE
Fixes #1224: add support for page object commands as object, not just array

### DIFF
--- a/lib/page-object/page-utils.js
+++ b/lib/page-object/page-utils.js
@@ -86,6 +86,11 @@ module.exports = new (function() {
    * @returns {null}
    */
   this.addCommands = function(parent, commands) {
+
+    if (!Array.isArray(commands) && typeof commands === 'object') {
+      commands = [commands];
+    }
+
     commands.forEach(function(m) {
       Object.keys(m).forEach(function(k) {
         parent[k] = m[k];

--- a/test/extra/pageobjects/pageObjCommandsObject.js
+++ b/test/extra/pageobjects/pageObjCommandsObject.js
@@ -1,0 +1,19 @@
+module.exports = {
+  elements: {},
+  commands: {
+    testCommand : function() {
+      return this;
+    }
+  },
+
+  sections: {
+    signUp: {
+      selector: '#signupSection',
+      commands: {
+        testCommand : function() {
+          return this;
+        }
+      }
+    }
+  }
+};

--- a/test/src/core/testPageObjectApi.js
+++ b/test/src/core/testPageObjectApi.js
@@ -65,6 +65,16 @@ module.exports = {
       assert.equal(page.elements.otherElement.selector, '#otherElement');
     },
 
+    testPageObjectCommandsObject: function () {
+      var page = this.client.api.page.pageObjCommandsObject();
+      assert.ok('testCommand' in page, 'testCommand exists in page object');
+      assert.equal(page.testCommand(), page, 'testCommand() returns page object');
+
+      var signUp = page.section.signUp;
+      assert.ok('testCommand' in signUp, 'testCommand exists in page object section');
+      assert.equal(signUp.testCommand(), signUp, 'testCommand() returns page object section');
+    },
+
     testPageObjectSubDirectory : function() {
       assert.ok('addl' in this.client.api.page);
       assert.ok('simplePageObject' in this.client.api.page.addl);


### PR DESCRIPTION
#1224 
Prior to this change, commands defined in page objects only supported arrays, for example:

```js
// myPageObject.js
module.exports = {
  elements: {},
  commands: [
    {
      mySingleCommand: function(){
        //...
      }
    }
  ]
};
```

With this change, the array isn't required, allowing you to specify commands as a single object.  This now matches `elements` which also supports both array and object formats for its definition.

```js
// myPageObject.js
module.exports = {
  elements: {},

  // with this change, no array
  commands: {
    mySingleCommand: function(){
      //...
    }
  }
};
```