### PR TITLE
Allow customization of screenshot file names

### DIFF
--- a/lib/api/client-commands/end.js
+++ b/lib/api/client-commands/end.js
@@ -30,7 +30,7 @@ End.prototype.command = function(callback) {
 
   if (client.sessionId) {
     if (this.testFailuresExist() && this.shouldTakeScreenshot()) {
-      var fileNamePath = Utils.getScreenshotFileName(client.api.currentTest, false, client.options.screenshots.path);
+      var fileNamePath = client.getScreenshotFileName(client.api.currentTest, false);
       Logger.info('We have failures in "' + client.api.currentTest.name + '". Taking screenshot...');
 
       client.api.saveScreenshot(fileNamePath, function(result, err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -385,7 +385,7 @@ Nightwatch.prototype.runProtocolAction = function(requestOptions, callback) {
       result = self.handleTestError(result);
 
       if (screenshotContent && self.options.screenshots.on_error) {
-        var fileNamePath = Utils.getScreenshotFileName(self.api.currentTest, true, self.options.screenshots.path);
+        var fileNamePath = self.getScreenshotFileName(self.api.currentTest, true);
         self.saveScreenshotToFile(fileNamePath, screenshotContent);
         result.lastScreenshotFile = fileNamePath;
       }
@@ -410,6 +410,12 @@ Nightwatch.prototype.addError = function(message, logMessage) {
     Logger.warn('    ' + (logMessage || message));
   }
 
+};
+
+Nightwatch.prototype.getScreenshotFileName = function(currentTest, is_error) {
+  var getFileName = this.options.screenshots.getFileName || Utils.getScreenshotFileName;
+  var fileName = getFileName(currentTest, is_error, this.options);
+  return path.resolve(path.join(this.options.screenshots.path, fileName));
 };
 
 Nightwatch.prototype.saveScreenshotToFile = function(fileName, content, cb) {

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -120,7 +120,7 @@ Util.format = function format(f) {
   });
 };
 
-Util.getScreenshotFileName = function(currentTest, is_error, screenshots_path) {
+Util.getScreenshotFileName = function(currentTest, is_error) {
   var prefix = currentTest.module + '/' + currentTest.name;
   prefix = prefix.replace(/\s/g, '-').replace(/"|'/g, '');
   prefix += is_error ? '_ERROR' : '_FAILED';
@@ -131,7 +131,7 @@ Util.getScreenshotFileName = function(currentTest, is_error, screenshots_path) {
   dateParts.pop();
   var dateStamp = dateParts.join('-');
 
-  return path.resolve(path.join(screenshots_path, prefix + '_' + dateStamp + '.png'));
+  return prefix + '_' + dateStamp + '.png';
 };
 
 Util.isObject = function(obj) {


### PR DESCRIPTION
In this PR I'm adding new option – `screenshots.getFileName` – it is function, that could be used to customize screenshot file name. 

### Use case:
We are using custom tool to process junit reports from nightwatch (and other tools) and upload these reports and screenshots to the cloud. To map screenshot to test execution we use special folder structure, i.e. it should include browser name (like in added unit test).