### PR TITLE
Double-checks that resultValue.indexOf exists in .contains assertions

### DIFF
--- a/lib/api/expect/_baseAssertion.js
+++ b/lib/api/expect/_baseAssertion.js
@@ -215,7 +215,10 @@ BaseAssertion.prototype.formatMessage = function() {
 BaseAssertion.prototype['@containsFlag'] = function(value) {
   var verb = (this.hasFlag('that') || this.hasFlag('which')) ? 'contains' : 'contain';
   this.conditionFlag(value, function() {
-    return this.resultValue ? this.resultValue.indexOf(value) > -1 : false;
+    if (this.resultValue && this.resultValue.indexOf) {
+      return this.resultValue.indexOf(value) > -1;
+    }
+    return false;
   }, [
     'not ' + verb,
     verb


### PR DESCRIPTION
This fix is in relation to #989 

Although there is probably some deeper reason why resultValue is being set to something unexpected, this at least will handle it more gracefully if resultValue gets into a weird state. Rather than throwing, it will just assert that resultValue does not contain the specified value.