### PR TITLE
Enable passing arrow functions with implicit returns to `execute`

### DIFF
--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -1346,8 +1346,8 @@ module.exports = function(Nightwatch) {
     var fn;
 
     if (typeof script === 'function') {
-      fn = 'var passedArgs = Array.prototype.slice.call(arguments,0); return ' +
-        script.toString() + '.apply(window, passedArgs);';
+      fn = 'var passedArgs = Array.prototype.slice.call(arguments,0); return (' +
+        script.toString() + ').apply(window, passedArgs);';
     } else {
       fn = script;
     }

--- a/test/src/api/protocol/testExecute.js
+++ b/test/src/api/protocol/testExecute.js
@@ -31,7 +31,7 @@ module.exports = MochaTest.add('client.execute', {
       });
 
     assert.equal(command.data, '{"script":"var passedArgs = Array.prototype.slice.call(arguments,0); ' +
-      'return function () {return test();}.apply(window, passedArgs);","args":["arg1"]}');
+      'return (function () {return test();}).apply(window, passedArgs);","args":["arg1"]}');
   },
 
   testExecuteFunctionNoArgs : function(done) {
@@ -43,7 +43,7 @@ module.exports = MochaTest.add('client.execute', {
       });
 
     assert.equal(command.data, '{"script":"var passedArgs = Array.prototype.slice.call(arguments,0); ' +
-      'return function () {return test();}.apply(window, passedArgs);","args":[]}');
+      'return (function () {return test();}).apply(window, passedArgs);","args":[]}');
   },
 
   testExecuteAsyncFunction : function() {
@@ -52,7 +52,7 @@ module.exports = MochaTest.add('client.execute', {
     var command = protocol.executeAsync(function() {return test();}, ['arg1']);
 
     assert.equal(command.data, '{"script":"var passedArgs = Array.prototype.slice.call(arguments,0); ' +
-      'return function () {return test();}.apply(window, passedArgs);","args":["arg1"]}');
+      'return (function () {return test();}).apply(window, passedArgs);","args":["arg1"]}');
   },
 
   testExecuteAsync : function(done) {


### PR DESCRIPTION
One of my colleagues noticed the interesting fact that they could pass an arrow function with a block body and explicit return, but not an arrow function with an expression body and an implicit return.

That is, this would work:
```
  protocol.execute(() => { return 'something'; });
```

While this would cause an exception:
```
  protocol.execute(() => 'something');
```

Given that these two functions are meant to be equivalent, this was a very surprising result.

The underlying cause is that we serialize the function and concatenate it with additional code that was expecting to be able to chain on to the function. Without braces around the string representation, this concatenation ends up trying to call `apply` on the result of the expression in the function, instead of calling it on the function itself.

We can resolve this by wrapping the serialized function in parenthesis, disambiguating the call target for `apply`.

I haven't added an explicit test for this, because it would fail in the Node 0.10 CI environment where arrow functions aren't valid syntax. 🙁