### PR TITLE
Fix for .waitForElement failing silently via the API

### DIFF
--- a/lib/api/element-commands/_waitForElement.js
+++ b/lib/api/element-commands/_waitForElement.js
@@ -201,6 +201,19 @@ class WaitForElement extends EventEmitter {
     return this;
   }
 
+  completeFail(...args) {
+    args.push(this);
+    try {
+      this.cb.apply(this.api, args);
+    } catch (err) {
+      this.emit('error', err);
+
+      return this;
+    }
+
+    return this;
+  }
+
   pass(result, defaultMsg, timeMs) {
     this.message = this.formatMessage(defaultMsg, timeMs);
 
@@ -214,7 +227,7 @@ class WaitForElement extends EventEmitter {
 
     this.assert(result, false, {actual, expected}, null, this.message, this.abortOnFailure, this.stackTrace);
 
-    return this.complete(result);
+    return this.completeFail(result);
   }
 
   assert(result, ...args) {

--- a/test/src/api/commands/testWaitForElementNotVisible.js
+++ b/test/src/api/commands/testWaitForElementNotVisible.js
@@ -92,7 +92,7 @@ describe('waitForElementNotVisible', function() {
           if (err) {
             try {
               assert.equal(err.message,
-                `Timed out while waiting for element <#weblogin> to not be visible for 15 milliseconds. - expected \u001b[0;32m"not visible"\u001b[0m but got: \u001b[0;31m"visible"\u001b[0m`
+                'Timed out while waiting for element <#weblogin> to not be visible for 15 milliseconds. - expected \u001b[0;32m"not visible"\u001b[0m but got: \u001b[0;31m"visible"\u001b[0m'
               );
               done();
             } catch (err) {

--- a/test/src/api/commands/testWaitForElementPresent.js
+++ b/test/src/api/commands/testWaitForElementPresent.js
@@ -3,6 +3,8 @@ const MockServer  = require('../../../lib/mockserver.js');
 const Nightwatch = require('../../../lib/nightwatch.js');
 const CommandGlobals = require('../../../lib/globals/commands.js');
 
+const initClient = () => Nightwatch.initClient();
+
 describe('waitForElementPresent', function() {
   before(function(done) {
     CommandGlobals.beforeEach.call(this, done);
@@ -13,65 +15,93 @@ describe('waitForElementPresent', function() {
   });
 
   it('client.waitForElementPresent() success', function(done) {
-    this.client.api.waitForElementPresent('#weblogin', 100, function(result, instance) {
-      assert.equal(instance.expectedValue, 'found');
-      assert.equal(result.status, 0);
-      assert.deepEqual(result.value[0], { ELEMENT: '0' });
-    });
+    initClient()
+      .then(client => {
+        client.api.waitForElementPresent('#weblogin', 100, function(result, instance) {
+          assert.equal(instance.expectedValue, 'found');
+          assert.equal(result.status, 0);
+          assert.deepEqual(result.value[0], { ELEMENT: '0' });
+        });
 
-    this.client.start(done);
+        client.start(done);
+      });
   });
 
   it('client.waitForElementPresent() with webdriver response success', function(done) {
-    Nightwatch.initClient({
-      selenium : {
-        version2: false
-      }
-    }).then(client => {
-      MockServer.addMock({
-        'url': '/wd/hub/session/1352110219202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
-        'response': JSON.stringify({
-          sessionId: '1352110219202',
-          status: 0
-        })
+    initClient()
+      .then(client => {
+
+        client.api.waitForElementPresent('#webdriver', 100, function(result, instance) {
+          assert.equal(instance.expectedValue, 'found');
+          assert.equal(result.status, 0);
+          assert.deepEqual(result.value, [{'element-6066-11e4-a52e-4f735466cecf': '5cc459b8-36a8-3042-8b4a-258883ea642b'}]);
+        }).end();
+
+        client.start(done);
       });
-
-      client.api.waitForElementPresent('#webdriver', 100, function(result, instance) {
-        assert.equal(instance.expectedValue, 'found');
-        assert.equal(result.status, 0);
-        assert.deepEqual(result.value, [{'element-6066-11e4-a52e-4f735466cecf': '5cc459b8-36a8-3042-8b4a-258883ea642b'}]);
-      });
-
-      client.start(done);
-    });
-
   });
 
   it('client.waitForElementPresent() failure with custom message', function(done) {
-    this.client.api.globals.waitForConditionPollInterval = 10;
-    this.client.api.waitForElementPresent('.weblogin', 15, function callback(result, instance) {
-      assert.equal(instance.message, 'Element .weblogin found in 15 milliseconds');
-      assert.equal(result.value, false);
-    }, 'Element %s found in %d milliseconds');
+    initClient()
+      .then(client => {
 
-    this.client.start(done);
+        client.api.globals.waitForConditionPollInterval = 10;
+        client.api.waitForElementPresent('.weblogin', 15, function callback(result, instance) {
+          assert.equal(instance.message, 'Element .weblogin found in 15 milliseconds');
+          assert.equal(result.value, false);
+        }, 'Element %s found in %d milliseconds').end();
+
+        client.queue.run((err) => {
+          if (err) {
+            try {
+              assert.equal(err.message,
+                `Element .weblogin found in 15 milliseconds - expected \u001b[0;32m"found"\u001b[0m but got: \u001b[0;31m"not found"\u001b[0m`
+              );
+              done();
+            } catch (err) {
+              done(err);
+            }
+            return;
+          }
+          done(Error('client.waitForElementPresent() should have failed'));
+        });
+      });
   });
 
   it('client.waitForElementPresent() failure', function(done) {
-    this.client.api.globals.waitForConditionPollInterval = 10;
+    initClient()
+      .then(client => {
+        client.api.globals.waitForConditionPollInterval = 10;
 
-    this.client.api.waitForElementPresent('.weblogin', 15, function callback(result) {
-      assert.equal(result.value, false);
-    });
+        client.api.waitForElementPresent('.weblogin', 15, function callback(result) {
+          assert.equal(result.value, false);
+        }).end();
 
-    this.client.start(done);
+        client.queue.run((err) => {
+          if (err) {
+            try {
+              assert.equal(err.message,
+                `Timed out while waiting for element <.weblogin> to be present for 15 milliseconds. - expected \u001b[0;32m"found"\u001b[0m but got: \u001b[0;31m"not found"\u001b[0m`
+              );
+              done();
+            } catch (err) {
+              done(err);
+            }
+            return;
+          }
+          done(Error('client.waitForElementPresent() should have failed'));
+        });
+      });
   });
 
   it('client.waitForElementPresent() failure no abort', function(done) {
-    this.client.api.waitForElementPresent('.weblogin', 100, false, function callback(result) {
-      assert.equal(result.value, false);
-    });
+    initClient()
+        .then(client => {
+        client.api.waitForElementPresent('.weblogin', 100, false, function callback(result) {
+          assert.equal(result.value, false);
+        });
 
-    this.client.start(done);
+        client.queue.run(done);
+      });
   });
 });

--- a/test/src/api/commands/testWaitForElementPresent.js
+++ b/test/src/api/commands/testWaitForElementPresent.js
@@ -55,7 +55,7 @@ describe('waitForElementPresent', function() {
           if (err) {
             try {
               assert.equal(err.message,
-                `Element .weblogin found in 15 milliseconds - expected \u001b[0;32m"found"\u001b[0m but got: \u001b[0;31m"not found"\u001b[0m`
+                'Element .weblogin found in 15 milliseconds - expected \u001b[0;32m"found"\u001b[0m but got: \u001b[0;31m"not found"\u001b[0m'
               );
               done();
             } catch (err) {
@@ -81,7 +81,7 @@ describe('waitForElementPresent', function() {
           if (err) {
             try {
               assert.equal(err.message,
-                `Timed out while waiting for element <.weblogin> to be present for 15 milliseconds. - expected \u001b[0;32m"found"\u001b[0m but got: \u001b[0;31m"not found"\u001b[0m`
+                'Timed out while waiting for element <.weblogin> to be present for 15 milliseconds. - expected \u001b[0;32m"found"\u001b[0m but got: \u001b[0;31m"not found"\u001b[0m'
               );
               done();
             } catch (err) {
@@ -96,7 +96,7 @@ describe('waitForElementPresent', function() {
 
   it('client.waitForElementPresent() failure no abort', function(done) {
     initClient()
-        .then(client => {
+      .then(client => {
         client.api.waitForElementPresent('.weblogin', 100, false, function callback(result) {
           assert.equal(result.value, false);
         });

--- a/test/src/api/commands/testWaitForElementVisible.js
+++ b/test/src/api/commands/testWaitForElementVisible.js
@@ -3,6 +3,9 @@ const common = require('../../../common.js');
 const MockServer  = require('../../../lib/mockserver.js');
 const CommandGlobals = require('../../../lib/globals/commands.js');
 const NightwatchAssertion = common.require('core/assertion.js');
+const Nightwatch = require('../../../lib/nightwatch.js');
+
+const initClient = () => Nightwatch.initClient();
 
 describe('waitForElementVisible', function() {
   const createOrig = NightwatchAssertion.create;
@@ -34,18 +37,21 @@ describe('waitForElementVisible', function() {
       })
     });
 
-    this.client.api.globals.abortOnAssertionFailure = false;
-    this.client.api.globals.waitForConditionPollInterval = 10;
-    this.client.api.waitForElementVisible('#weblogin', 15, 10, function (result, instance) {
-      assert.equal(assertion[0], false);
-      assert.equal(assertion[1].actual, 'not visible');
-      assert.equal(assertion[4], false);
-      NightwatchAssertion.create = createOrig;
-    });
+    initClient()
+      .then(client => {
+        client.api.globals.abortOnAssertionFailure = false;
+        client.api.globals.waitForConditionPollInterval = 10;
+        client.api.waitForElementVisible('#weblogin', 15, 10, function (result, instance) {
+          assert.equal(assertion[0], false);
+          assert.equal(assertion[1].actual, 'not visible');
+          assert.equal(assertion[4], false);
+          NightwatchAssertion.create = createOrig;
+        });
 
-    this.client.start(function(err) {
-      done(err);
-    });
+        client.start(function(err) {
+          done(err);
+        });
+      });
   });
 
   it('client.waitForElementVisible() fail with global timeout default', function (done) {
@@ -69,17 +75,21 @@ describe('waitForElementVisible', function() {
       })
     });
 
-    this.client.api.globals.waitForConditionTimeout = 15;
-    this.client.api.globals.waitForConditionPollInterval = 10;
-    this.client.api.waitForElementVisible('#weblogin', function callback(result, instance) {
-      assert.equal(assertion[0], false);
-      assert.equal(assertion[3], 'Timed out while waiting for element <#weblogin> to be visible for 15 milliseconds.');
-      assert.equal(assertion[1].actual, 'not visible');
+    initClient()
+      .then(client => {
+        client.api.globals.waitForConditionTimeout = 15;
+        client.api.globals.waitForConditionPollInterval = 10;
+        client.api.waitForElementVisible('#weblogin', function callback(result, instance) {
+          assert.equal(assertion[0], false);
+          assert.equal(assertion[3], 'Timed out while waiting for element <#weblogin> to be visible for 15 milliseconds.');
+          assert.equal(assertion[1].actual, 'not visible');
 
-      NightwatchAssertion.create = createOrig;
-    });
+          NightwatchAssertion.create = createOrig;
+          done();
+        });
 
-    this.client.start(done);
+        client.start(done);
+      });
   });
 
   it('client.waitForElementVisible() fail with global timeout default and custom message', function (done) {
@@ -103,15 +113,19 @@ describe('waitForElementVisible', function() {
       })
     });
 
-    this.client.api.globals.waitForConditionTimeout = 15;
-    this.client.api.globals.waitForConditionPollInterval = 10;
-    this.client.api.waitForElementVisible('#weblogin', function callback(result, instance) {
-      assert.equal(assertion[3], 'Test message <#weblogin> and a global 15 ms.');
+    initClient()
+      .then(client => {
+        client.api.globals.waitForConditionTimeout = 15;
+        client.api.globals.waitForConditionPollInterval = 10;
+        client.api.waitForElementVisible('#weblogin', function callback(result, instance) {
+          assert.equal(assertion[3], 'Test message <#weblogin> and a global 15 ms.');
 
-      NightwatchAssertion.create = createOrig;
-    }, 'Test message <%s> and a global %s ms.');
+          NightwatchAssertion.create = createOrig;
+          done();
+        }, 'Test message <%s> and a global %s ms.');
 
-    this.client.start(done);
+        client.start(done);
+      });
   });
 
   it('client.waitForElementVisible() StaleElementReference error', function (done) {
@@ -155,22 +169,25 @@ describe('waitForElementVisible', function() {
         })
       }, true);
 
-    this.client.api.waitForElementVisible('#stale-element', 110, 10, function callback(result, instance) {
-      assert.equal(assertion[0], true);
-      assert.equal(result.value, true);
 
-      NightwatchAssertion.create = createOrig;
-    });
+    initClient()
+      .then(client => {
+        client.api.waitForElementVisible('#stale-element', 110, 10, function callback(result, instance) {
+          assert.equal(assertion[0], true);
+          assert.equal(result.value, true);
 
-    this.client.start(function() {
-      MockServer.removeMock({
-        url: '/wd/hub/session/1352110219202/elements',
-        method: 'POST'
+          NightwatchAssertion.create = createOrig;
+        });
+
+        client.start(function() {
+          MockServer.removeMock({
+            url: '/wd/hub/session/1352110219202/elements',
+            method: 'POST'
+          });
+
+          done();
+        });
       });
-
-      done();
-    });
-
 
   });
 

--- a/test/src/core/testQueue.js
+++ b/test/src/core/testQueue.js
@@ -6,46 +6,89 @@ describe('test Queue', function () {
   beforeEach(function (done) {
     Globals.beforeEach.call(this, {
       silent: true,
-      output: false
+          output: false
     }, () => {
       this.client.queue.reset();
       done();
     });
   });
 
-  afterEach(function (done) {
-    Globals.afterEach.call(this, done);
-  });
-
-  it('Test commands queue', function (done) {
-    let client = this.client;
-    let queue = client.queue;
-    let urlCommand;
-    let endCommand;
-    Nocks.url().deleteSession();
-
-    client.api.url('http://localhost').end();
-
-    assert.equal(queue.list().length, 2);
-    urlCommand = queue.rootNode.childNodes[0];
-    endCommand = queue.rootNode.childNodes[1];
-
-    assert.equal(endCommand.done, false);
-    assert.equal(urlCommand.done, false);
-    assert.equal(endCommand.started, false);
-
-    this.client.start(err => {
-      if (err) {
-        return done(err);
-      }
-
-      assert.equal(urlCommand.done, true);
-      assert.equal(endCommand.childNodes.length, 1);
-      assert.equal(endCommand.done, true);
-      assert.equal(queue.list().length, 2);
-      done();
+    afterEach(function (done) {
+        Globals.afterEach.call(this, done);
     });
 
-    assert.equal(urlCommand.started, true);
+    it('Test commands queue', function (done) {
+      let client = this.client;
+      let queue = client.queue;
+      let urlCommand;
+      let endCommand;
+      Nocks.url().deleteSession();
+
+      client.api.url('http://localhost').end();
+
+      assert.equal(queue.list().length, 2);
+      urlCommand = queue.rootNode.childNodes[0];
+      endCommand = queue.rootNode.childNodes[1];
+
+      assert.equal(endCommand.done, false);
+      assert.equal(urlCommand.done, false);
+      assert.equal(endCommand.started, false);
+
+      this.client.start(err => {
+        if (err) {
+          return done(err);
+        }
+
+        assert.equal(urlCommand.done, true);
+        assert.equal(endCommand.childNodes.length, 1);
+        assert.equal(endCommand.done, true);
+        assert.equal(queue.list().length, 2);
+        done();
+      });
+
+      assert.equal(urlCommand.started, true);
+  });
+
+  it('waitForElement failures should report a failure when abortOnFailure is true', function (done) {
+
+    let client = this.client;
+    let queue = this.client.queue;
+
+    client.api
+      .url('http://localhost')
+      .waitForElementVisible('#badElement', 15)
+      .end();
+
+    // this will timeout on a failure
+    queue.run(err => {
+      if (err) {
+        done();
+      }
+    });
+  });
+
+  it('Failed assertions should throw an error', function (done) {
+    let api = this.client.api;
+    let client = this.client;
+    let queue = this.client.queue;
+
+    client.api.assert.visible('#badElement');
+
+    queue.run(err => {
+      if (err) {
+        try {
+          assert.equal(err.message,
+            `Testing if element <#badElement> is visible. Element could not be located in 1000 ms. - expected \u001b[0;32m"true"\u001b[0m but got: \u001b[0;31m"null"\u001b[0m`
+          );
+          done();
+        } catch (err) {
+          done(err);
+        }
+        return;
+      }
+      done(
+        Error('should have thrown an error for command failure with abortOnFailure true')
+      );
+    });
   });
 });

--- a/test/src/core/testQueue.js
+++ b/test/src/core/testQueue.js
@@ -13,40 +13,40 @@ describe('test Queue', function () {
     });
   });
 
-    afterEach(function (done) {
-        Globals.afterEach.call(this, done);
+  afterEach(function (done) {
+    Globals.afterEach.call(this, done);
+  });
+
+  it('Test commands queue', function (done) {
+    let client = this.client;
+    let queue = client.queue;
+    let urlCommand;
+    let endCommand;
+    Nocks.url().deleteSession();
+
+    client.api.url('http://localhost').end();
+
+    assert.equal(queue.list().length, 2);
+    urlCommand = queue.rootNode.childNodes[0];
+    endCommand = queue.rootNode.childNodes[1];
+
+    assert.equal(endCommand.done, false);
+    assert.equal(urlCommand.done, false);
+    assert.equal(endCommand.started, false);
+
+    this.client.start(err => {
+      if (err) {
+        return done(err);
+      }
+
+      assert.equal(urlCommand.done, true);
+      assert.equal(endCommand.childNodes.length, 1);
+      assert.equal(endCommand.done, true);
+      assert.equal(queue.list().length, 2);
+      done();
     });
 
-    it('Test commands queue', function (done) {
-      let client = this.client;
-      let queue = client.queue;
-      let urlCommand;
-      let endCommand;
-      Nocks.url().deleteSession();
-
-      client.api.url('http://localhost').end();
-
-      assert.equal(queue.list().length, 2);
-      urlCommand = queue.rootNode.childNodes[0];
-      endCommand = queue.rootNode.childNodes[1];
-
-      assert.equal(endCommand.done, false);
-      assert.equal(urlCommand.done, false);
-      assert.equal(endCommand.started, false);
-
-      this.client.start(err => {
-        if (err) {
-          return done(err);
-        }
-
-        assert.equal(urlCommand.done, true);
-        assert.equal(endCommand.childNodes.length, 1);
-        assert.equal(endCommand.done, true);
-        assert.equal(queue.list().length, 2);
-        done();
-      });
-
-      assert.equal(urlCommand.started, true);
+    assert.equal(urlCommand.started, true);
   });
 
   it('waitForElement failures should report a failure when abortOnFailure is true', function (done) {
@@ -78,7 +78,7 @@ describe('test Queue', function () {
       if (err) {
         try {
           assert.equal(err.message,
-            `Testing if element <#badElement> is visible. Element could not be located in 1000 ms. - expected \u001b[0;32m"true"\u001b[0m but got: \u001b[0;31m"null"\u001b[0m`
+            'Testing if element <#badElement> is visible. Element could not be located in 1000 ms. - expected \u001b[0;32m"true"\u001b[0m but got: \u001b[0;31m"null"\u001b[0m'
           );
           done();
         } catch (err) {

--- a/test/src/core/testQueue.js
+++ b/test/src/core/testQueue.js
@@ -6,7 +6,7 @@ describe('test Queue', function () {
   beforeEach(function (done) {
     Globals.beforeEach.call(this, {
       silent: true,
-          output: false
+      output: false
     }, () => {
       this.client.queue.reset();
       done();


### PR DESCRIPTION
This addresses #1889.

I'm completely open to other ways of fixing this, let me know what you think.

The core issue is that in `_waitForElement.js` the `complete()` function was issuing the `complete` event _before_ issuing an `error` event in the case of a failure. Because downstream this is received in the queue service and is treated as a Promise resolution, the initial `complete` would resolve the queue Promise and the later `error` would trigger `reject` on an already-resolved Promise. This means it would do nothing as reject/resolve will not execute after Promise resolution.

This means that if you used the API via `this.client.start` or `queue.run` with a callback, that callback would only ever receive the result of a `complete` call, which is `null`, this allowing any `waitForElement*` calls to fail silently.

The solution I've provided is to have two `complete` functions, one for failure, one for passes. The one for failure never issues the `complete` event.

Addressing this revealed several unit tests that were failing silently, all were `waitForElement` unit tests. Those are fixed here as well. 

After those unit test were fixed there was another underlying bug to the pattern used in those files (causing more unit test failures), where `client.start`'s callback from previous `it` tests were being run upon failures in later `it` statements within the same suite. This is addressed by instancing the client using the `initClient` function I have included.

I've applied this pattern to only the tests the require them to pass in this PR, and will gladly submit a future PR to address this elsewhere. (For example, the cookie tests have this bug as well -- if the second `it` test generates a failure, it trigger the first `it`'s `client.start` callback.)

Feedback very welcome. Thanks for this library!