### PR TITLE
Render js errors in test case code as <error> in <testcase> in junit …

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -358,12 +358,14 @@ Nightwatch.prototype.runProtocolAction = function(requestOptions, callback) {
 
   var request = new HttpRequest(requestOptions)
     .on('result', function(result) {
-      if (typeof callback != 'function') {
-        var error = new Error('Callback parameter is not a function - ' + typeof(callback) + ' passed: "' + callback + '"');
-        self.errors.push(error.stack);
-        self.results.errors++;
-      } else {
+
+      try {
+        if (typeof callback !== 'function') {
+          throw new Error('Callback parameter is not a function - ' + typeof(callback) + ' passed: "' + callback + '"');
+        }
         callback.call(self.api, result);
+      } catch(err) {
+        self.handleException(err);
       }
 
       if (result.lastScreenshotFile && self.results.tests.length > 0) {

--- a/lib/runner/reporters/junit.js
+++ b/lib/runner/reporters/junit.js
@@ -48,6 +48,18 @@ module.exports = new (function() {
     });
   }
 
+  function adaptErrMessages(module) {
+    Object.keys(module.completed).forEach(function(item) {
+      var testcase = module.completed[item];
+      var errmessages = testcase.errmessages;
+      if (errmessages.length) {
+        var stackParts = errmessages[0].split('\n');
+        stackParts.shift();
+        testcase.errorStackTrace = Utils.stackTraceFilter(stackParts);
+      }
+    });
+  }
+
   function writeReport(moduleKey, data, opts, callback) {
     var module = globalResults.modules[moduleKey];
     var pathParts = moduleKey.split(path.sep);
@@ -56,6 +68,7 @@ module.exports = new (function() {
     var output_folder = opts.output_folder;
 
     adaptAssertions(module);
+    adaptErrMessages(module);
 
     if (pathParts.length) {
       output_folder = path.join(output_folder, pathParts.join(path.sep));

--- a/lib/runner/reporters/junit.js
+++ b/lib/runner/reporters/junit.js
@@ -52,13 +52,15 @@ module.exports = new (function() {
     Object.keys(module.completed).forEach(function(item) {
       var testcase = module.completed[item];
       var errmessages = testcase.errmessages;
-      if (errmessages.length) {
-        var stackParts = errmessages[0].split('\n');
+      for (var i = 0; i < errmessages.length; i++) {
+        var stackParts = errmessages[i].split('\n');
         stackParts.shift();
-        testcase.errorStackTrace = Utils.stackTraceFilter(stackParts);
+        testcase.errorStackTraces = testcase.errorStackTraces || [];
+        testcase.errorStackTraces.push(Utils.stackTraceFilter(stackParts));
       }
     });
   }
+  this._adaptErrMessages = adaptErrMessages; // for unit tests
 
   function writeReport(moduleKey, data, opts, callback) {
     var module = globalResults.modules[moduleKey];

--- a/lib/runner/reporters/junit.xml.ejs
+++ b/lib/runner/reporters/junit.xml.ejs
@@ -14,7 +14,10 @@
 <% if (assertions[i].screenshots && assertions[i].screenshots.length > 0) { %><system-out><% for (var j = 0; j < assertions[i].screenshots.length; j++) { %>[[ATTACHMENT|<%= assertions[i].screenshots[j] %>]]<% } %></system-out><% } %>
     <% }
     if (testcase.failed > 0 && testcase.stackTrace) {
-    %><failure message="<%= testcase.message %>"><%= testcase.stackTrace %></failure><% } %>
+    %><failure message="<%= testcase.message %>"><%= testcase.stackTrace %></failure><% }
+    if (testcase.errors > 0 && testcase.errorStackTrace) {
+    %>
+    <error message="Error executing test code"><%= testcase.errorStackTrace %></error><% } %>
     </testcase><% if (systemerr != '') {%>
       <system-err>
         <%= systemerr %>

--- a/lib/runner/reporters/junit.xml.ejs
+++ b/lib/runner/reporters/junit.xml.ejs
@@ -15,9 +15,14 @@
     <% }
     if (testcase.failed > 0 && testcase.stackTrace) {
     %><failure message="<%= testcase.message %>"><%= testcase.stackTrace %></failure><% }
-    if (testcase.errors > 0 && testcase.errorStackTrace) {
+    var errorStackTraces = testcase.errorStackTraces;
+    if (testcase.errors > 0 && errorStackTraces) {
+      for (var i = 0; i < errorStackTraces.length; i++) {
+        %> <error message="Error executing test code"><%= testcase.errorStackTraces[i] %></error><%
+      }
+    }
     %>
-    <error message="Error executing test code"><%= testcase.errorStackTrace %></error><% } %>
+
     </testcase><% if (systemerr != '') {%>
       <system-err>
         <%= systemerr %>

--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -101,7 +101,8 @@ Runner.prototype.runTestModule = function(modulePath, fullPaths) {
         assertions  : [].concat(results.tests),
         timeMs : time,
         time : (time/1000).toPrecision(4),
-        stackTrace : results.stackTrace
+        stackTrace : results.stackTrace,
+        errmessages: errors
       };
 
       if (Array.isArray(errors) && errors.length) {

--- a/test/sampletests/witherrors/errorInCallback.js
+++ b/test/sampletests/witherrors/errorInCallback.js
@@ -1,0 +1,7 @@
+module.exports = {
+  errorInCallback : function (client) {
+    client.url('http://localhost', function() {
+      throw new Error('some url callback error');
+    });
+  }
+};

--- a/test/sampletests/witherrors/sample.js
+++ b/test/sampletests/witherrors/sample.js
@@ -1,0 +1,5 @@
+module.exports = {
+  sample : function (client) {
+    throw new Error('some error');
+  }
+};

--- a/test/src/runner/cli/testParallelExecution.js
+++ b/test/src/runner/cli/testParallelExecution.js
@@ -5,6 +5,8 @@ var path = require('path');
 var assert = require('assert');
 var common = require('../../../common.js');
 
+var SAMPLE_TEST_COUNT = 24; // number of test modules in sampletests
+
 module.exports = {
   'test Parallel Execution' : {
 
@@ -98,7 +100,7 @@ module.exports = {
           done(err);
           return;
         }
-        assert.equal(self.allArgs.length, 22);
+        assert.equal(self.allArgs.length, SAMPLE_TEST_COUNT);
         assert.ok(path.join('sampletests', 'async', 'sample_1') in runner.runningProcesses);
         assert.ok(path.join('sampletests', 'before-after', 'sampleSingleTest_2') in runner.runningProcesses);
 
@@ -156,7 +158,7 @@ module.exports = {
 
       runner.setup({}, function () {
         assert.ok(!runner.isParallelMode());
-        assert.equal(self.allArgs.length, 22);
+        assert.equal(self.allArgs.length, SAMPLE_TEST_COUNT);
         done();
       });
 
@@ -184,7 +186,7 @@ module.exports = {
           return;
         }
         assert.ok(!runner.isParallelMode());
-        assert.equal(self.allArgs.length, 22);
+        assert.equal(self.allArgs.length, SAMPLE_TEST_COUNT);
         done();
       });
 

--- a/test/src/runner/reporters/testJunit.js
+++ b/test/src/runner/reporters/testJunit.js
@@ -1,0 +1,20 @@
+var assert = require('assert');
+var common = require('../../../common.js');
+var JunitReporter = common.require('runner/reporters/junit.js');
+
+module.exports = {
+  'test adaptErrMessages' : {
+    'test start with callback on success' : function() {
+      var theModule = {
+        completed: {
+          fooTestCase: {
+            errmessages: ['some error header\nsome stack']
+          }
+        }
+      };
+
+      JunitReporter._adaptErrMessages(theModule);
+      assert.equal(theModule.completed.fooTestCase.errorStackTraces[0], 'some stack');
+    }
+  }
+};

--- a/test/src/runner/testRunTestsuite.js
+++ b/test/src/runner/testRunTestsuite.js
@@ -241,6 +241,45 @@ module.exports = {
       runner.run().catch(function(err) {
         done(err);
       });
+    },
+    'test errors are added to both suite and test case' : function(done) {
+      var testsPath = path.join(__dirname, '../../sampletests/witherrors');
+
+      var runner = new Runner([testsPath], {
+        seleniumPort: 10195,
+        silent: true,
+        output: false
+      }, {
+        output_folder: false,
+        start_session: true
+      }, function (err, results) {
+        if (err) {
+          throw err;
+        }
+
+        var errorText1 = 'some url callback error';
+        var errorText2 = 'some error';
+        assert.equal(results.errors, 2);
+        assert.equal(results.errmessages.length, 2);
+        assert.ok(results.errmessages[0].indexOf(errorText1) !== -1);
+        assert.ok(results.errmessages[1].indexOf(errorText2) !== -1);
+
+        var errorInCallback = results.modules.errorInCallback.completed.errorInCallback;
+        assert.equal(errorInCallback.errors, 1);
+        assert.equal(errorInCallback.errmessages.length, 1);
+        assert.ok(errorInCallback.errmessages[0].indexOf(errorText1) !== -1);
+
+        var sample = results.modules.sample.completed.sample;
+        assert.equal(sample.errors, 1);
+        assert.equal(sample.errmessages.length, 1);
+        assert.ok(sample.errmessages[0].indexOf(errorText2) !== -1);
+
+        done();
+      });
+
+      runner.run().catch(function (err) {
+        done(err);
+      });
     }
   }
 };


### PR DESCRIPTION
Fix for [issue 1461](https://github.com/nightwatchjs/nightwatch/issues/1461).

Save the error message to the testcase in on testcase:finished, and render it in the junit reporter.

I assumed there can only be one error per test case. Is that correct?