### PR TITLE
[feature request] cli switch to list defined tags #851

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -547,7 +547,9 @@ exports.cli = function(runTests) {
 
 exports.runner = function(argv, done, settings) {
   var runner = exports.CliRunner(argv);
-  return runner.setup(settings, done).runTests(done);
+  return (argv.listtags) ? //depending on this, list the tags or run the tests
+    runner.setup(settings, done).runListTags(done) : //Would really like to remove the redudent ...setup(...)
+    runner.setup(settings, done).runTests(done);
 };
 
 exports.initGrunt = function(grunt) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -547,9 +547,10 @@ exports.cli = function(runTests) {
 
 exports.runner = function(argv, done, settings) {
   var runner = exports.CliRunner(argv);
-  return (argv.listtags) ? //depending on this, list the tags or run the tests
-    runner.setup(settings, done).runListTags(done) : //Would really like to remove the redudent ...setup(...)
-    runner.setup(settings, done).runTests(done);
+  runner.setup(settings, done);
+  return (argv.listtags) ?
+    runner.runListTags(done) :
+    runner.runTests(done);
 };
 
 exports.initGrunt = function(grunt) {

--- a/lib/runner/cli/cli.js
+++ b/lib/runner/cli/cli.js
@@ -149,6 +149,10 @@ module.exports = new (function() {
     this.command('skiptags')
       .description('Skips tests that have the specified tag or tags (comma separated).');
 
+    // $ nightwatch --listtags
+      this.command('listtags').
+          description('Lists currently valid tags compatible for use with either --tag or --skiptags.');
+
     // $ nightwatch --retries
     this.command('retries')
       .description('Retries failed or errored testcases up <n> times.');

--- a/lib/runner/cli/cli.js
+++ b/lib/runner/cli/cli.js
@@ -150,8 +150,8 @@ module.exports = new (function() {
       .description('Skips tests that have the specified tag or tags (comma separated).');
 
     // $ nightwatch --listtags
-      this.command('listtags').
-          description('Lists currently valid tags compatible for use with either --tag or --skiptags.');
+    this.command('listtags')
+      .description('Lists currently valid tags compatible for use with either --tag or --skiptags.');
 
     // $ nightwatch --retries
     this.command('retries')

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -384,36 +384,16 @@ CliRunner.prototype = {
    * @returns {CliRunner}
    */
   runListTags: function (finished) {
-    const location = "FV: clirunner:runListTags";
-
-    var fn = function (a1,a2) {
-        console.log(location, "fn", a1, a2);
-    };
-
-    //want to know what this does.
     var source;
+    finished = finished || function(){};
     try {
       source = this.getTestSource();
     } catch (err) {
-      fn(err, {});
+      finished(err, {});
       return;
     }
 
-    var runner = new TagListRunner(source, this.test_settings, {
-      //  thus far, we don't need this stuff.
-      // output_folder : this.output_folder,
-      src_folders : this.settings.src_folders
-      // live_output : this.settings.live_output,
-      // detailed_output : this.settings.detailed_output,
-      // start_session: this.startSession,
-      // reporter : this.argv.reporter,
-      // testcase : this.argv.testcase,
-      // end_session_on_fail : this.endSessionOnFail,
-      // retries : this.argv.retries,
-      // test_worker : this.isTestWorker(),
-      // suite_retries : this.argv.suiteRetries
-    }, fn);
-
+    var runner = new TagListRunner(source, this.test_settings, { src_folders : this.settings.src_folders }, finished);
     runner.run();
 
     return this;

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -114,12 +114,12 @@ CliRunner.prototype = {
       switch(typeof target[key]) {
         case 'object':
           this.replaceEnvVariables(target[key]);
-        break;
+          break;
         case 'string':
           target[key] = target[key].replace(/\$\{(\w+)\}/g, function(match, varName) {
             return process.env[varName] || '${' + varName + '}';
           });
-        break;
+          break;
       }
     }
 

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -5,6 +5,7 @@ var clone = require('lodash.clone');
 var defaults = require('lodash.defaultsdeep');
 
 var Runner = require('../run.js');
+var TagListRunner = require('../taglistrun');
 var Logger = require('../../util/logger.js');
 var Utils = require('../../util/utils.js');
 var Selenium = require('../selenium.js');
@@ -374,6 +375,48 @@ CliRunner.prototype = {
     }
 
     return deferred.promise;
+  },
+
+  /**
+   * Lists the tags currently known to the test runner.
+   *
+   * @param {function} [finished] optional callback
+   * @returns {CliRunner}
+   */
+  runListTags: function (finished) {
+    const location = "FV: clirunner:runListTags";
+
+    var fn = function (a1,a2) {
+        console.log(location, "fn", a1, a2);
+    };
+
+    //want to know what this does.
+    var source;
+    try {
+      source = this.getTestSource();
+    } catch (err) {
+      fn(err, {});
+      return;
+    }
+
+    var runner = new TagListRunner(source, this.test_settings, {
+      //  thus far, we don't need this stuff.
+      // output_folder : this.output_folder,
+      src_folders : this.settings.src_folders
+      // live_output : this.settings.live_output,
+      // detailed_output : this.settings.detailed_output,
+      // start_session: this.startSession,
+      // reporter : this.argv.reporter,
+      // testcase : this.argv.testcase,
+      // end_session_on_fail : this.endSessionOnFail,
+      // retries : this.argv.retries,
+      // test_worker : this.isTestWorker(),
+      // suite_retries : this.argv.suiteRetries
+    }, fn);
+
+    runner.run();
+
+    return this;
   },
 
   /**

--- a/lib/runner/taglistrun.js
+++ b/lib/runner/taglistrun.js
@@ -95,15 +95,12 @@ TagListRunner.prototype.run = function runner() {
     .then(function(tagList) {
       deferred.resolve(tagList);
     })
-    // .catch(function(err) {
-    //   self.doneCb(err, false); //
-    // })
     .catch(function(err) {
+      self.doneCb(err, false);
       deferred.reject(err);
     });
 
   return deferred.promise;
-
 };
 
 module.exports = TagListRunner;

--- a/lib/runner/taglistrun.js
+++ b/lib/runner/taglistrun.js
@@ -1,0 +1,109 @@
+var Walk = require('./walk.js');
+var TestSuite = require('./testsuite.js');
+var Logger = require('../util/logger.js');
+var path = require('path');
+var Q = require('q');
+
+function TagListRunner(testSource, opts, additionalOpts, doneCb) {
+  this.testSource = testSource || [];
+  this.options = opts;
+  this.additionalOpts = additionalOpts;
+  this.doneCb = doneCb || function() {}; //TODO: Consider removing.
+}
+
+TagListRunner.readPaths = function(testSource, opts, cb) {
+  var deferred = Q.defer();
+  cb = cb || function() {};
+
+  if (typeof testSource == 'string') {
+    testSource = [testSource];
+  }
+
+  var fullPaths = testSource.map(function (p) {
+    if (p.indexOf(process.cwd()) === 0 || path.resolve(p) === p) {
+      return p;
+    }
+
+    return path.join(process.cwd(), p);
+  });
+
+  if (fullPaths.length === 0) {
+    throw new Error('No source folder defined. Check configuration.');
+  }
+
+  var errorMessage = ['No tests defined! using source folder:', fullPaths];
+  if (opts.tag_filter) {
+    errorMessage.push('; using tags:', opts.tag_filter);
+  }
+
+  Walk.readPaths(fullPaths, function (err, modules) {
+    if (err) {
+      if (err.code == 'ENOENT') {
+        var error = new Error('Cannot read source folder: ' + err.path);
+        cb(error, false);
+        deferred.reject(error);
+        return;
+      }
+      cb(err, false);
+      deferred.reject(err);
+      return;
+    }
+
+    opts.modulesNo = modules.length;
+
+    if (modules.length === 0) {
+      var error2 = new Error(errorMessage.join(' '));
+      cb(error2);
+      deferred.reject(error2);
+      return;
+    }
+
+    cb(null, modules, fullPaths);
+    deferred.resolve([modules, fullPaths]);
+  }, opts);
+
+  return deferred.promise;
+};
+
+TagListRunner.prototype.run = function runner() {
+  var deferred = Q.defer();
+  var self = this;
+
+  TagListRunner.readPaths(this.testSource, this.options)
+    .spread(function TagListRunnerSpreadCallback(modulePaths, fullPaths) {
+      var tagsList = [];
+
+      modulePaths.forEach(function(modulePath) {
+        var testSuite = new TestSuite(modulePath, fullPaths, self.options, self.additionalOpts);
+        var tags = testSuite.module["@attributes"]["@tags"] || [];
+        tags.map( function(tag) { tagsList.push(tag); } )
+      });
+
+      /*
+        Output Ideas:
+          Tag List: tag1, tag2, tag3 ...
+
+          Tag List:
+            Module:Tags tag1, tag2
+            Module1:Tags tag3, tag2
+       */
+
+      tagsList = tagsList.filter( function deDup( itm, idx, srcArr ) { return srcArr.indexOf(itm) == idx; }).sort();
+      console.log( 'Tag List: ', tagsList.join(", ") );
+      return tagsList;
+    })
+    .then(function(tagList) {
+      deferred.resolve(tagList);
+    })
+    // .catch(function(err) {
+    //   self.doneCb(err, false); //
+    // })
+    .catch(function(err) {
+      deferred.reject(err);
+    });
+
+  return deferred.promise;
+
+};
+
+module.exports = TagListRunner;

--- a/lib/runner/taglistrun.js
+++ b/lib/runner/taglistrun.js
@@ -75,8 +75,8 @@ TagListRunner.prototype.run = function runner() {
 
       modulePaths.forEach(function(modulePath) {
         var testSuite = new TestSuite(modulePath, fullPaths, self.options, self.additionalOpts);
-        var tags = testSuite.module["@attributes"]["@tags"] || [];
-        tags.map( function(tag) { tagsList.push(tag); } )
+        var tags = testSuite.module['@attributes']['@tags'] || [];
+        tags.map( function(tag) { tagsList.push(tag); } );
       });
 
       /*
@@ -89,7 +89,7 @@ TagListRunner.prototype.run = function runner() {
        */
 
       tagsList = tagsList.filter( function deDup( itm, idx, srcArr ) { return srcArr.indexOf(itm) == idx; }).sort();
-      console.log( 'Tag List: ', tagsList.join(", ") );
+      console.log( 'Tag List: ', tagsList.join(', ') );
       return tagsList;
     })
     .then(function(tagList) {

--- a/test/src/runner/testRunWithListTags.js
+++ b/test/src/runner/testRunWithListTags.js
@@ -1,0 +1,46 @@
+var path = require('path');
+var assert = require('assert');
+var common = require('../../common.js');
+var CommandGlobals = require('../../lib/globals/commands.js');
+var tagListRun = common.require('runner/taglistrun.js');
+
+module.exports = {
+  'testRunWithListTags': {
+    before: function (done) {
+      CommandGlobals.beforeEach.call(this, done);
+    },
+
+    after: function (done) {
+      CommandGlobals.afterEach.call(this, done);
+    },
+
+    beforeEach: function () {
+      process.removeAllListeners('exit');
+      process.removeAllListeners('uncaughtException');
+    },
+
+    afterEach: function () {
+      Object.keys(require.cache).forEach(function(module) {
+        delete require.cache[module];
+      });
+    },
+
+    testRunWithListTags: function (done) {
+      var testsPath = path.join(__dirname, '../../sampletests/tags');
+      var runner = new tagListRun( [testsPath], {src_folders:testsPath}, {start_session: false} );
+      var result = runner.run();
+
+      result
+        .then(function(r) {
+          assert.equal( r.length, 2 );
+
+          assert.equal( (r.indexOf('login') > -1), true );
+          assert.equal( (r.indexOf('other') > -1), true );
+          done();
+        })
+        .catch(function(er) {
+          done(er);
+        });
+    }
+  }
+};


### PR DESCRIPTION
In response to my feature request ["[feature request] cli switch to list defined tags #851"](https://github.com/nightwatchjs/nightwatch/issues/851), I came up with an implementation. 

I've kept my changes to a minimum and most of my implementation is in a new module (`taglistrun`). 

I've named the command is `--listtags`. It's a terminal command (as in terminates, not cli) like `help` or `version` 

This is my first signifiant contribution to this or any other project. If I've made a mistake, kindly give me guidance and accept my apologies. I have tried to carefully follow your CONTRIBITUING.md.

Thanks for considering my contribution and thanks for nightwatch as a whole. It's great. 