### PR TITLE
refactored reporter filenaming to use desiredCapabilities for platfor…

### DIFF
--- a/lib/runner/clientmanager.js
+++ b/lib/runner/clientmanager.js
@@ -25,9 +25,12 @@ ClientManager.prototype.init = function(opts) {
 
   this['@client'].once('selenium:session_create', function() {
     var capabilities = this.api.capabilities || {};
+    var desiredCapabilities = opts.desiredCapabilities || {};
     var browserName = (capabilities.browserName && capabilities.browserName.toUpperCase()) || '';
+    var browserVersion = capabilities.version || desiredCapabilities.deviceName;
+    var platform = desiredCapabilities.platform || desiredCapabilities.platformName + '_' + desiredCapabilities.platformVersion;
 
-    self.options.report_prefix = browserName + '_' + this.api.capabilities.version + '_' + this.api.capabilities.platform + '_';
+    self.options.report_prefix = browserName + '_' + browserVersion + '_' + platform + '_';
   });
   return this;
 };

--- a/test/src/runner/testRunner.js
+++ b/test/src/runner/testRunner.js
@@ -82,6 +82,10 @@ module.exports = {
         seleniumPort : 10195,
         silent : true,
         output : false,
+        desiredCapabilities: {
+          platformName: 'PLATFORM_NAME',
+          platformVersion: 'PLATFORM_VERSION'
+        },
         globals : {
           beforeEach : function(client, doneFn) {
             currentTestArray.push({
@@ -108,8 +112,8 @@ module.exports = {
         fs.readdir(src_folders[0], function(err, list) {
           try {
             assert.deepEqual(list, ['simple', 'tags'], 'The subfolders have been created.');
-            var simpleReportFile = 'output/simple/FIREFOX_TEST_TEST_sample.xml';
-            var tagsReportFile = 'output/tags/FIREFOX_TEST_TEST_sampleTags.xml';
+            var simpleReportFile = 'output/simple/FIREFOX_TEST_PLATFORM_NAME_PLATFORM_VERSION_sample.xml';
+            var tagsReportFile = 'output/tags/FIREFOX_TEST_PLATFORM_NAME_PLATFORM_VERSION_sampleTags.xml';
 
             assert.ok(fileExistsSync(simpleReportFile), 'The simple report file was not created.');
             assert.ok(fileExistsSync(tagsReportFile), 'The tags report file was not created.');
@@ -147,7 +151,12 @@ module.exports = {
       var runner = new Runner(src_folders, {
         seleniumPort : 10195,
         silent : true,
-        output : false
+        output : false,
+        desiredCapabilities: {
+          platformName: 'PLATFORM_NAME',
+          platformVersion: 'PLATFORM_VERSION',
+          platform:'WINDOWS_10'
+        }
       }, {
         output_folder : 'output',
         start_session : true,
@@ -156,7 +165,7 @@ module.exports = {
       }, function(err, results) {
 
         assert.strictEqual(err, null);
-        var sampleReportFile = path.join(__dirname, '../../../output/FIREFOX_TEST_TEST_sample.xml');
+        var sampleReportFile = path.join(__dirname, '../../../output/FIREFOX_TEST_WINDOWS_10_sample.xml');
 
         assert.ok(fileExistsSync(sampleReportFile), 'The sample file report file was not created.');
         fs.readFile(sampleReportFile, function(err, data) {
@@ -174,7 +183,6 @@ module.exports = {
         done(err);
       });
     },
-
     'test run unit tests with junit output and failures' : function(done) {
       var src_folders = [
         path.join(__dirname, '../../asynchookstests/unittest-failure')


### PR DESCRIPTION
An issues occurs in the naming of report files done by Nightwatch. Because of the way the report names are created, there are cases (especially for mobile browser tests) where the reports for different tests have the same name, making the reports overwrite each other on save.
This is now it looks for a 'good' report name 

CHROME_55.0.2883.91_ANDROID_premier-subscriber.xml

And a 'bad' one, that will probably get overwritten by another report with the same name

SAFARI_undefined_undefined_premier-subscriber.xml 

The issue is fixed in this PR leading to a filenaming something like this, by falling back to desiredCapabilities for browser version if no capability is returned


SAFARI_iPhone 7 Plus Simulator_iOS_10.2_premier-subscriber.xml
--


- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`)
- [x] If you're fixing a bug also create an issue if one doesn't exist yet
- [ ] If it's a new feature explain why do you think it's necessary
- [ ] If your change include drastic or low level changes please discuss them to make sure they will be accepted and what the impact will be
- [x] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will not make it in very quick, if at all.
- [x] Do not include changes that are not related to the issue at hand
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.
- [x] Add unit tests