### PR TITLE
Issue-1448 Added logic to retry session based on retries/suiteRetries

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -194,7 +194,7 @@ Nightwatch.prototype.loadKeyCodes = function() {
 };
 
 Nightwatch.prototype.start = function() {
-  const sessionRetries = this.additionalOpts.suite_retries  || this.additionalOpts.retries || 1;
+  var sessionRetries = this.additionalOpts.suite_retries  || this.additionalOpts.retries || 1;
   if (!this.sessionId && this.options.start_session) {
     this
       .once('selenium:session_create', this.start)
@@ -461,7 +461,7 @@ Nightwatch.prototype.handleTestError = function(result) {
 };
 
 Nightwatch.prototype.startSession = function (attempts) {
-  const attemptsLeft = attempts -1;
+  var attemptsLeft = attempts -1;
   if (this.terminated) {
     return this;
   }
@@ -497,7 +497,7 @@ Nightwatch.prototype.startSession = function (attempts) {
     if (attemptsLeft > 0) {
       self.emit('selenium:session_create_retry', data, err);
       return self.startSession(attemptsLeft);
-    } 
+    }
     
     if (self.options.output) {
       console.error('\n' + Logger.colors.light_red('Error retrieving a new session from the selenium server'));

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ var Logger = require('./util/logger.js');
 var Api = require('./core/api.js');
 var Utils = require('./util/utils.js');
 
-function Nightwatch(options) {
+function Nightwatch(options, additionalOpts) {
   events.EventEmitter.call(this);
 
   this.api = {
@@ -25,7 +25,7 @@ function Nightwatch(options) {
   this.context = null;
   this.terminated = false;
 
-  this.setOptions(options)
+  this.setOptions(options, additionalOpts)
       .setCapabilities()
       .loadKeyCodes();
 
@@ -57,7 +57,8 @@ util.inherits(Nightwatch, events.EventEmitter);
 
 Nightwatch.prototype.assertion = Assertion.assert;
 
-Nightwatch.prototype.setOptions = function(options) {
+Nightwatch.prototype.setOptions = function(options, additionalOpts) {
+  this.additionalOpts = additionalOpts || {};
   this.options = {};
   this.api.options = {};
   if (options && typeof options == 'object') {
@@ -193,10 +194,11 @@ Nightwatch.prototype.loadKeyCodes = function() {
 };
 
 Nightwatch.prototype.start = function() {
+  const sessionRetries = this.additionalOpts.suite_retries  || this.additionalOpts.retries || 1;
   if (!this.sessionId && this.options.start_session) {
     this
       .once('selenium:session_create', this.start)
-      .startSession();
+      .startSession(sessionRetries);
     return this;
   }
 
@@ -458,7 +460,8 @@ Nightwatch.prototype.handleTestError = function(result) {
   };
 };
 
-Nightwatch.prototype.startSession = function () {
+Nightwatch.prototype.startSession = function (attempts) {
+  const attemptsLeft = attempts -1;
   if (this.terminated) {
     return this;
   }
@@ -482,10 +485,20 @@ Nightwatch.prototype.startSession = function () {
     } else if (isRedirect) {
       self.followRedirect(request, response);
     } else {
-      request.emit('error', data, null);
+      if (attemptsLeft > 0) {
+        self.emit('selenium:session_create_retry', response);
+        return self.startSession(attemptsLeft);
+      } else {
+        request.emit('error', data, null);
+      }
     }
   })
   .on('error', function(data, err) {
+    if (attemptsLeft > 0) {
+      self.emit('selenium:session_create_retry', data, err);
+      return self.startSession(attemptsLeft);
+    } 
+    
     if (self.options.output) {
       console.error('\n' + Logger.colors.light_red('Error retrieving a new session from the selenium server'));
     }
@@ -504,6 +517,7 @@ Nightwatch.prototype.startSession = function () {
 
   return this;
 };
+
 
 Nightwatch.prototype.followRedirect = function (request, response) {
   if (!response.headers || !response.headers.location) {
@@ -524,8 +538,8 @@ Nightwatch.prototype.followRedirect = function (request, response) {
 
 exports = module.exports = {};
 
-exports.client = function(options) {
-  return new Nightwatch(options);
+exports.client = function(options, additionalOpts) {
+  return new Nightwatch(options, additionalOpts);
 };
 
 exports.cli = function(runTests) {

--- a/lib/runner/clientmanager.js
+++ b/lib/runner/clientmanager.js
@@ -11,9 +11,9 @@ function ClientManager() {
 
 util.inherits(ClientManager, events.EventEmitter);
 
-ClientManager.prototype.init = function(opts) {
+ClientManager.prototype.init = function(opts,additionalOpts) {
   try {
-    this['@client'] = Nightwatch.client(opts);
+    this['@client'] = Nightwatch.client(opts, additionalOpts);
   } catch (err) {
     console.log(err.stack);
     this.emit('error', err, false);

--- a/lib/runner/clientmanager.js
+++ b/lib/runner/clientmanager.js
@@ -196,7 +196,7 @@ ClientManager.prototype.checkQueue = function() {
   var deferred = Q.defer();
   if (this.shouldRestartQueue()) {
     this.restartQueue(function() {
-      deferred.resolve(); 
+      deferred.resolve();
     });
   } else {
     deferred.resolve();

--- a/lib/runner/clientmanager.js
+++ b/lib/runner/clientmanager.js
@@ -11,7 +11,7 @@ function ClientManager() {
 
 util.inherits(ClientManager, events.EventEmitter);
 
-ClientManager.prototype.init = function(opts,additionalOpts) {
+ClientManager.prototype.init = function(opts, additionalOpts) {
   try {
     this['@client'] = Nightwatch.client(opts, additionalOpts);
   } catch (err) {
@@ -196,7 +196,7 @@ ClientManager.prototype.checkQueue = function() {
   var deferred = Q.defer();
   if (this.shouldRestartQueue()) {
     this.restartQueue(function() {
-      deferred.resolve();
+      deferred.resolve(); 
     });
   } else {
     deferred.resolve();

--- a/lib/runner/testsuite.js
+++ b/lib/runner/testsuite.js
@@ -21,6 +21,7 @@ function TestSuite(modulePath, fullPaths, opts, addtOpts) {
   this.currentTest = '';
   this.module.setReportKey(fullPaths, addtOpts.src_folders);
   this.options = opts;
+  this.addtOpts = addtOpts;
   this.testMaxRetries = addtOpts.retries || 0;
   this.suiteMaxRetries = addtOpts.suite_retries || 0;
   this.suiteRetries = 0;
@@ -43,7 +44,7 @@ TestSuite.prototype.setupClient = function() {
   this.client.on('error', function(err) {
     self.deferred.reject(err);
   });
-  this.client.init(this.options);
+  this.client.init(this.options, this.addtOpts);
   this.client.api('currentEnv', this.options.currentEnv);
   this.module.set('client', this.client.api());
   if (this.client.endSessionOnFail() && !this.module.endSessionOnFail()) {

--- a/test/src/index/testNightwatchIndex.js
+++ b/test/src/index/testNightwatchIndex.js
@@ -365,8 +365,8 @@ module.exports = {
           browserName: 'safari'
         }
       });
-      let timesHit = 0;
-      let maxRetries = 5;
+      var timesHit = 0;
+      var maxRetries = 5;
       client.on('selenium:session_create_retry', function (data) {
         timesHit++;
       });


### PR DESCRIPTION
This addresses https://github.com/nightwatchjs/nightwatch/issues/1448 . Attempts to create a session with selenium will now retry based on either the --retries flag or the --suiteRetries flag

Passing the additonalOptions from the cli arguements alll the way to the code that initializes the session is a bit ugly but seems safer than attempting a refactor or overloading the existing options object that gets through.  The advantage is that this will just work with existing settings. It is fairly intuitive that retrying a session initialization is tied to the retry cli commands

- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`)
- [x] If you're fixing a bug also create an issue if one doesn't exist yet
- [ ] If it's a new feature explain why do you think it's necessary
- [x] If your change include drastic or low level changes please discuss them to make sure they will be accepted and what the impact will be
- [x] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will not make it in very quick, if at all.
- [x] Do not include changes that are not related to the issue at hand
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.
- [x] Add unit tests