### PR TITLE
Fix #1808 - load custom commands on page objects

### DIFF
--- a/lib/api-loader/page-object.js
+++ b/lib/api-loader/page-object.js
@@ -16,7 +16,9 @@ class PageObjectLoader extends BaseCommandLoader {
       .loadCustomAssertions(pageObject);
 
     if (this.nightwatchInstance.startSessionEnabled) {
-      apiLoader.loadElementCommands(pageObject)
+      apiLoader
+        .loadElementCommands(pageObject)
+        .loadCustomCommands(pageObject)
         .loadExpectAssertions(pageObject);
 
       pageObject.expect.section = pageObject.expect.element;

--- a/test/src/core/testPageObjectCustomCommands.js
+++ b/test/src/core/testPageObjectCustomCommands.js
@@ -1,0 +1,48 @@
+const assert = require('assert');
+const path = require('path');
+const MockServer = require('../../lib/mockserver.js');
+const Nightwatch = require('../../lib/nightwatch.js');
+
+describe('test PageObject Commands', function () {
+  before(function (done) {
+    this.server = MockServer.init();
+
+    this.server.on('listening', function () {
+      done();
+    });
+  });
+
+  after(function (done) {
+    this.server.close(function () {
+      done();
+    });
+  });
+
+  beforeEach(function (done) {
+    Nightwatch.init({
+      page_objects_path: path.join(__dirname, '../../extra/pageobjects'),
+      custom_commands_path: [path.join(__dirname, '../../extra/commands')]
+    }, function () {
+      done();
+    });
+
+    this.client = Nightwatch.client();
+  });
+
+  it('testPageObjectCustomCommands', function (done) {
+    let api = this.client.api;
+    let page = api.page.simplePageObj();
+
+    page
+      .waitForElementPresent('#weblogin', 1000, true, function callback(result) {
+        assert.strictEqual(this, api, 'page callback context using selector should equal api');
+      })
+      // just make sure page object contains custom command
+      .customPerform(function () {
+        done();
+      });
+
+    this.client.start();
+  });
+});
+


### PR DESCRIPTION
In v1, custom commands are not being loaded onto page objects. This change should fix this.

I also added a test to make sure it doesn't break in the future. Before my change the test was failing.