### PR TITLE
Issue-1911: fixing issue with port #1911

### DIFF
--- a/lib/settings/settings.js
+++ b/lib/settings/settings.js
@@ -98,8 +98,6 @@ class Settings {
   setWebdriverSettings() {
     if (this.settings.selenium && this.settings.selenium.start_process) {
       lodashMerge(this.settings.webdriver, this.settings.selenium);
-    } else if (this.settings.selenium) {
-      defaultsDeep(this.settings.webdriver, this.settings.selenium);
     }
 
     if (this.settings.start_session === undefined && this.settings.webdriver.start_session !== undefined) {

--- a/test/src/runner/cli/testCliRunner.js
+++ b/test/src/runner/cli/testCliRunner.js
@@ -33,6 +33,19 @@ describe('Test CLI Runner', function() {
     mockery.registerMock('./nightwatch.json', config);
     mockery.registerMock('./nightwatch.conf.js', config);
 
+    mockery.registerMock('./selenium_disabled.json', {
+      test_settings: {
+        selenium: {
+          start_process: true
+        },
+        test_settings: {
+          'default': {
+            selenium_port: 4441
+          }
+        }
+      }
+    });
+
     mockery.registerMock('./output_disabled.json', {
       src_folders: ['tests'],
       output_folder: false,
@@ -241,6 +254,9 @@ describe('Test CLI Runner', function() {
         if (b == './extra/globals-err.js') {
           return './extra/globals-err.js';
         }
+        if (b == './selenium_disabled.json') {
+          return './selenium_disabled.json'
+        }
         return './nightwatch.json';
       },
       resolve: function(a) {
@@ -392,6 +408,28 @@ describe('Test CLI Runner', function() {
     assert.equal(runner.test_settings.username, 'testuser');
     assert.equal(runner.test_settings.credentials.service.user, 'testuser');
     assert.equal(runner.test_settings.desiredCapabilities['test.user'], 'testuser');
+  });
+
+  it('testSeleniumPortWhenStartProcessDisabled', function() {
+    mockery.registerMock('fs', {
+      statSync: function(module) {
+        if (module == './selenium_disabled.json') {
+          return {
+            isFile: function() {
+              return true
+            }
+          };
+        }
+        throw new Error('Does not exist');
+      }
+    });
+    const CliRunner = common.require('runner/cli/cli.js');
+    let runner = new CliRunner({
+      config: './selenium_disabled.json',
+    }).setup();
+
+    assert.equal(runner.isWebDriverManaged(), false);
+    assert.notEqual(runner.test_settings.webdriver.port, 4444);
   });
 
   it('testGetTestSourceSingle', function() {


### PR DESCRIPTION
Fix for issue #1911 
### Description
When start selenium is disabled even then selenium port for all requests are same as in selenium_setting and not the one mention on test settings.

### Root Cause
While setting webdriver settings, port from this selenium is setting is set even though it is not being used. This setting is used for all subsequent requests [here](https://github.com/nightwatchjs/nightwatch/blob/master/lib/index.js#L240)