### PR TITLE
Prevent Nightwatch killing the process before the done function finishes

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -737,19 +737,23 @@ CliRunner.prototype = {
 
           return true;
         }).then(function() {
+          var doneResult = {};
+          var exit = function(){ process.exit(code); }
           if (done) {
             try {
-              done(self.childProcessOutput, code);
+                doneResult = done(self.childProcessOutput, code);
             } catch (err) {
-              done(err);
+                doneResult = done(err);
             }
           }
-
           if (code) {
-            process.exit(code);
+            if (typeof doneResult.then === 'function') {
+              doneResult.then(exit);
+            } else {
+              exit()
+            }
           }
         });
-
       });
     });
 

--- a/test/src/runner/cli/testParallelExecution.js
+++ b/test/src/runner/cli/testParallelExecution.js
@@ -86,6 +86,40 @@ module.exports = {
       assert.ok(runner.parallelMode);
     },
 
+    testParallelExecutionWithPromisedDone: function (done) {
+      var self = this;
+      var CliRunner = common.require('runner/cli/clirunner.js');
+      var runner = new CliRunner({
+        config: path.join(__dirname, '../../../extra/nightwatch.json'),
+        env: 'default,mixed'
+      });
+
+      runner.setup({}, function(output, code) {
+        if (output instanceof Error) {
+          done(output);
+          return;
+        }
+        assert.ok(!runner.isParallelMode());
+        assert.equal(code, 0);
+        assert.deepEqual(output, {'default': [], mixed: []});
+        assert.equal(self.allArgs.length, 2);
+        assert.equal(self.allArgs[0].indexOf('default') > -1, true);
+        assert.equal(self.allArgs[1].indexOf('mixed') > -1, true);
+
+        assert.ok('default_1' in runner.runningProcesses);
+        assert.ok('mixed_2' in runner.runningProcesses);
+        assert.equal(runner.runningProcesses['default_1'].processRunning, false);
+        assert.equal(runner.runningProcesses['mixed_2'].processRunning, false);
+        return new Promise(function (resolve) {
+          setTimeout(function(){
+              resolve();
+          }, 5);
+        }).then(done);
+      });
+
+      assert.ok(runner.parallelMode);
+    },
+
     testParallelExecutionWithWorkersDefaults: function (done) {
       var self = this;
       var CliRunner = common.require('runner/cli/clirunner.js');


### PR DESCRIPTION
## Bug

Prevent Nightwatch killing the process before the (asynchronous) `done` function has finished (Support promised callback for cli runner)

## why?

This will prevent nightwatch from executing `process.exit(code)` while the done callback is still executing

## impact?

Low - no breaking changes.

## testing?

Unit tests added.
but, response with `code 1` is not tested currently (as the process would exit) and this is where the change is.

## Issue

related: https://github.com/nightwatchjs/nightwatch/issues/1256