### PR TITLE
Promote installing as dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ UI automated testing framework powered by [Node.js](http://nodejs.org/). It uses
 We're delighted to announce the release of Nightwatch v1.0 in BETA. To install it run: 
 
 ```sh
-$ npm install nightwatch@1.0.3
+$ npm install --save-dev nightwatch@1.0.3
 ```
 
 Also please have a look at the [releases/v1.0](https://github.com/nightwatchjs/nightwatch/tree/releases/v1.0) branch.


### PR DESCRIPTION
Nightwatch is most likely used as a dev dependency, so in order to
promote best practices, the install command was changed to show the most
common use case.