### PR TITLE
Add support for dynamic elements and sections

### DIFF
--- a/lib/page-object/page-utils.js
+++ b/lib/page-object/page-utils.js
@@ -1,3 +1,6 @@
+var Element = require('./element.js');
+var clone = require('lodash.clone');
+
 module.exports = new (function() {
   /**
    * Returns the properties object passed as an argument (or null if no arguments are passed).
@@ -34,7 +37,7 @@ module.exports = new (function() {
 
     elements.forEach(function(els) {
       Object.keys(els).forEach(function(name) {
-        definition = typeof els[name] === 'string' ? { selector: els[name] } : els[name];
+        definition = (typeof els[name] === 'string' || typeof els[name] === 'function') ? { selector: els[name] } : els[name];
         options = {
           name: name,
           parent: parent,
@@ -60,17 +63,26 @@ module.exports = new (function() {
   this.createSections = function(parent, sections) {
     var Section = require('./section.js');
     var sectionObjects = {};
-    var definition;
     var options;
 
     Object.keys(sections).forEach(function(name) {
-      definition = sections[name];
+      var definition = sections[name];
+
       options = {
         name: name,
         parent: parent,
         locateStrategy: 'css selector'
       };
-      sectionObjects[name] = new Section(definition, options);
+
+      if (typeof definition.selector === 'function') {
+        sectionObjects[name] = function() {
+          var newDefinition = clone(definition);
+          newDefinition.selector = newDefinition.selector.apply(null, arguments);
+          return new Section(newDefinition, options);
+        };
+      } else {
+        sectionObjects[name] = new Section(definition, options);
+      }
     });
 
     parent.section = sectionObjects;
@@ -93,5 +105,32 @@ module.exports = new (function() {
     });
 
     return this;
+  };
+
+
+ /**
+  * Looks up an element on a page/section to which it is bound and, if it is a dynamic
+  * element, calls the function and returns a new `Element`.
+  *
+  * @param {String} elementName The element name
+  * @returns {Element}
+  */
+  this.getElement = function(elementName) {
+    elementName = elementName.substring(1);
+
+    if (elementName in this.elements) {
+      var element = this.elements[elementName];
+
+      if (typeof element.selector === 'function') {
+        var definition = {selector: element.selector.apply(null, Array.prototype.slice.call(arguments, 1))};
+
+        return new Element(definition, element);
+      }
+
+      return element;
+    }
+
+    throw new Error(elementName + ' was not found in "' + this.name +
+      '". Available elements: ' + Object.keys(this.elements));
   };
 })();

--- a/lib/page-object/page.js
+++ b/lib/page-object/page.js
@@ -20,6 +20,8 @@ function Page(options, commandLoader, api, client) {
     .createSections(this, options.sections || {})
     .addCommands(this, options.commands || []);
 
+  this.$ = PageUtils.getElement;
+
   CommandWrapper.addWrappedCommands(this, this.commandLoader);
 }
 

--- a/lib/page-object/section.js
+++ b/lib/page-object/section.js
@@ -23,6 +23,8 @@ function Section(definition, options) {
     .createSections(this, definition.sections || {})
     .addCommands(this, definition.commands || []);
 
+  this.$ = PageUtils.getElement;
+
   CommandWrapper.addWrappedCommands(this, this.commandLoader);
 }
 

--- a/test/extra/pageobjects/simplePageObj.js
+++ b/test/extra/pageobjects/simplePageObj.js
@@ -11,7 +11,12 @@ module.exports = {
     loginCss: { selector: '#weblogin' },
     loginIndexed: { selector: '#weblogin', index: 1 },
     loginXpath: { selector: '//weblogin', locateStrategy: 'xpath' },
-    loginId: { selector: 'weblogin', locateStrategy: 'id' }
+    loginId: { selector: 'weblogin', locateStrategy: 'id' },
+    loginDynamicNoArgsInline: function(){return '#weblogin';},
+    loginDynamicSingleArgInline: function(element){return '' + element;},
+    loginDynamicMultiArgsInline: function(arg1, arg2){return arg1 + arg2;},
+    loginDynamicArgsCss: {selector: function(element){return '' + element;}},
+    loginDynamicArgsXpath: {selector: function(element){return '' + element;}, locateStrategy:'xpath'}
   },
   sections: {
     signUp: {
@@ -29,15 +34,32 @@ module.exports = {
       }
     },
     propTest: {
-        selector: '#propTest',
-        props: function(){
-            var defaults = {};
-            defaults[ this.name ] = this.selector + ' Value';
-            return {
-                defaults: defaults
-            };
-        }
+      selector: '#propTest',
+      props: function(){
+          var defaults = {};
+          defaults[ this.name ] = this.selector + ' Value';
+          return {
+              defaults: defaults
+          };
+      }
+    },
+    dynamicNoArgs: {
+      selector: function () { return '#signupSection'; },
+      elements: { foo: '#helpBtn' }
+    },
+    dynamicSingleArg: {
+      selector: function (arg1) { return '' + arg1; },
+      elements: { bar: '#helpBtn' }
+    },
+    dynamicMultiArgs: {
+      selector: function (arg1, arg2) { return arg1 + arg2; },
+      elements: { foobar: '#helpBtn' }
+    },
+    dynamicMultiArgsDynamicElement: {
+      selector: function (arg1, arg2) { return arg1 + arg2; },
+      elements: { dynamicSingleArg: function (arg1) { return '' + arg1; } }
     }
+
   },
   commands: [testCommands],
   props: function(){

--- a/test/src/page-object/testPageObjectCommands.js
+++ b/test/src/page-object/testPageObjectCommands.js
@@ -202,6 +202,75 @@ module.exports = {
       });
 
       this.client.start();
+    },
+
+    testDynamicPageObjectInline: function(done){
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/0/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/0/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+      var page = this.client.api.page.simplePageObj();
+      page.click(page.$('@loginDynamicSingleArgInline', '#weblogin'), function callback(result){
+        assert.equal(result.status, 0);
+      }).click(page.$('@loginDynamicMultiArgsInline', '#web', 'login'), function callback(result){
+        assert.equal(result.status, 0);
+        done();
+      });
+
+      this.client.start();
+    },
+
+    testDynamicPageObjectNotInline: function(done){
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/0/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/0/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+      var page = this.client.api.page.simplePageObj();
+      page.click(page.$('@loginDynamicArgsCss', '#weblogin'), function callback(result){
+        assert.equal(result.status, 0);
+      }).click(page.$('@loginDynamicArgsXpath', '//weblogin'), function callback(result){
+        assert.equal(result.status, 0);
+        done();
+      });
+
+      this.client.start();
+    },
+
+    testDynamicPageObjectNoArgs: function(done){
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/0/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+      var page = this.client.api.page.simplePageObj();
+      page.click(page.$('@loginDynamicNoArgsInline'), function callback(result){
+        assert.equal(result.status, 0);
+        done();
+      });
+
+      this.client.start();
     }
   }
 };

--- a/test/src/page-object/testPageObjectDynamicSections.js
+++ b/test/src/page-object/testPageObjectDynamicSections.js
@@ -1,0 +1,106 @@
+var assert = require('assert');
+var path = require('path');
+var Globals = require('../../lib/globals.js');
+var MockServer  = require('../../lib/mockserver.js');
+var Nightwatch = require('../../lib/nightwatch.js');
+
+module.exports = {
+  'test PageObject Dynamic Sections' : {
+    before : function(done) {
+      this.server = MockServer.init();
+      Globals.interceptStartFn();
+      this.server.on('listening', function() {
+        done();
+      });
+    },
+    after : function(done) {
+      Globals.restoreStartFn();
+      this.server.close(function() {
+        done();
+      });
+    },
+    beforeEach : function(done) {
+      Nightwatch.init({
+        page_objects_path: path.join(__dirname, '../../extra/pageobjects')
+      }, function () {
+        done();
+      });
+
+      this.client = Nightwatch.client();
+    },
+
+    testDynamicSectionSingleArg: function(done){
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/1/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+
+
+      var page = this.client.api.page.simplePageObj();
+      page.section.dynamicSingleArg('#signupSection').click('@bar', function callback(result){
+        assert.equal(result.status, 0);
+        done();
+      });
+
+      this.client.start();
+    },
+
+    testDynamicSectionMultiArgs: function(done){
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/1/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+
+      var page = this.client.api.page.simplePageObj();
+
+      page.section.dynamicMultiArgs('#signup', 'Section').click('@foobar', function callback(result){
+        assert.equal(result.status, 0);
+        done();
+      });
+
+      this.client.start();
+    },
+
+    testDynamicSectionNoArgs: function(done){
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/1/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+      var page = this.client.api.page.simplePageObj();
+      page.section.dynamicNoArgs().click('@foo', function callback(result){
+        assert.equal(result.status, 0);
+        done();
+      });
+
+      this.client.start();
+    },
+
+    testDynamicSectionDynamicElement: function(done) {
+      MockServer.addMock({
+        'url' : '/wd/hub/session/1352110219202/element/0/click',
+        'response' : JSON.stringify({
+          sessionId: '1352110219202',
+          status:0
+        })
+      }, true);
+      var page = this.client.api.page.simplePageObj();
+      var section = page.section.dynamicMultiArgsDynamicElement('#signup', 'Section')
+
+      section.click(section.$('@dynamicSingleArg', '#weblogin'), function callback(result){
+        assert.equal(result.status, 0);
+        done();
+      });
+
+      this.client.start();
+    },
+  }
+};


### PR DESCRIPTION
Since #1001 is still open and apparently moribund I tackled #698 from a different direction.

I prefer the explicit API of getting a reference to an element from the page/section to pass to the action rather than the hard-to-read complexity of passing arguments in-band (which also only supports passing strings). To minimize the additional verbosity I made the reference-getting method `$`, but I'm certainly not married to that, if people dislike it.

Example:

    // 'signup'
    {
        elements: {
            phoneNumber: function (type) { return 'input.phone.' + type; }
        },
        sections: {
            plan: {
                selector: function (name) { return '.plan.' + name; },
                elements: {
                    submit: 'button[type=submit]'
                }
            }
        }
    }

    var signup = client.page.signup();
    signup.setValue(signup.$('@phone_number', 'home'), '555-555-5555');

    var freePlan = signup.section.plan('free');
    freePlan.click('@submit');