### PR TITLE
Feature: support for src_folders which are inside of node_modules

### DIFF
--- a/lib/runner/cli/child-process.js
+++ b/lib/runner/cli/child-process.js
@@ -50,8 +50,22 @@ ChildProcess.prototype.run = function(colors, done) {
     env.__NIGHTWATCH_ENV_KEY = self.itemKey;
     env.__NIGHTWATCH_ENV_LABEL = self.env_itemKey;
 
+    var testCWD = process.cwd();
+    var testFilePath = self.args[self.args.length - 2];
+
+    /*
+    * Require the file in the right cwd to ensure it doesn't error
+    */
+    if (testFilePath.indexOf('node_modules') > -1) {
+      var paths = testFilePath.split('/');
+      testCWD = paths.splice(0, paths.indexOf('node_modules') + 2).join('/');
+      if (self.settings.output) {
+        console.log('This test will use its own cwd:', testCWD);
+      }
+    }
+
     self.child = child_process.spawn(process.execPath, cliArgs, {
-      cwd: process.cwd(),
+      cwd: testCWD,
       encoding: 'utf8',
       env: env,
       stdio: [null, null, null, 'ipc']
@@ -64,7 +78,7 @@ ChildProcess.prototype.run = function(colors, done) {
     self.processRunning = true;
 
     if (self.settings.output) {
-      console.log('Started child process for:' + self.env_label);
+      console.log('  Started child process for:' + self.env_label);
     }
 
     self.child.stdout.on('data', function (data) {

--- a/lib/runner/filematcher.js
+++ b/lib/runner/filematcher.js
@@ -23,6 +23,8 @@ function matchFilePath(filePath, pathArr) {
   return false;
 }
 
+var originalCWD = process.cwd();
+
 module.exports = {
   tags: {
     /**
@@ -31,7 +33,17 @@ module.exports = {
      * @returns {boolean} true if specified test matches given tag
      */
     match : function (testFilePath, opts) {
+      /*
+       * Require the file in the right cwd to ensure it doesnt error
+       */
+      if (testFilePath.indexOf('node_modules') > -1) {
+        var paths = testFilePath.split('/');
+        var testCWD = paths.splice(0, paths.indexOf('node_modules') + 2).join('/');
+        process.chdir(testCWD);
+      }
+
       var test = require(testFilePath);
+      process.chdir(originalCWD);
       return this.checkModuleTags(test, opts);
     },
 

--- a/lib/runner/module.js
+++ b/lib/runner/module.js
@@ -1,10 +1,22 @@
 var path = require('path');
 var Utils = require('../util/utils.js');
 
+var originalCWD = process.cwd();
+
 function Module(modulePath, opts, addtOpts) {
+  /*
+   * Require the file in the right cwd to ensure it has access
+   * to its own dependancies
+   */
+  if (modulePath.indexOf('node_modules') > -1) {
+    var paths = modulePath.split('/');
+    var testCWD = paths.splice(0, paths.indexOf('node_modules') + 2).join('/');
+    process.chdir(testCWD);
+  }
 
   try {
     this['@module'] = require(modulePath);
+    process.chdir(originalCWD);
   } catch (err) {
     throw err;
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mocha-lcov-reporter": "^1.2.0",
     "mock-spawn": "^0.2.1",
     "mockery": "~1.4.0",
+    "nightwatch-component-a": "git://github.com/cesine/nightwatch-component-a",
     "nock": "~0.45.0"
   },
   "bin": {

--- a/test/nightwatch.json
+++ b/test/nightwatch.json
@@ -1,5 +1,8 @@
 {
-  "src_folders" : ["./test/src"],
+  "src_folders" : [
+    "./test/src",
+    "./node_modules/nightwatch-component-a/test"
+  ],
   "test_workers" : false,
   "selenium" : {
     "start_process" : false,


### PR DESCRIPTION
- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`)
- [x]  NA If you're fixing a bug also create an issue if one doesn't exist yet
- [x] If it's a new feature explain why do you think it's necessary

This PR sets the `cwd` of child processes to use the `cwd` of the test if the test is inside a node_module, with out this the test is looking for its dependancies in the parent project.

For example:
```
{
  "src_folders" : [
    "./test",
    "./node_modules/nightwatch-component-a/test",
    "./node_modules/nightwatch-component-b/test"
  ],
```

Here is a sample repo https://github.com/cesine/nightwatch-modular-example

Before 

https://travis-ci.org/cesine/nightwatch-modular-example/builds/198396464

After

https://travis-ci.org/cesine/nightwatch-modular-example/builds/198442636

- [x] If your change include drastic or low level changes please discuss them to make sure they will be accepted and what the impact will be

Setting the cwd of a child process is what would make nightwatch a more normal node package where code runs in the relative cwd of its package, not in the cwd of the calling package. https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback

- [x] NA If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will not make it in very quick, if at all.
- [x] Do not include changes that are not related to the issue at hand
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.
- [x] Add unit tests