### PR TITLE
Stop clearing global test results and fill in missing data

### DIFF
--- a/lib/runner/clientmanager.js
+++ b/lib/runner/clientmanager.js
@@ -89,6 +89,7 @@ ClientManager.prototype.publishTestResults = function(testcase, results) {
 
   var currentTestSuite = this['@client'].api.currentTest.results;
 
+  currentTestSuite.steps.push(this['@client'].api.currentTest.name);
   currentTestSuite.passed += results.passed;
   currentTestSuite.failed += results.failed;
   currentTestSuite.errors += results.errors;
@@ -103,7 +104,7 @@ ClientManager.prototype.publishTestResults = function(testcase, results) {
     skipped : results.skipped,
     tests : results.tests.length,
     assertions : results.tests,
-    stackTrace : results.stackTrace
+    stackTrace : results.tests[results.tests.length - 1].stackTrace
   };
 
   return this;

--- a/lib/runner/clientmanager.js
+++ b/lib/runner/clientmanager.js
@@ -104,7 +104,7 @@ ClientManager.prototype.publishTestResults = function(testcase, results) {
     skipped : results.skipped,
     tests : results.tests.length,
     assertions : results.tests,
-    stackTrace : (results.tests.length) ? results.tests[results.tests.length - 1].stackTrace : '';
+    stackTrace : (results.tests.length) ? results.tests[results.tests.length - 1].stackTrace : ''
   };
 
   return this;

--- a/lib/runner/clientmanager.js
+++ b/lib/runner/clientmanager.js
@@ -104,7 +104,7 @@ ClientManager.prototype.publishTestResults = function(testcase, results) {
     skipped : results.skipped,
     tests : results.tests.length,
     assertions : results.tests,
-    stackTrace : if (results.tests.length) ? results.tests[results.tests.length - 1].stackTrace : '';
+    stackTrace : (results.tests.length) ? results.tests[results.tests.length - 1].stackTrace : '';
   };
 
   return this;

--- a/lib/runner/clientmanager.js
+++ b/lib/runner/clientmanager.js
@@ -104,7 +104,7 @@ ClientManager.prototype.publishTestResults = function(testcase, results) {
     skipped : results.skipped,
     tests : results.tests.length,
     assertions : results.tests,
-    stackTrace : results.tests[results.tests.length - 1].stackTrace
+    stackTrace : if (results.tests.length) ? results.tests[results.tests.length - 1].stackTrace : '';
   };
 
   return this;

--- a/lib/runner/testsuite.js
+++ b/lib/runner/testsuite.js
@@ -199,6 +199,7 @@ TestSuite.prototype.run = function() {
     }
     this.deferred.resolve(this.testResults);
   } else {
+    this.client.clearGlobalResult();
     this.setCurrentTest();
     this.globalBeforeEach()
       .then(function() {

--- a/lib/runner/testsuite.js
+++ b/lib/runner/testsuite.js
@@ -337,7 +337,6 @@ TestSuite.prototype.resetTestCases = function() {
 
 TestSuite.prototype.setCurrentTest = function() {
   var moduleKey = this.getReportKey();
-  this.client.clearGlobalResult();
 
   this.client.api('currentTest', {
     name : this.currentTest,


### PR DESCRIPTION
Issue here: https://github.com/nightwatchjs/nightwatch/issues/1406

Why:

The global test results after the first try were useless because they
were being zeroed out. Also stack trace and steps weren’t being set to
anything at all.