### PR TITLE
Priority given to configuration passed in as a string

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -56,12 +56,13 @@ CliRunner.prototype = {
    */
   readSettings : function() {
     // use default nightwatch.json file if we haven't received another value
-
     if (this.cli.command('config').isDefault(this.argv.config)) {
       var defaultValue = this.cli.command('config').defaults();
       var localJsValue = path.resolve(SETTINGS_JS_FILE);
 
-      if (Utils.fileExistsSync(SETTINGS_JS_FILE)) {
+      if (this.argv.configStr) {
+        this.argv.config = this.argv.configStr;
+      } else if (Utils.fileExistsSync(SETTINGS_JS_FILE)) {
         this.argv.config = localJsValue;
       } else if (Utils.fileExistsSync(defaultValue)) {
         this.argv.config = path.join(path.resolve('./'), this.argv.config);
@@ -82,9 +83,10 @@ CliRunner.prototype = {
 
     this.argv.env = typeof this.argv.env == 'string' ? this.argv.env : 'default';
 
-    // reading the settings file
+    // reading the settings
     try {
-      this.settings = require(this.argv.config);
+      var settingsResolve = this.argv.configStr ? JSON.parse : require;
+      this.settings = settingsResolve(this.argv.config);
       this.replaceEnvVariables(this.settings);
 
       this.manageSelenium = !this.isParallelMode() && this.settings.selenium &&


### PR DESCRIPTION
To facilitate usage of nightwatch executions as part of server process that runs from js code, allow the user to pass in a stingified example of settings that would ordinarily be in nightwatch.json. This is highly dynamic and easier to debug since one can keep the logic that generates new configurations (say I want to change globals each time) in the node process and not the nightwatch process.