### PR TITLE
Allow for multi-path strings in certain settings

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -95,7 +95,7 @@ CliRunner.prototype = {
       }
 
       if (this.settings.page_objects_path && typeof this.settings.page_objects_path == 'string') {
-        this.settings.src_folders = [this.settings.page_objects_path.split(',')];
+        this.settings.page_objects_path = this.settings.page_objects_path.split(',');
       }
 
       this.settings.output = this.settings.output || typeof this.settings.output == 'undefined';

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -94,6 +94,10 @@ CliRunner.prototype = {
         this.settings.src_folders = [this.settings.src_folders];
       }
 
+      if (this.settings.page_objects_path && typeof this.settings.page_objects_path == 'string') {
+        this.settings.src_folders = [this.settings.page_objects_path.split(',')];
+      }
+
       this.settings.output = this.settings.output || typeof this.settings.output == 'undefined';
       this.settings.detailed_output = this.settings.detailed_output || typeof this.settings.detailed_output == 'undefined';
     } catch (ex) {

--- a/lib/runner/filematcher.js
+++ b/lib/runner/filematcher.js
@@ -84,7 +84,7 @@ module.exports = {
   exclude : {
     adaptFilePath : function(filePath, excludedPath) {
       if (!Array.isArray(excludedPath)) {
-        excludedPath = [excludedPath];
+        excludedPath = excludedPath.split(',');
       }
       return excludedPath.map(function(item) {
         return adaptFilePath(filePath, item);

--- a/lib/runner/walk.js
+++ b/lib/runner/walk.js
@@ -31,7 +31,7 @@ function addMatcher(type, filePath, opts) {
   if (Array.isArray(matchers)) {
     Matchers[type].push.apply(Matchers[type], matchers);
   } else {
-    Matchers[type].push(matchers);
+    Matchers[type].push.apply(Matchers[type], matchers.split(','));
   }
 
 }


### PR DESCRIPTION
We over at https://github.com/keystonejs/keystone-nightwatch-e2e have a requirement to programmatically set the `src_folders`, `page_object_path`, and `exclude` nightwatch.json settings with multi-path strings.  For example, we want to be able to do things like this:
```
"src_folders": "${SRC_FOLDER_PATHS}",
"page_objects_path": "${PAGE_OBJECTS_PATHS}"
"exclude": "${EXCLUDE_PATHS}"
```
where:
```
process.env.SRC_FOLDER_PATHS = "test/e2e/adminUI/tests, test/e2e/app/tests";
process.env.PAGE_OBJECTS_PATHS = "test/e2e/adminUI/po, test/e2e/app/po";
process.env.EXCLUDE_PATHS = "test/e2e/adminUI/tests/group006Fields/utils.js, test/e2e/adminUI/tests/group999/*";
```

This is not possible with the current implementation as whereever it expects a string path, it assumes a single path.  We need the ability to specify multiple paths in a single string.  This change accomplishes that in a very unobtrusive manner by using string splitting whereever a string path is expected.

We have tested this with our pending implementation requiring this at https://github.com/keystonejs/keystone-nightwatch-e2e/pull/20.  Let us know if there's anything else we may need to do to get this merged.