### PR TITLE
Issue-1922: Moved failure screenshot logic from end.js to testsuite.js

### DIFF
--- a/lib/api/client-commands/end.js
+++ b/lib/api/client-commands/end.js
@@ -1,6 +1,5 @@
 const events = require('events');
 const Logger = require('../../util/logger.js');
-const Screenshots = require('../../testsuite/screenshots.js');
 
 /**
  * Ends the session. Uses session protocol command.
@@ -21,16 +20,6 @@ class End extends events.EventEmitter {
     let client = this.client;
 
     if (this.api.sessionId) {
-      if (this.testFailuresExist() && this.shouldTakeScreenshot()) {
-        let fileNamePath = Screenshots.getScreenshotFileName(client.api.currentTest, false, client.options.screenshots.path);
-        Logger.info('Failures in "' + this.api.currentTest.name + '". Taking screenshot...');
-
-        this.api.saveScreenshot(fileNamePath, (result, err) => {
-          if (err || !this.client.transport.isResultSuccess(result))  {
-            Logger.warn('Error saving screenshot...', err || result);
-          }
-        });
-      }
 
       this.api.session('delete', result => {
         client.session.clearSession();
@@ -47,20 +36,7 @@ class End extends events.EventEmitter {
     return this.client.api;
   }
 
-  testFailuresExist() {
-    let currentTest = this.api.currentTest || {};
-
-    if (currentTest.results) {
-      return currentTest.results.errors > 0 || currentTest.results.failed > 0;
-    }
-
-    return null;
-  }
-
-  shouldTakeScreenshot() {
-    return this.api.options.screenshots.enabled && this.api.options.screenshots.on_failure;
-  }
-
+  
   complete(callback, result) {
     if (typeof callback === 'function') {
       callback.call(this.api, result);

--- a/lib/testsuite/testsuite.js
+++ b/lib/testsuite/testsuite.js
@@ -11,6 +11,7 @@ const NightwatchAssertError = require('../core/assertion.js').AssertionError;
 const SuiteRetries = require('./retries.js');
 const Nightwatch = require('../index.js');
 const Concurrency = require('../runner/concurrency/concurrency.js');
+const Screenshots = require('./screenshots.js');
 
 class TestSuite extends EventEmitter {
   constructor(modulePath, allModulePaths, settings, argvOpts, addtOpts = {}) {
@@ -355,6 +356,17 @@ class TestSuite extends EventEmitter {
       })
       .then(possibleError => {
         // if there was an error in the testcase and skip_testcases_on_fail, we must send it forward, but after we run afterEach and after hooks
+        if (!this.shouldRetryTestCase() && this.testFailuresExist() && this.shouldTakeScreenshot()) {
+          let fileNamePath = Screenshots.getScreenshotFileName(this.api.currentTest, false, this.api.options.screenshots.path);
+          Logger.info('Failures in "' + this.api.currentTest.name + '". Taking screenshot...');
+  
+          this.api.saveScreenshot(fileNamePath, (result, err) => {
+            if (err || !this.client.transport.isResultSuccess(result))  {
+              Logger.warn('Error saving screenshot...', err || result);
+            }
+          });
+        }
+        
         return this.runHook('afterEach')
           .then(() => this.testCaseFinished())
           .then(() => possibleError);
@@ -488,6 +500,20 @@ class TestSuite extends EventEmitter {
     }
 
     return this;
+  }
+
+  shouldTakeScreenshot() {
+    return this.api.options.screenshots.enabled && this.api.options.screenshots.on_failure;
+  }
+
+  testFailuresExist() {
+    let currentTest = this.api.currentTest || {};
+
+    if (currentTest.results) {
+      return currentTest.results.errors > 0 || currentTest.results.failed > 0;
+    }
+
+    return null;
   }
 
   resetQueue() {


### PR DESCRIPTION
See https://github.com/nightwatchjs/nightwatch/issues/1922

This is a first attempt, hoping someone who knows more can tell me if I botched this.  Unit tests still pass though.

This will be captured before `after` and `afterEach` functions, so we'll lose screenshot capability in those hooks, but I don't think that should really be the focus.  Ideally you would only want to screenshot the core of your test?