### PR TITLE
add a selenium setting 'java_path'

### DIFF
--- a/lib/runner/selenium.js
+++ b/lib/runner/selenium.js
@@ -55,7 +55,13 @@ SeleniumServer.prototype.start = function() {
   }
 
   this.setCliArgs();
-  this.process = child_process.spawn('java', this.cliOpts, {
+  
+  var java = 'java';
+  if (this.settings.selenium.java_path) {
+      java = this.settings.selenium.java_path + java;
+  }
+  
+  this.process = child_process.spawn(java, this.cliOpts, {
     stdio: ['ignore', 'pipe', 'pipe']
   });
 

--- a/test/src/runner/testSelenium.js
+++ b/test/src/runner/testSelenium.js
@@ -110,5 +110,39 @@ module.exports = {
         done();
       });
     }
-  }
+  },
+  
+  testStartServerWithJavaPath : function(done) {
+      this.mockedSpawn.setStrategy(function (command, args, opts) {
+        assert.deepEqual(opts, {stdio : ['ignore', 'pipe', 'pipe']});
+        if (command !== '/java8/bin/java') {
+          return null;
+        }
+        return function (cb) {
+          this.stdout.write('Started org.openqa.jetty.jetty.Server');
+          return cb(0); // and exit 0
+        };
+      });
+
+      Selenium.startServer({
+        selenium : {
+          java_path : '/java8/bin/',
+          start_process : true,
+          server_path : './selenium.jar',
+          log_path : false,
+          cli_args : {
+            'webdriver.test.property' : 'test',
+            'webdriver.empty.property' : '',
+            '-DpropName' : '1'
+          }
+        }
+      }, function(error, process) {
+        assert.equal(process.command, 'java');
+        assert.deepEqual(process.args, ['-DpropName=1', '-Dwebdriver.test.property=test', '-jar', './selenium.jar', '-port', 4444]);
+        assert.equal(process.host, undefined);
+        assert.equal(process.port, 4444);
+        assert.equal(error, null);
+        done();
+      });
+    },
 };

--- a/test/src/runner/testSelenium.js
+++ b/test/src/runner/testSelenium.js
@@ -144,5 +144,5 @@ module.exports = {
         assert.equal(error, null);
         done();
       });
-    },
+    }
 };


### PR DESCRIPTION
add a selenium setting 'java_path', so that users have a chance to specify their desired Java runtime. This will be very userful if a user's default Java runtime is not compatible with selenium but has no permission or does not want to change his default configuration.
a related unit test is also added

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with addressing it quicker.

- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`)
- [ ] If you're fixing a bug also create an issue if one doesn't exist yet
- [x] If it's a new feature explain why do you think it's necessary
- [ ] If your change include drastic or low level changes please discuss them to make sure they will be accepted and what the impact will be
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will not make it in very quick, if at all.
- [ ] Do not include changes that are not related to the issue at hand
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.
- [x] Add unit tests