### PR TITLE
Allow to use Typescript to write tests/hooks/commands

### DIFF
--- a/lib/api-loader/_base-loader.js
+++ b/lib/api-loader/_base-loader.js
@@ -4,8 +4,6 @@ const EventEmitter = require('events');
 const Utils = require('../util/utils.js');
 const Element = require('../page-object/element.js');
 
-const VALID_FILENAME_EXT = '.js';
-
 class BaseLoader extends EventEmitter {
   constructor(nightwatchInstance) {
     super();
@@ -157,10 +155,14 @@ class BaseLoader extends EventEmitter {
       return this;
     }
 
-    this.commandName = path.basename(fileName, VALID_FILENAME_EXT);
+    const extension = Utils.VALID_FILENAME_EXTS.find(extension => {
+      return fileName.endsWith(extension);
+    });
+
+    this.commandName = path.basename(fileName, extension);
 
     try {
-      this.__module = require(path.join(dirPath, fileName));
+      this.__module = Utils.requireModule(path.join(dirPath, fileName));
     } catch (err) {
       throw new Error(`There was an error while trying to load the file ${fileName}:\n${err.stack}`);
     }

--- a/lib/runner/folder-walk.js
+++ b/lib/runner/folder-walk.js
@@ -31,7 +31,7 @@ class Results {
 
 class Walk {
   static get FILE_EXT_PATTERN () {
-    return /\.js$/;
+    return /\.(j|t)s$/;
   }
 
   constructor(testSource = [], settings, argv = {}) {

--- a/lib/runner/test-source.js
+++ b/lib/runner/test-source.js
@@ -39,7 +39,7 @@ class TestSource {
       testsource = path.join(process.cwd(), targetPath);
     }
 
-    if (testsource.substr(-3) !== TestSource.defaultFileExt) {
+    if (!Utils.VALID_FILENAME_EXTS.includes(testsource.substr(-3))) {
       testsource += TestSource.defaultFileExt;
     }
 

--- a/lib/testsuite/context.js
+++ b/lib/testsuite/context.js
@@ -101,7 +101,7 @@ class Context {
 
   loadModule() {
     try {
-      this.__module = require(this.modulePath);
+      this.__module = Utils.requireModule(this.modulePath);
     } catch (err) {
       throw err;
     }

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -57,6 +57,16 @@ class Utils {
     };
   }
 
+  static requireModule(path) {
+    const exported = require(path);
+
+    if (exported.hasOwnProperty('default')) {
+      return exported.default;
+    }
+
+    return exported;
+  }
+
   static formatElapsedTime(timeMs, includeMs = false) {
     let seconds = timeMs/1000;
 
@@ -310,7 +320,7 @@ class Utils {
   }
 
   static isFileNameValid(fileName) {
-    return path.extname(fileName) === '.js';
+    return Utils.VALID_FILENAME_EXTS.includes(path.extname(fileName));
   }
 
   static checkPath(source, originalErr = null) {
@@ -390,6 +400,8 @@ class Utils {
     return deferred;
   }
 }
+
+Utils.VALID_FILENAME_EXTS = ['.js', '.ts'];
 
 function contains(str, text) {
   if (Array.isArray(text)) {


### PR DESCRIPTION
This is not actually meant to be merged – I just wanted to submit what I've tried to make Typescript work with Nightwatch. Run the Nightwatch executable with ts-node, and it turns out that you can use Typescript to write Nightwatch tests/hooks/commands/config. I'm sure that there will be pitfalls, but I haven't seen anything significant so far (the test names appear to be wrong, but I don't care for my use case).

I do believe Typescript is the future of Javascript, and I don't think littering your project folder with tons of compiled TS files is a good solution to make Typescript work with Typescript code. I don't want you to take my opinions at face value, though. What I'd like to know is: what are the plans, if any, regarding Typescript integration?

It really isn't much work to make Nightwatch work with Typescript without the unnecessary compilation artifacts, as you can see. Do you think there is a chance that Nightwatch will ever stop being strict about file extensions?

Thanks for your time.
