### PR TITLE
Bug 1039 callback explicit failures

### DIFF
--- a/lib/runner/testsuite.js
+++ b/lib/runner/testsuite.js
@@ -86,12 +86,12 @@ TestSuite.prototype.initHooks = function() {
           var called = false;
           var originalFn = self.module.get(key);
 
-          var doneFn = function() {
+          var doneFn = function(err) {
             called = true;
             if (callbackDeffered) {
               return;
             }
-            return done();
+            return done(err, true);
           };
 
           self.runHookMethod(item, context, argsCount, key, doneFn, this.deferred);
@@ -177,8 +177,8 @@ TestSuite.prototype.initAfterEachHook = function() {
         if (self.options.compatible_testcase_support) {
           asyncFn.call(module, doneFn);
         } else {
-          asyncFn.call(module, api, function() {
-            doneFn();
+          asyncFn.call(module, api, function(err) {
+            doneFn(err);
           });
         }
 
@@ -509,9 +509,8 @@ TestSuite.prototype.adaptDoneCallback = function(done, hookName, deferred) {
 TestSuite.prototype.makePromise = function (fn) {
   var deferred = Q.defer();
   try {
-    fn.call(this, function(err, hookErr) {
-      // in case of an exception thrown inside a global hook, we need to reject the promise here
-      if (hookErr && Utils.isErrorObject(err)) {
+    fn.call(this, function(err, rejectOnError) {
+      if (rejectOnError && Utils.isErrorObject(err)) {
         deferred.reject(err);
       } else {
         deferred.resolve();

--- a/test/asynchookstests/async-provide-error/after.js
+++ b/test/asynchookstests/async-provide-error/after.js
@@ -1,0 +1,11 @@
+module.exports = {
+  demoTest : function (client) {
+    client.url('http://localhost')
+      .assert.elementPresent('#weblogin')
+      .end();
+  },
+
+  after : function(client, done) {
+    done(new Error('Provided error after'));
+  }
+};

--- a/test/asynchookstests/async-provide-error/afterEach.js
+++ b/test/asynchookstests/async-provide-error/afterEach.js
@@ -1,0 +1,11 @@
+module.exports = {
+  demoTest : function (client) {
+    client.url('http://localhost')
+      .assert.elementPresent('#weblogin')
+      .end();
+  },
+
+  afterEach : function(client, done) {
+    done(new Error('Provided error afterEach'));
+  }
+};

--- a/test/asynchookstests/async-provide-error/before.js
+++ b/test/asynchookstests/async-provide-error/before.js
@@ -1,0 +1,11 @@
+module.exports = {
+  demoTest : function (client) {
+    client.url('http://localhost')
+      .assert.elementPresent('#weblogin')
+      .end();
+  },
+
+  before : function(client, done) {
+    done(new Error('Provided error before'));
+  }
+};

--- a/test/asynchookstests/async-provide-error/beforeEach.js
+++ b/test/asynchookstests/async-provide-error/beforeEach.js
@@ -1,0 +1,11 @@
+module.exports = {
+  demoTest : function (client) {
+    client.url('http://localhost')
+      .assert.elementPresent('#weblogin')
+      .end();
+  },
+
+  beforeEach : function(client, done) {
+    done(new Error('Provided error beforeEach'));
+  }
+};

--- a/test/src/runner/testRunWithHooks.js
+++ b/test/src/runner/testRunWithHooks.js
@@ -4,7 +4,7 @@ var common = require('../../common.js');
 var CommandGlobals = require('../../lib/globals/commands.js');
 var Runner = common.require('runner/run.js');
 
-module.exports = {
+var tests = {
   'testRunWithHooks' : {
     before: function (done) {
       CommandGlobals.beforeEach.call(this, done);
@@ -174,7 +174,7 @@ module.exports = {
         persist_globals : true,
         globals: globals
       }, {
-        output_folder: false, 
+        output_folder: false,
         start_session: true
       }, function (err, results) {
         if (err) {
@@ -219,3 +219,42 @@ module.exports = {
     }
   }
 };
+
+var hooks = ['before', 'after', 'beforeEach', 'afterEach'];
+
+hooks.forEach(function (hook) {
+  var provideErrorTest = 'test async ' + hook + ' hook provide error';
+
+  tests.testRunWithHooks[provideErrorTest] = function (done) {
+    var provideErrorTestPath = path.join(__dirname,
+      '../../asynchookstests/async-provide-error/' + hook + '.js');
+    var expectedErrorMessage = 'Provided error ' + hook;
+
+    var globals = {
+      calls : 0,
+      asyncHookTimeout: 10
+    };
+
+    var runner = new Runner([provideErrorTestPath], {
+      seleniumPort: 10195,
+      silent: true,
+      output: false,
+      persist_globals : true,
+      globals: globals
+    }, {
+      output_folder: false,
+      start_session: true
+    }, function (err, results) {
+      assert.equal(err.message, expectedErrorMessage);
+      assert.ok(err instanceof Error);
+
+      done();
+    });
+
+    runner.run().catch(function(err) {
+      done(err);
+    });
+  };
+});
+
+module.exports = tests;


### PR DESCRIPTION
Fail the test when an error is provided to the `done` callback in a `before`, `beforeEach`, `after` or `afterEach` hook. This is already the documented behavior.

Addresses #1039. Created following discussion with @beatfactor in #1134.

Thanks!

_Note:_ I would like to create a followup PR to add this behavior to the callback in the client API's `perform` method.