### PR TITLE
Element id screenshot 

### DIFF
--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -922,6 +922,25 @@ module.exports = function(Nightwatch) {
     return getRequest('/element/' + id + '/location', callback);
   };
 
+  /**
+   * Takes a screenshot of the visible region encompassed by the bounding rectangle
+   * of an element. If given a parameter argument scroll that
+   * evaluates to false, the element will not be scrolled into view.
+   *
+   * The element's coordinates are returned as a JSON object with x and y properties.
+   *
+   * @link
+   * @param {string} id ID of the element to route the command to.
+   * @param {boolean} scrollIntoView Set to false to stop the element from scrolling into view. Default is true.
+   * @param {function} callback Callback function which is called with the result value.
+   * @api protocol.elementScreenshot
+   * @returns {x:number, y:number} The X and Y coordinates for the element on the page.
+   */
+  Actions.elementIdScreenshot = function(id, scroll, callback) {
+    var scrollToView = typeof scroll === 'boolean' ? scroll : true
+    return getRequest('/element/' + id + '/screenshot?scroll=' + scrollToView, callback);
+  };
+
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Document Handling
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -937,7 +937,8 @@ module.exports = function(Nightwatch) {
    * @returns {x:number, y:number} The X and Y coordinates for the element on the page.
    */
   Actions.elementIdScreenshot = function(id, scroll, callback) {
-    var scrollToView = typeof scroll === 'boolean' ? scroll : true
+    var scrollToView = typeof scroll === 'boolean' ? scroll : true;
+
     return getRequest('/element/' + id + '/screenshot?scroll=' + scrollToView, callback);
   };
 

--- a/test/src/api/protocol/testElementCommands.js
+++ b/test/src/api/protocol/testElementCommands.js
@@ -240,10 +240,11 @@ module.exports = MochaTest.add('element actions', {
     var protocol = this.protocol;
 
     var command = protocol.elementIdScreenshot('TEST_ELEMENT', false, function callback() {
-      done()
-    })
+      done();
+    });
 
     assert.equal(command.request.method, 'GET');
+    
     assert.equal(command.request.path, '/wd/hub/session/1352110219202/element/TEST_ELEMENT/screenshot?scroll=false');
   }
 });

--- a/test/src/api/protocol/testElementCommands.js
+++ b/test/src/api/protocol/testElementCommands.js
@@ -234,5 +234,16 @@ module.exports = MochaTest.add('element actions', {
     assert.equal(command.request.method, 'POST');
     assert.equal(command.data, '{"value":["t","e","s","t"]}');
     assert.equal(command.request.path, '/wd/hub/session/1352110219202/element/TEST_ELEMENT/value');
+  },
+
+  textElementIdScreenshot: function(done) {
+    var protocol = this.protocol;
+
+    var command = protocol.elementIdScreenshot('TEST_ELEMENT', false, function callback() {
+      done()
+    })
+
+    assert.equal(command.request.method, 'GET');
+    assert.equal(command.request.path, '/wd/hub/session/1352110219202/element/TEST_ELEMENT/screenshot?scroll=false');
   }
 });


### PR DESCRIPTION
This PR implements the element screenshot web driver action: https://www.w3.org/TR/webdriver/#take-element-screenshot

The reason I consider this useful is that I'm in the process of implementing a visual regression testing extension for nightwatch and I need to to be able to take screenshots of portions of the website. 