### PR TITLE
inheriting full stdio if settings.output

### DIFF
--- a/lib/runner/cli/child-process.js
+++ b/lib/runner/cli/child-process.js
@@ -54,7 +54,8 @@ ChildProcess.prototype.run = function(colors, done) {
       cwd: process.cwd(),
       encoding: 'utf8',
       env: env,
-      stdio: [null, null, null, 'ipc']
+      // use inherit to see original output
+      stdio: self.settings.output ? 'inherit' : [null, null, null, 'ipc']
     });
 
     self.child.on('message', function(data) {
@@ -67,13 +68,16 @@ ChildProcess.prototype.run = function(colors, done) {
       console.log('Started child process for:' + self.env_label);
     }
 
-    self.child.stdout.on('data', function (data) {
-      self.writeToStdout(data);
-    });
+    // Add basic stdio
+    if (!self.settings.output) {
+      self.child.stdout.on('data', function (data) {
+        self.writeToStdout(data);
+      });
 
-    self.child.stderr.on('data', function (data) {
-      self.writeToStdout(data);
-    });
+      self.child.stderr.on('data', function (data) {
+        self.writeToStdout(data);
+      });
+    }
 
     self.child.on('exit', function (code) {
       if (self.settings.output) {


### PR DESCRIPTION
While debugging I found that using stdio inherit made it easier to trace what was going wrong in child processes. I put this in its own PR in case you like it, or would want changes (i dont know nightwatch super well so maybe there are other flags you use to trigger more verbose/heavy output?)