### PR TITLE
Changes .travis.yml to run the builds in node 6. Adds a 's…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 sudo: false
 node_js:
   - "6"
+  - "8"
 
 before_script:
   - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
+  - "6"
+  - "8"
 
 before_script:
+  - set -e
   - npm install -g grunt-cli
   - npm install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 sudo: false
 node_js:
   - "6"
-  - "8"
 
 before_script:
   - set -e

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "coveralls": "latest",
     "grunt": "~0.4.4",
     "grunt-complexity": "^0.1.7",
-    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-jshint": "~0.11.0",
     "grunt-jsonlint": "~1.0.4",
     "grunt-npm-release": "latest",
     "jscoverage": "latest",

--- a/test/sampletests/before-after/syncBeforeAndAfter.js
+++ b/test/sampletests/before-after/syncBeforeAndAfter.js
@@ -12,7 +12,7 @@ module.exports = {
   demoTestSyncOne : function (client) {
     client.url('http://localhost');
     var testName = client.currentTest.name;
-    assert.equal(testName, 'demoTestSyncOxne');
+    assert.equal(testName, 'demoTestSyncOne');
   },
 
   demoTestSyncTwo : function (client) {

--- a/test/src/core/testRequestWithCredentials.js
+++ b/test/src/core/testRequestWithCredentials.js
@@ -26,7 +26,7 @@ module.exports = {
 
       client.on('selenium:session_create', function (sessionId, request) {
         var authorization = new Buffer('testusername:123456').toString('base64');
-        assert.equal(request.request._headers['authorization'], 'Basic ' + authorization, 'Testing if the Authorization header is set correctly');
+        assert.equal(request.reqOptions.headers.Authorization, 'Basic ' + authorization, 'Testing if the Authorization header is set correctly');
         done();
       });
 

--- a/test/src/runner/testRunner.js
+++ b/test/src/runner/testRunner.js
@@ -201,8 +201,12 @@ module.exports = {
             return;
           }
           var content = data.toString();
+          
+          var hasNode6ErrorStyle = content.indexOf('<failure message="AssertionError: 1 == 0 - expected &quot;0&quot; but got: &quot;1&quot;">') > 0;
+          var hasNode8ErrorStyle = content.indexOf('AssertionError [ERR_ASSERTION]: 1 == 0') > 0;
+          
           try {
-            assert.ok(content.indexOf('<failure message="AssertionError: 1 == 0 - expected &quot;0&quot; but got: &quot;1&quot;">') > 0, 'Report contains failure information.')
+            assert.ok(hasNode6ErrorStyle || hasNode8ErrorStyle,'Report contains failure information.');
             done();
           } catch (err) {
             done(err);


### PR DESCRIPTION
Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with addressing it quicker.

- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`)
- [x] If you're fixing a bug also create an issue if one doesn't exist yet
- [x] If it's a new feature explain why do you think it's necessary
- [x] If your change include drastic or low level changes please discuss them to make sure they will be accepted and what the impact will be
- [x] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will not make it in very quick, if at all.
- [x] Do not include changes that are not related to the issue at hand
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.
- [ ] ~Add unit tests~

---

# What does this PR do:
* Changes `.travis.yml` to run the builds in node 6. Also adds a `set -e` to make the build fail when an error happens.

* Changes `grunt-contrib-jshint`'s version to a non-buggy one (0.10 was having this error: https://github.com/gruntjs/grunt-contrib-jshint/issues/256 ).

@beatfactor if the requirement is to run in node 0.10 (a no longer supported NodeJS version), please let me know. The reason why the tests are failing are due to the fact that Node 0.10 does not support `const` keywords (as well as other more recent features of the JS language) and some of the dependencies are shipping non-transpiled to ES5 code (e.g.: `joi`, which is a dependency of `xml2json`'s dependency on your project).

Closes #1657 