### PR TITLE
Add @unstable tag to testsuite

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -884,22 +884,27 @@ CliRunner.prototype = {
         child.setLabel(outputLabel);
         child.on('result', function(childResult) {
           switch (childResult.type) {
-            case 'testsuite_finished':
+            case "testsuite_finished":
+              const isTestSuiteUnstable = globalResults.modules[childResult.moduleKey].isUnstable;
               globalResults.modules[childResult.moduleKey] = childResult.results;
+
               if (childResult.errmessages.length) {
                 globalResults.errmessages.concat(childResult.errmessages);
               }
 
               globalResults.passed += childResult.passed;
-              globalResults.failed += childResult.failed;
-              globalResults.errors += childResult.errors;
               globalResults.skipped += childResult.skipped;
               globalResults.tests += childResult.tests;
 
+              // If testsuite is not marked unstable, increment no. of failed and errors
+              if (!isTestSuiteUnstable) {
+                globalResults.failed += childResult.failed;
+                globalResults.errors += childResult.errors;
+              }
+
               self.printChildProcessOutput(childResult.itemKey);
               break;
-            case 'testsuite_started':
-
+            case "testsuite_started":
               break;
           }
 

--- a/lib/runner/module.js
+++ b/lib/runner/module.js
@@ -19,6 +19,7 @@ function Module(modulePath, opts, addtOpts) {
   this['@attributes'] = {
     '@endSessionOnFail' : true,
     '@disabled' : false,
+    '@unstable': false,
     '@desiredCapabilities' : {},
     '@tags' : []
   };
@@ -193,6 +194,10 @@ Module.prototype.endSessionOnFail = function() {
 Module.prototype.isDisabled = function() {
   return this['@attributes']['@disabled'];
 };
+
+Module.prototype.isUnstable = function() {
+  return this["@attributes"]["@unstable"];
+}
 
 Module.prototype.desiredCapabilities = function(capability) {
   if (capability && (capability in this['@attributes']['@desiredCapabilities'])) {


### PR DESCRIPTION
When @unstable is added to a testsuite, no. of failed and errors
are not incremented making the test to pass.

Usage:
```
module.exports = function(browser) {
  @unstable: true,
   …
}
```

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with addressing it quicker.

IMPORTANT: please base your branch on releases/v0.9, not on master.

- [ ] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`)
- [ ] If you're fixing a bug also create an issue if one doesn't exist yet
- [ ] If it's a new feature explain why do you think it's necessary
- [ ] If your change include drastic or low level changes please discuss them to make sure they will be accepted and what the impact will be
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will not make it in very quick, if at all.
- [ ] Do not include changes that are not related to the issue at hand
- [ ] Follow the same coding style with regards to spaces, semicolons, variable naming etc.
- [ ] Add unit tests
