### PR TITLE
Issue-1891: Update documentation for waitForElement commands

### DIFF
--- a/lib/api/element-commands/waitForElementNotPresent.js
+++ b/lib/api/element-commands/waitForElementNotPresent.js
@@ -16,8 +16,9 @@ const WaitForElement = require('./_waitForElement.js');
  *
  * @method waitForElementNotPresent
  * @param {string} selector The selector (CSS / Xpath) used to locate the element.
- * @param {number} time The number of milliseconds to wait. The runner performs repeated checks every 500 ms.
- * @param {boolean} [abortOnFailure] By the default if the element is not found the test will fail. Set this to false if you wish for the test to continue even if the assertion fails. To set this globally you can define a property `abortOnAssertionFailure` in your globals.
+ * @param {number} [time=waitForConditionTimeout] The total number of milliseconds to wait before failing.
+ * @param {number} [poll=waitForConditionPollInterval] The number of milliseconds to wait between checks. You can use this only if you also specify the time parameter.
+ * @param {boolean} [abortOnFailure=abortOnAssertionFailure] By the default if the element is not found the test will fail. Set this to false if you wish for the test to continue even if the assertion fails. To set this globally you can define a property `abortOnAssertionFailure` in your globals.
  * @param {function} [callback] Optional callback function to be called when the command finishes.
  * @param {string} [message] Optional message to be shown in the output; the message supports two placeholders: %s for current selector and %d for the time (e.g. Element %s was not in the page for %d ms).
  * @see waitForElementPresent

--- a/lib/api/element-commands/waitForElementNotVisible.js
+++ b/lib/api/element-commands/waitForElementNotVisible.js
@@ -16,8 +16,9 @@ const WaitForElementPresent = require('./waitForElementPresent.js');
  *
  * @method waitForElementNotVisible
  * @param {string} selector The selector (CSS / Xpath) used to locate the element.
- * @param {number} time The number of milliseconds to wait. The runner performs repeated checks every 500 ms.
- * @param {boolean} [abortOnFailure] By the default if the element is not found the test will fail. Set this to false if you wish for the test to continue even if the assertion fails. To set this globally you can define a property `abortOnAssertionFailure` in your globals.
+ * @param {number} [time=waitForConditionTimeout] The total number of milliseconds to wait before failing.
+ * @param {number} [poll=waitForConditionPollInterval] The number of milliseconds to wait between checks. You can use this only if you also specify the time parameter.
+ * @param {boolean} [abortOnFailure=abortOnAssertionFailure] By the default if the element is not found the test will fail. Set this to false if you wish for the test to continue even if the assertion fails. To set this globally you can define a property `abortOnAssertionFailure` in your globals.
  * @param {function} [callback] Optional callback function to be called when the command finishes.
  * @param {string} [message] Optional message to be shown in the output; the message supports two placeholders: %s for current selector and %d for the time (e.g. Element %s was not in the page for %d ms).
  * @since v0.4.0

--- a/lib/api/element-commands/waitForElementPresent.js
+++ b/lib/api/element-commands/waitForElementPresent.js
@@ -26,8 +26,9 @@ const WaitForElement = require('./_waitForElement.js');
  *
  * @method waitForElementPresent
  * @param {string} selector The selector (CSS / Xpath) used to locate the element.
- * @param {number} time The number of milliseconds to wait. The runner performs repeated checks every 500 ms.
- * @param {boolean} [abortOnFailure] By the default if the element is not found the test will fail. Set this to false if you wish for the test to continue even if the assertion fails. To set this globally you can define a property `abortOnAssertionFailure` in your globals.
+ * @param {number} [time=waitForConditionTimeout] The total number of milliseconds to wait before failing.
+ * @param {number} [poll=waitForConditionPollInterval] The number of milliseconds to wait between checks. You can use this only if you also specify the time parameter.
+ * @param {boolean} [abortOnFailure=abortOnAssertionFailure] By the default if the element is not found the test will fail. Set this to false if you wish for the test to continue even if the assertion fails. To set this globally you can define a property `abortOnAssertionFailure` in your globals.
  * @param {function} [callback] Optional callback function to be called when the command finishes.
  * @param {string} [message] Optional message to be shown in the output; the message supports two placeholders: %s for current selector and %d for the time (e.g. Element %s was not in the page for %d ms).
  * @api commands

--- a/lib/api/element-commands/waitForElementVisible.js
+++ b/lib/api/element-commands/waitForElementVisible.js
@@ -26,8 +26,9 @@ const WaitForElementPresent = require('./waitForElementPresent.js');
  *
  * @method waitForElementVisible
  * @param {string} selector The selector (CSS / Xpath) used to locate the element.
- * @param {number} time The number of milliseconds to wait. The runner performs repeated checks every 500 ms.
- * @param {boolean} [abortOnFailure] By the default if the element is not found the test will fail. Set this to false if you wish for the test to continue even if the assertion fails. To set this globally you can define a property `abortOnAssertionFailure` in your globals.
+ * @param {number} [time=waitForConditionTimeout] The total number of milliseconds to wait before failing.
+ * @param {number} [poll=waitForConditionPollInterval] The number of milliseconds to wait between checks. You can use this only if you also specify the time parameter.
+ * @param {boolean} [abortOnFailure=abortOnAssertionFailure] By the default if the element is not found the test will fail. Set this to false if you wish for the test to continue even if the assertion fails. To set this globally you can define a property `abortOnAssertionFailure` in your globals.
  * @param {function} [callback] Optional callback function to be called when the command finishes.
  * @param {string} [message] Optional message to be shown in the output; the message supports two placeholders: %s for current selector and %d for the time (e.g. Element %s was not in the page for %d ms).
  * @api commands


### PR DESCRIPTION
Fix for issue #1891 

- Indicate time parameter is optional
- Add poll parameter
- Add default value for time, poll, abortOnFailure

