### PR TITLE
Css classname assertion logs fix

### DIFF
--- a/lib/api/assertions/cssClassNotPresent.js
+++ b/lib/api/assertions/cssClassNotPresent.js
@@ -23,7 +23,7 @@ exports.assertion = function(selector, className, msg) {
   this.message = msg || util.format('Testing if element <%s> does not have css class: "%s".', selector, className);
 
   this.expected = function() {
-    return 'without ' + className;
+    return className;
   };
 
   this.pass = function(value) {

--- a/lib/api/assertions/cssClassPresent.js
+++ b/lib/api/assertions/cssClassPresent.js
@@ -23,7 +23,7 @@ exports.assertion = function(selector, className, msg) {
   this.message = msg || util.format('Testing if element <%s> has css class: "%s".', selector, className);
 
   this.expected = function() {
-    return 'has ' + className;
+    return className;
   };
 
   this.pass = function(value) {

--- a/test/src/api/assertions/testCssClassNotPresent.js
+++ b/test/src/api/assertions/testCssClassNotPresent.js
@@ -20,7 +20,7 @@ module.exports = {
         assertion : function(passed, result, expected, msg, abortOnFailure) {
           assert.equal(passed, true);
           assert.equal(result, 'other-css-class some-css-class');
-          assert.equal(expected, 'without test-css-class');
+          assert.equal(expected, 'test-css-class');
           assert.equal(msg, 'Testing if element <.test_element> does not have css class: "test-css-class".');
           assert.equal(abortOnFailure, true);
           done();
@@ -45,7 +45,7 @@ module.exports = {
         assertion : function(passed, result, expected, msg, abortOnFailure) {
           assert.equal(passed, false);
           assert.equal(result, 'test-css-class other-css-class');
-          assert.equal(expected, 'without test-css-class');
+          assert.equal(expected, 'test-css-class');
           assert.equal(abortOnFailure, true);
           done();
         }
@@ -69,7 +69,7 @@ module.exports = {
         assertion : function(passed, result, expected, msg, abortOnFailure) {
           assert.equal(passed, false);
           assert.equal(result, null);
-          assert.equal(expected, 'without test-css-class');
+          assert.equal(expected, 'test-css-class');
           assert.equal(abortOnFailure, true);
           done();
         }

--- a/test/src/api/assertions/testCssClassPresent.js
+++ b/test/src/api/assertions/testCssClassPresent.js
@@ -20,7 +20,7 @@ module.exports = {
         assertion : function(passed, result, expected, msg, abortOnFailure) {
           assert.equal(passed, true);
           assert.equal(result, 'other-css-class test-css-class');
-          assert.equal(expected, 'has test-css-class');
+          assert.equal(expected, 'test-css-class');
           assert.equal(msg, 'Testing if element <.test_element> has css class: "test-css-class".');
           assert.equal(abortOnFailure, true);
           done();
@@ -45,7 +45,7 @@ module.exports = {
         assertion : function(passed, result, expected, msg, abortOnFailure) {
           assert.equal(passed, false);
           assert.equal(result, 'other-css-class');
-          assert.equal(expected, 'has test-css-class');
+          assert.equal(expected, 'test-css-class');
           assert.equal(abortOnFailure, true);
           done();
         }
@@ -69,7 +69,7 @@ module.exports = {
         assertion : function(passed, result, expected, msg, abortOnFailure) {
           assert.equal(passed, false);
           assert.equal(result, null);
-          assert.equal(expected, 'has test-css-class');
+          assert.equal(expected, 'test-css-class');
           assert.equal(abortOnFailure, true);
           done();
         }


### PR DESCRIPTION
remove 'has'/'without' prefix from the assertion(s) `expected` field.

it is quite confusing to see `'has my-classname'`/`'without my-classname'` in the assertion logs, and it seems the prepended `'has'`/`'without'` has no special purpose.