### PR TITLE
Add the ability to load typescript .ts test files

### DIFF
--- a/lib/runner/walk.js
+++ b/lib/runner/walk.js
@@ -87,7 +87,7 @@ module.exports = {
     Matchers.filter = [];
 
     var allmodules = [];
-    var extensionPattern = load_typescript_tests ? /\.ts$/ : /\.js$/;
+    var extensionPattern = opts.load_typescript_tests ? /\.ts$/ : /\.js$/;
     var modulePaths = paths.slice(0);
 
     (function readSourcePaths() {

--- a/lib/runner/walk.js
+++ b/lib/runner/walk.js
@@ -87,7 +87,7 @@ module.exports = {
     Matchers.filter = [];
 
     var allmodules = [];
-    var extensionPattern = /\.js$/;
+    var extensionPattern = load_typescript_tests ? /\.ts$/ : /\.js$/;
     var modulePaths = paths.slice(0);
 
     (function readSourcePaths() {


### PR DESCRIPTION
I thought it could be nice to be able to load and run test files as typescript files without the need to compile them beforhead.

Using this branch I simply ran `ts-node node_modules/.bin/nightwatch` which collected my `ts` files without pre-compiling them.

This option is available when defining `load_typescript_tests` in `default` env:
```
 "test_settings" : {
    "default" : {
      "launch_url" : "http://localhost",
      "load_typescript_tests": true
      ...
      }
  }
```

The name is absolutely arbitrary, so if you have better name suggestion - it will change.
I couldn't find any UT to run. Where and how do I run them?