### PR TITLE
add a JSDoc example for `.keys()`

### DIFF
--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -865,6 +865,16 @@ module.exports = function(Nightwatch) {
    *
    * Rather than the `setValue`, the modifiers are not released at the end of the call. The state of the modifier keys is kept between calls, so mouse interactions can be performed while modifier keys are depressed.
    *
+   * ```
+   * module.exports = {
+   *  'Confirm #foo is removed when the escape key is pressed.': function(browser) {
+   *    browser.keys(['\uE00C'], () => {
+   *	    browser.expect.element('#foo').to.not.be.visible;
+   *   });
+   *  }
+   * };
+   * ```
+   *
    * @link
    * @param {Array} keysToSend The keys sequence to be sent.
    * @param {function} [callback] Optional callback function to be called when the command finishes.


### PR DESCRIPTION
This is a small JSDoc change, proposed because I like seeing examples in the API docs.