### PR TITLE
Set selenium.port to undefined.

### DIFF
--- a/lib/settings/defaults.js
+++ b/lib/settings/defaults.js
@@ -74,7 +74,7 @@ module.exports = {
     cli_args: {},
     server_path: null,
     log_path: '',
-    port: 4444,
+    port: undefined,
     check_process_delay: 500
   },
 


### PR DESCRIPTION
The `settings.setWebdriverSettings()` function merges `selenium` in `webdriver`:
```
...
    } else if (this.settings.selenium) {
      defaultsDeep(this.settings.webdriver, this.settings.selenium);
    }
...
```

This eventually causes `setWebdriverHttpOption()` in `lib/index.js` to incorrectly treat `typeof webdriverOpts[port]` as set (`typeof webdriverOpts[newSetting] == 'number'`).

In this PR, we just set `selenium.port` to `undefined` in `lib/settings/defaults.js`. I'm not sure this is the right option here, but it looked to me to be the most straightforward, least disrupting.

Fixes https://github.com/nightwatchjs/nightwatch/issues/1949
