### PR TITLE
Add option for nightwatch.conf.js to be asynchronous

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -548,7 +548,14 @@ exports.cli = function(runTests) {
 
 exports.runner = function(argv, done, settings) {
   var runner = exports.CliRunner(argv);
-  return runner.setup(settings, done).runTests(done);
+  return runner.setup(settings, function(){
+
+    if (typeof done === 'function') {
+	    done();
+    }
+
+    runner.runTests(done);
+  })
 };
 
 exports.initGrunt = function(grunt) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -551,11 +551,11 @@ exports.runner = function(argv, done, settings) {
   return runner.setup(settings, function(){
 
     if (typeof done === 'function') {
-	    done();
+      done();
     }
 
     runner.runTests(done);
-  })
+  });
 };
 
 exports.initGrunt = function(grunt) {

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -31,9 +31,10 @@ CliRunner.prototype = {
    * @returns {CliRunner}
    */
   init : function(done) {
-    this
-      .readSettings()
-      .parseTestSettings({}, done);
+    var that = this;
+    this.readSettings(function() {
+      that.parseTestSettings({}, done);
+    });
 
     return this;
   },
@@ -44,9 +45,10 @@ CliRunner.prototype = {
    * @returns {CliRunner}
    */
   setup : function(settings, done) {
-    this
-      .readSettings()
-      .parseTestSettings(settings, done);
+    var that= this;
+    this.readSettings(function() {
+      that.parseTestSettings(settings, done);
+    });
 
     return this;
   },
@@ -54,7 +56,9 @@ CliRunner.prototype = {
   /**
    * Read the provided config json file; defaults to settings.json if one isn't provided
    */
-  readSettings : function() {
+  readSettings : function(done) {
+	  var that = this;
+
     // use default nightwatch.json file if we haven't received another value
 
     if (this.cli.command('config').isDefault(this.argv.config)) {
@@ -82,26 +86,49 @@ CliRunner.prototype = {
 
     this.argv.env = typeof this.argv.env == 'string' ? this.argv.env : 'default';
 
-    // reading the settings file
-    try {
-      this.settings = require(this.argv.config);
-      this.replaceEnvVariables(this.settings);
+	  var settings_content = require(this.argv.config);
 
-      this.manageSelenium = !this.isParallelMode() && this.settings.selenium &&
-        this.settings.selenium.start_process || false;
-
-      if (typeof this.settings.src_folders == 'string') {
-        this.settings.src_folders = [this.settings.src_folders];
-      }
-
-      this.settings.output = this.settings.output || typeof this.settings.output == 'undefined';
-      this.settings.detailed_output = this.settings.detailed_output || typeof this.settings.detailed_output == 'undefined';
-    } catch (ex) {
-      Logger.error(ex.stack);
-      this.settings = {};
+	  // If the required file is a function then invoke it
+	  if (typeof settings_content === 'function') {
+		  settings_content(function (settings) {
+        that.saveSettings(settings, done);
+      });
+    } else {
+	    this.saveSettings(settings_content, done);
     }
 
     return this;
+  },
+
+	/**
+   * Save settings object to the runner instance
+	 * @param {Object} settings
+	 */
+  saveSettings : function(settings, done) {
+	  // reading the settings file
+	  try {
+		  this.settings = settings;
+		  this.replaceEnvVariables(this.settings);
+
+		  this.manageSelenium = !this.isParallelMode() && this.settings.selenium &&
+			  this.settings.selenium.start_process || false;
+
+		  if (typeof this.settings.src_folders == 'string') {
+			  this.settings.src_folders = [this.settings.src_folders];
+		  }
+
+		  this.settings.output = this.settings.output || typeof this.settings.output == 'undefined';
+		  this.settings.detailed_output = this.settings.detailed_output || typeof this.settings.detailed_output == 'undefined';
+	  } catch (ex) {
+		  Logger.error(ex.stack);
+		  this.settings = {};
+	  }
+
+		if (typeof done === 'function') {
+			done();
+		}
+
+	  return this;
   },
 
   /**
@@ -531,6 +558,8 @@ CliRunner.prototype = {
 
     if (this.parallelModeWorkers()) {
       this.setupParallelMode(null, done);
+    } else if (typeof done === 'function') {
+      done();
     }
 
     return this;

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -57,7 +57,7 @@ CliRunner.prototype = {
    * Read the provided config json file; defaults to settings.json if one isn't provided
    */
   readSettings : function(done) {
-	  var that = this;
+    var that = this;
 
     // use default nightwatch.json file if we haven't received another value
 
@@ -86,49 +86,49 @@ CliRunner.prototype = {
 
     this.argv.env = typeof this.argv.env == 'string' ? this.argv.env : 'default';
 
-	  var settings_content = require(this.argv.config);
+    var settings_content = require(this.argv.config);
 
-	  // If the required file is a function then invoke it
-	  if (typeof settings_content === 'function') {
-		  settings_content(function (settings) {
+    // If the required file is a function then invoke it
+    if (typeof settings_content === 'function') {
+      settings_content(function (settings) {
         that.saveSettings(settings, done);
       });
     } else {
-	    this.saveSettings(settings_content, done);
+      this.saveSettings(settings_content, done);
     }
 
     return this;
   },
 
-	/**
+  /**
    * Save settings object to the runner instance
-	 * @param {Object} settings
-	 */
+   * @param {Object} settings
+   */
   saveSettings : function(settings, done) {
-	  // reading the settings file
-	  try {
-		  this.settings = settings;
-		  this.replaceEnvVariables(this.settings);
+    // reading the settings file
+    try {
+      this.settings = settings;
+      this.replaceEnvVariables(this.settings);
 
-		  this.manageSelenium = !this.isParallelMode() && this.settings.selenium &&
-			  this.settings.selenium.start_process || false;
+      this.manageSelenium = !this.isParallelMode() && this.settings.selenium &&
+        this.settings.selenium.start_process || false;
 
-		  if (typeof this.settings.src_folders == 'string') {
-			  this.settings.src_folders = [this.settings.src_folders];
-		  }
+      if (typeof this.settings.src_folders == 'string') {
+        this.settings.src_folders = [this.settings.src_folders];
+      }
 
-		  this.settings.output = this.settings.output || typeof this.settings.output == 'undefined';
-		  this.settings.detailed_output = this.settings.detailed_output || typeof this.settings.detailed_output == 'undefined';
-	  } catch (ex) {
-		  Logger.error(ex.stack);
-		  this.settings = {};
-	  }
+      this.settings.output = this.settings.output || typeof this.settings.output == 'undefined';
+      this.settings.detailed_output = this.settings.detailed_output || typeof this.settings.detailed_output == 'undefined';
+    } catch (ex) {
+      Logger.error(ex.stack);
+      this.settings = {};
+    }
 
-		if (typeof done === 'function') {
-			done();
-		}
+    if (typeof done === 'function') {
+      done();
+    }
 
-	  return this;
+    return this;
   },
 
   /**
@@ -140,12 +140,12 @@ CliRunner.prototype = {
       switch(typeof target[key]) {
         case 'object':
           this.replaceEnvVariables(target[key]);
-        break;
+          break;
         case 'string':
           target[key] = target[key].replace(/\$\{(\w+)\}/g, function(match, varName) {
             return process.env[varName] || '${' + varName + '}';
           });
-        break;
+          break;
       }
     }
 


### PR DESCRIPTION
This PR adds the option of having an asynchronous config file. This would be useful for dynamically building the config from other services such as building a list of devices to test against after querying the Browserstack API, or by using `prompt` to ask for username/passwords to prevent needing to store them in config files or expose via environment variables.

Example async config file:
```
 module.exports = function (done) {
    return new Promise(function(resolve) {
        setTimeout(function() {
            resolve({
                "src_folders": ["./test/src"],
		"test_workers": false,
		"selenium": {
		    "start_process": false,
		    "start_session": false
		}
            });
        }, 3000);
    }).then(done);
};
```