### PR TITLE
Enhance page objects to include all commands

### DIFF
--- a/lib/api-loader/page-object.js
+++ b/lib/api-loader/page-object.js
@@ -17,6 +17,7 @@ class PageObjectLoader extends BaseCommandLoader {
 
     if (this.nightwatchInstance.startSessionEnabled) {
       apiLoader
+        .loadClientCommands(pageObject)
         .loadElementCommands(pageObject)
         .loadCustomCommands(pageObject)
         .loadExpectAssertions(pageObject);

--- a/test/src/core/testPageObjectApi.js
+++ b/test/src/core/testPageObjectApi.js
@@ -93,8 +93,8 @@ describe('test PageObjectApi', function () {
 
     assert.ok('click' in page);
     assert.ok('waitForElementPresent' in page);
-    assert.ok(!('end' in page));
-    assert.ok(!('switchWindow' in page));
+    assert.ok('end' in page);
+    assert.ok('switchWindow' in page);
   });
 });
 


### PR DESCRIPTION
Chaining can sometimes be frustrating due to limitations on the page object [only loading element commands](https://github.com/nightwatchjs/nightwatch/wiki/Page-Object-API#enhanced-page-object-command-api-methods):

```js
const page = client.page.Something();

// this works
page.waitForElementVisible();
// this doesn't work
page.execute();
// this works, but I have to use .api
page.api.execute();
```

 This attemps to solve that by adding all commands, both `clientCommands` and `elementCommands`, to the page object.