### PR TITLE
Issue/1991 fix skiptags skipping tests without tags

### DIFF
--- a/lib/runner/folder-walk.js
+++ b/lib/runner/folder-walk.js
@@ -109,7 +109,7 @@ class Walk {
         matched = minimatch(filename, this.settings.filename_filter);
       }
 
-      if (this.settings.tag_filter || this.settings.skiptags) {
+      if (this.settings.tag_filter.length || this.settings.skiptags.length) {
         matched = this.tags.match(filePath);
       }
 

--- a/lib/runner/folder-walk.js
+++ b/lib/runner/folder-walk.js
@@ -109,7 +109,7 @@ class Walk {
         matched = minimatch(filename, this.settings.filename_filter);
       }
 
-      if (this.settings.tag_filter.length || this.settings.skiptags.length) {
+      if (this.tags.anyTagsDefined()) {
         matched = this.tags.match(filePath);
       }
 

--- a/lib/runner/matchers/tags.js
+++ b/lib/runner/matchers/tags.js
@@ -49,19 +49,15 @@ class TagsMatcher {
   
   checkModuleTags(testModule) {
     const moduleTags = TagsMatcher.convertTags(testModule['@tags'] || testModule.tags);
-
-    if (this.hasIncludeTagFilter()) {
-      // if we passed the --tag argument, check if the module contains the tag (or tags)
-      if (!this.containsTag(moduleTags)) {
-        return false;
-      }
+    
+    // if we passed the --tag argument, check if the module contains the tag (or tags)
+    if (this.hasIncludeTagFilter() && !this.containsTag(moduleTags)) {
+      return false;
     }
 
-    if (this.hasSkipTagFilter()) {
-      // if we passed the --skiptags argument, check if the module doesn't contain any of the tags in the skiptags array
-      if (!this.excludesTag(moduleTags)) {
-        return false;
-      }
+    // if we passed the --skiptags argument, check if the module doesn't contain any of the tags in the skiptags array
+    if (this.hasSkipTagFilter() && !this.excludesTag(moduleTags)) {
+      return false;
     }
 
     return true;

--- a/lib/runner/matchers/tags.js
+++ b/lib/runner/matchers/tags.js
@@ -1,11 +1,6 @@
 const Logger = require('../../util/logger.js');
 
 class TagsMatcher {
-  constructor(settings) {
-    this.includeTags = TagsMatcher.convertTags(settings.tag_filter);
-    this.excludeTags = TagsMatcher.convertTags(settings.skiptags);
-  }
-
   /**
    * @param {string|Array} tagStringOrArray
    * @return {Array}
@@ -22,6 +17,11 @@ class TagsMatcher {
     return [];
   }
 
+  constructor(settings) {
+    this.includeTags = TagsMatcher.convertTags(settings.tag_filter);
+    this.excludeTags = TagsMatcher.convertTags(settings.skiptags);
+  }
+  
   checkModuleTags(testModule) {
     let moduleTags = testModule['@tags'] || testModule.tags;
     let match = true;

--- a/lib/runner/matchers/tags.js
+++ b/lib/runner/matchers/tags.js
@@ -12,7 +12,7 @@ class TagsMatcher {
   static convertTags(tags) {
     let tagsArray = Array.isArray(tags) ? tags : [];
     
-    if (Utils.isString(tags)) {
+    if (Utils.isString(tags) && tags.length > 0) {
       tagsArray = tags.split(TagsMatcher.SEPARATOR);
     } else if (Utils.isNumber(tags)) {
       tagsArray.push(tags);
@@ -50,18 +50,21 @@ class TagsMatcher {
   checkModuleTags(testModule) {
     const moduleTags = TagsMatcher.convertTags(testModule['@tags'] || testModule.tags);
 
-    let match = true;
     if (this.hasIncludeTagFilter()) {
       // if we passed the --tag argument, check if the module contains the tag (or tags)
-      match = this.containsTag(moduleTags);
+      if (!this.containsTag(moduleTags)) {
+        return false;
+      }
     }
 
     if (this.hasSkipTagFilter()) {
       // if we passed the --skiptags argument, check if the module doesn't contain any of the tags in the skiptags array
-      match = this.excludesTag(moduleTags);
+      if (!this.excludesTag(moduleTags)) {
+        return false;
+      }
     }
 
-    return match;
+    return true;
   }
 
   /**

--- a/lib/runner/matchers/tags.js
+++ b/lib/runner/matchers/tags.js
@@ -2,19 +2,22 @@ const Logger = require('../../util/logger.js');
 
 class TagsMatcher {
   /**
-   * @param {string|Array} tagStringOrArray
+   * @param {string|number|Array} tagStringOrArray
    * @return {Array}
    */
   static convertTags(tagStringOrArray) {
+    let tagsArray;
     if (Array.isArray(tagStringOrArray)) {
-      return tagStringOrArray;
+      tagsArray = tagStringOrArray;
+    } else if (typeof tagStringOrArray == 'string' && tagStringOrArray.length > 0) {
+      tagsArray = tagStringOrArray.split(',');
+    } else if (tagStringOrArray) {
+      tagsArray = [tagStringOrArray];
+    } else {
+      tagsArray = [];
     }
 
-    if (typeof tagStringOrArray == 'string' && tagStringOrArray.length > 0) {
-      return tagStringOrArray.split(',');
-    }
-
-    return [];
+    return tagsArray.map((t)=>String(t).toLowerCase());
   }
 
   constructor(settings) {
@@ -23,32 +26,22 @@ class TagsMatcher {
   }
   
   checkModuleTags(testModule) {
-    let moduleTags = testModule['@tags'] || testModule.tags;
-    let match = true;
+    let moduleTags = TagsMatcher.convertTags(testModule['@tags'] || testModule.tags);
 
-    if (!Array.isArray(moduleTags)) {
+    if (moduleTags.length === 0) {
       return this.includeTags.length === 0;
     }
 
-    if (this.includeTags || this.excludeTags) {
-      moduleTags = this.convertTagsToString(moduleTags);
+    let match = true;
+    if (this.includeTags.length > 0) {
+      match = this.containsTag(moduleTags, this.includeTags);
+    }
 
-      if (this.includeTags.length > 0) {
-        match = this.containsTag(moduleTags, this.convertTagsToString(this.includeTags));
-      }
-
-      if (this.excludeTags.length > 0) {
-        match = this.excludesTag(moduleTags, this.convertTagsToString(this.excludeTags));
-      }
+    if (this.excludeTags.length > 0) {
+      match = this.excludesTag(moduleTags, this.excludeTags);
     }
 
     return match;
-  }
-
-  convertTagsToString(tags) {
-    return [].concat(tags).map(function(tag) {
-      return String(tag).toLowerCase();
-    });
   }
 
   containsTag(moduleTags, tags) {

--- a/lib/runner/matchers/tags.js
+++ b/lib/runner/matchers/tags.js
@@ -2,7 +2,10 @@ const Logger = require('../../util/logger.js');
 
 class TagsMatcher {
   constructor(settings) {
-    this.settings = settings;
+    this.settings = {
+      tag_filter: settings.tag_filter ? settings.tag_filter : [],
+      skiptags: settings.skiptags ? settings.skiptags : [],
+    };
   }
 
   checkModuleTags(testModule) {
@@ -10,17 +13,17 @@ class TagsMatcher {
     let match = true;
 
     if (!Array.isArray(moduleTags)) {
-      return this.settings.tag_filter === undefined && this.settings.skiptags !== undefined;
+      return !this.settings.tag_filter.length;
     }
 
     if (this.settings.tag_filter || this.settings.skiptags) {
       moduleTags = this.convertTagsToString(moduleTags);
 
-      if (this.settings.tag_filter) {
+      if (this.settings.tag_filter.length) {
         match = this.containsTag(moduleTags, this.convertTagsToString(this.settings.tag_filter));
       }
 
-      if (this.settings.skiptags) {
+      if (this.settings.skiptags.length) {
         match = this.excludesTag(moduleTags, this.convertTagsToString(this.settings.skiptags));
       }
     }

--- a/lib/runner/matchers/tags.js
+++ b/lib/runner/matchers/tags.js
@@ -1,59 +1,67 @@
 const Logger = require('../../util/logger.js');
+const Utils = require('../../util/utils.js');
 
 class TagsMatcher {
+  static get SEPARATOR() {
+    return ',';
+  }
   /**
-   * @param {string|number|Array} tagStringOrArray
+   * @param {string|number|Array} tags
    * @return {Array}
    */
-  static convertTags(tagStringOrArray) {
-    let tagsArray;
-    if (Array.isArray(tagStringOrArray)) {
-      tagsArray = tagStringOrArray;
-    } else if (typeof tagStringOrArray == 'string' && tagStringOrArray.length > 0) {
-      tagsArray = tagStringOrArray.split(',');
-    } else if (tagStringOrArray) {
-      tagsArray = [tagStringOrArray];
-    } else {
-      tagsArray = [];
+  static convertTags(tags) {
+    let tagsArray = Array.isArray(tags) ? tags : [];
+    
+    if (Utils.isString(tags)) {
+      tagsArray = tags.split(TagsMatcher.SEPARATOR);
+    } else if (Utils.isNumber(tags)) {
+      tagsArray.push(tags);
     }
 
-    return tagsArray.map((t)=>String(t).toLowerCase());
+    // convert individual tags to strings
+    return tagsArray.map(tag => String(tag).toLowerCase());
+  }
+  
+  containsTag(moduleTags) {
+    return moduleTags.some(testTag => {
+      return this.tagsToIncludeArray.includes(testTag);
+    });
   }
 
+  excludesTag(moduleTags) {
+    return moduleTags.every(testTag => {
+      return !this.tagsToSkipArray.includes(testTag);
+    });
+  }
+  
   constructor(settings) {
-    this.includeTags = TagsMatcher.convertTags(settings.tag_filter);
-    this.excludeTags = TagsMatcher.convertTags(settings.skiptags);
+    this.tagsToIncludeArray = TagsMatcher.convertTags(settings.tag_filter);
+    this.tagsToSkipArray = TagsMatcher.convertTags(settings.skiptags);
+  }
+  
+  hasIncludeTagFilter() {
+    return this.tagsToIncludeArray.length > 0;   
+  }
+  
+  hasSkipTagFilter() {
+    return this.tagsToSkipArray.length > 0;   
   }
   
   checkModuleTags(testModule) {
-    let moduleTags = TagsMatcher.convertTags(testModule['@tags'] || testModule.tags);
-
-    if (moduleTags.length === 0) {
-      return this.includeTags.length === 0;
-    }
+    const moduleTags = TagsMatcher.convertTags(testModule['@tags'] || testModule.tags);
 
     let match = true;
-    if (this.includeTags.length > 0) {
-      match = this.containsTag(moduleTags, this.includeTags);
+    if (this.hasIncludeTagFilter()) {
+      // if we passed the --tag argument, check if the module contains the tag (or tags)
+      match = this.containsTag(moduleTags);
     }
 
-    if (this.excludeTags.length > 0) {
-      match = this.excludesTag(moduleTags, this.excludeTags);
+    if (this.hasSkipTagFilter()) {
+      // if we passed the --skiptags argument, check if the module doesn't contain any of the tags in the skiptags array
+      match = this.excludesTag(moduleTags);
     }
 
     return match;
-  }
-
-  containsTag(moduleTags, tags) {
-    return moduleTags.some(function(testTag) {
-      return tags.indexOf(testTag) > -1;
-    });
-  }
-
-  excludesTag(moduleTags, tags) {
-    return moduleTags.every(function(testTag) {
-      return tags.indexOf(testTag) === -1;
-    });
   }
 
   /**
@@ -80,7 +88,7 @@ class TagsMatcher {
   }
 
   anyTagsDefined() {
-    return this.includeTags.length || this.excludeTags.length;
+    return this.hasIncludeTagFilter() || this.hasSkipTagFilter();
   }
 }
 

--- a/lib/runner/matchers/tags.js
+++ b/lib/runner/matchers/tags.js
@@ -2,12 +2,14 @@ const Logger = require('../../util/logger.js');
 
 class TagsMatcher {
   constructor(settings) {
-    this.settings = {
-      tag_filter: TagsMatcher.convertTags(settings.tag_filter),
-      skiptags: TagsMatcher.convertTags(settings.skiptags),
-    };
+    this.includeTags = TagsMatcher.convertTags(settings.tag_filter);
+    this.excludeTags = TagsMatcher.convertTags(settings.skiptags);
   }
 
+  /**
+   * @param {string|Array} tagStringOrArray
+   * @return {Array}
+   */
   static convertTags(tagStringOrArray) {
     if (Array.isArray(tagStringOrArray)) {
       return tagStringOrArray;
@@ -25,18 +27,18 @@ class TagsMatcher {
     let match = true;
 
     if (!Array.isArray(moduleTags)) {
-      return !this.settings.tag_filter.length;
+      return this.includeTags.length === 0;
     }
 
-    if (this.settings.tag_filter || this.settings.skiptags) {
+    if (this.includeTags || this.excludeTags) {
       moduleTags = this.convertTagsToString(moduleTags);
 
-      if (this.settings.tag_filter.length) {
-        match = this.containsTag(moduleTags, this.convertTagsToString(this.settings.tag_filter));
+      if (this.includeTags.length > 0) {
+        match = this.containsTag(moduleTags, this.convertTagsToString(this.includeTags));
       }
 
-      if (this.settings.skiptags.length) {
-        match = this.excludesTag(moduleTags, this.convertTagsToString(this.settings.skiptags));
+      if (this.excludeTags.length > 0) {
+        match = this.excludesTag(moduleTags, this.convertTagsToString(this.excludeTags));
       }
     }
 
@@ -85,7 +87,7 @@ class TagsMatcher {
   }
 
   anyTagsDefined() {
-    return this.settings.tag_filter.length || this.settings.skiptags.length;
+    return this.includeTags.length || this.excludeTags.length;
   }
 }
 

--- a/lib/runner/matchers/tags.js
+++ b/lib/runner/matchers/tags.js
@@ -3,9 +3,21 @@ const Logger = require('../../util/logger.js');
 class TagsMatcher {
   constructor(settings) {
     this.settings = {
-      tag_filter: settings.tag_filter ? settings.tag_filter : [],
-      skiptags: settings.skiptags ? settings.skiptags : [],
+      tag_filter: TagsMatcher.convertTags(settings.tag_filter),
+      skiptags: TagsMatcher.convertTags(settings.skiptags),
     };
+  }
+
+  static convertTags(tagStringOrArray) {
+    if (Array.isArray(tagStringOrArray)) {
+      return tagStringOrArray;
+    }
+
+    if (typeof tagStringOrArray == 'string' && tagStringOrArray.length > 0) {
+      return tagStringOrArray.split(',');
+    }
+
+    return [];
   }
 
   checkModuleTags(testModule) {
@@ -70,6 +82,10 @@ class TagsMatcher {
     }
 
     return this.checkModuleTags(testModule);
+  }
+
+  anyTagsDefined() {
+    return this.settings.tag_filter.length || this.settings.skiptags.length;
   }
 }
 

--- a/lib/runner/runner.js
+++ b/lib/runner/runner.js
@@ -32,12 +32,12 @@ class Runner {
       let err = new Error(errorMessage.join(' '));
       let detailed = [];
 
-      if (settings.tag_filter) {
+      if (settings.tag_filter && settings.tag_filter.length) {
         detailed.push(`- using tags filter: ${settings.tag_filter}`);
       }
 
-      if (settings.skiptags && Array.isArray(settings.skiptags)) {
-        detailed.push(`- using skiptags filter: ${settings.skiptags.join(',')}`);
+      if (settings.skiptags && settings.skiptags.length) {
+        detailed.push(`- using skiptags filter: ${settings.skiptags}`);
       }
 
       if (settings.filter) {

--- a/lib/settings/settings.js
+++ b/lib/settings/settings.js
@@ -64,6 +64,14 @@ class Settings {
 
     if (typeof this.settings.skiptags == 'string' && this.settings.skiptags.length > 0) {
       this.settings.skiptags = this.settings.skiptags.split(',');
+    } else if (!Array.isArray(this.settings.skiptags)) {
+      this.settings.skiptags = [];
+    }
+
+    if (typeof this.settings.tag_filter == 'string' && this.settings.tag_filter.length > 0) {
+      this.settings.tag_filter = this.settings.tag_filter.split(',');
+    } else if (!Array.isArray(this.settings.tag_filter)) {
+      this.settings.tag_filter = [];
     }
 
     if (typeof this.settings.skipgroup == 'string' && this.settings.skipgroup.length > 0) {

--- a/lib/settings/settings.js
+++ b/lib/settings/settings.js
@@ -62,18 +62,6 @@ class Settings {
       this.settings.src_folders = [this.settings.src_folders];
     }
 
-    if (typeof this.settings.skiptags == 'string' && this.settings.skiptags.length > 0) {
-      this.settings.skiptags = this.settings.skiptags.split(',');
-    } else if (!Array.isArray(this.settings.skiptags)) {
-      this.settings.skiptags = [];
-    }
-
-    if (typeof this.settings.tag_filter == 'string' && this.settings.tag_filter.length > 0) {
-      this.settings.tag_filter = this.settings.tag_filter.split(',');
-    } else if (!Array.isArray(this.settings.tag_filter)) {
-      this.settings.tag_filter = [];
-    }
-
     if (typeof this.settings.skipgroup == 'string' && this.settings.skipgroup.length > 0) {
       this.settings.skipgroup = this.settings.skipgroup.split(',');
     }

--- a/test/src/runner/cli/testCliRunner.js
+++ b/test/src/runner/cli/testCliRunner.js
@@ -258,7 +258,7 @@ describe('Test CLI Runner', function() {
     mockery.disable();
   });
 
-  it('testInitDefaults', function() {
+  function registerNoSettingsJsonMock(){
     mockery.registerMock('fs', {
       statSync: function(module) {
         if (module == './settings.json') {
@@ -271,14 +271,16 @@ describe('Test CLI Runner', function() {
         };
       }
     });
+  }
+
+  it('testInitDefaults', function() {
+    registerNoSettingsJsonMock();
 
     const CliRunner = common.require('runner/cli/cli.js');
     let runner = new CliRunner({
       config: './nightwatch.json',
       env: 'default',
       output: 'output',
-      skiptags: 'home,arctic',
-      tag: 'danger'
     }).setup();
 
     assert.deepEqual(runner.settings.src_folders, ['tests']);
@@ -286,12 +288,36 @@ describe('Test CLI Runner', function() {
     assert.strictEqual(runner.test_settings.custom_commands_path, null);
     assert.strictEqual(runner.test_settings.custom_assertions_path, null);
     assert.strictEqual(runner.test_settings.output, true);
-    assert.strictEqual(runner.test_settings.tag_filter, 'danger');
-    assert.deepEqual(runner.test_settings.skiptags, ['home', 'arctic']);
+    assert.deepEqual(runner.test_settings.tag_filter, []);
+    assert.deepEqual(runner.test_settings.skiptags, []);
     assert.equal(runner.globals.settings.output_folder, 'output');
     assert.equal(runner.globals.settings.parallel_mode, false);
     assert.equal(runner.isWebDriverManaged(), false);
     assert.equal(runner.globals.settings.start_session, true);
+  });
+
+  it('should configure empty tags as empty arrays', function() {
+    registerNoSettingsJsonMock();
+    const CliRunner = common.require('runner/cli/cli.js');
+    let runner = new CliRunner({
+      config: './nightwatch.json',
+    }).setup();
+
+    assert.deepEqual(runner.test_settings.tag_filter, []);
+    assert.deepEqual(runner.test_settings.skiptags, []);
+  });
+
+  it('should parse comma-separated tags to arrays', function() {
+    registerNoSettingsJsonMock();
+    const CliRunner = common.require('runner/cli/cli.js');
+    let runner = new CliRunner({
+      config: './nightwatch.json',
+      skiptags: 'home,arctic',
+      tag: 'danger'
+    }).setup();
+
+    assert.deepEqual(runner.test_settings.tag_filter, ['danger']);
+    assert.deepEqual(runner.test_settings.skiptags, ['home', 'arctic']);
   });
 
   it('testSetOutputFolder', function() {

--- a/test/src/runner/cli/testCliRunner.js
+++ b/test/src/runner/cli/testCliRunner.js
@@ -273,14 +273,12 @@ describe('Test CLI Runner', function() {
     });
   }
 
-  it('testInitDefaults', function() {
+  it('should have reasonable defaults for CLI arguments', function() {
     registerNoSettingsJsonMock();
 
     const CliRunner = common.require('runner/cli/cli.js');
     let runner = new CliRunner({
       config: './nightwatch.json',
-      env: 'default',
-      output: 'output',
     }).setup();
 
     assert.deepEqual(runner.settings.src_folders, ['tests']);
@@ -288,36 +286,35 @@ describe('Test CLI Runner', function() {
     assert.strictEqual(runner.test_settings.custom_commands_path, null);
     assert.strictEqual(runner.test_settings.custom_assertions_path, null);
     assert.strictEqual(runner.test_settings.output, true);
-    assert.deepEqual(runner.test_settings.tag_filter, []);
-    assert.deepEqual(runner.test_settings.skiptags, []);
-    assert.equal(runner.globals.settings.output_folder, 'output');
+    assert.equal(runner.test_settings.tag_filter, null);
+    assert.equal(runner.test_settings.skiptags, '');
+    assert.equal(runner.test_settings.filename_filter, undefined);
+    assert.equal(runner.test_settings.skipgroup, '');
+    assert.equal(runner.globals.settings.output_folder, 'tests_output');
     assert.equal(runner.globals.settings.parallel_mode, false);
     assert.equal(runner.isWebDriverManaged(), false);
     assert.equal(runner.globals.settings.start_session, true);
   });
 
-  it('should configure empty tags as empty arrays', function() {
+  it('should override settings with CLI arguments', function() {
     registerNoSettingsJsonMock();
     const CliRunner = common.require('runner/cli/cli.js');
     let runner = new CliRunner({
       config: './nightwatch.json',
-    }).setup();
-
-    assert.deepEqual(runner.test_settings.tag_filter, []);
-    assert.deepEqual(runner.test_settings.skiptags, []);
-  });
-
-  it('should parse comma-separated tags to arrays', function() {
-    registerNoSettingsJsonMock();
-    const CliRunner = common.require('runner/cli/cli.js');
-    let runner = new CliRunner({
-      config: './nightwatch.json',
+      verbose: 'yes',
+      output: 'test-output-folder',
       skiptags: 'home,arctic',
-      tag: 'danger'
+      tag: 'danger',
+      filter: 'test-filename-filter',
+      skipgroup: 'test-skip-group',
     }).setup();
 
-    assert.deepEqual(runner.test_settings.tag_filter, ['danger']);
-    assert.deepEqual(runner.test_settings.skiptags, ['home', 'arctic']);
+    assert.strictEqual(runner.test_settings.silent, false);
+    assert.equal(runner.test_settings.tag_filter, 'danger');
+    assert.equal(runner.test_settings.skiptags, 'home,arctic');
+    assert.equal(runner.test_settings.filename_filter, 'test-filename-filter');
+    assert.equal(runner.test_settings.skipgroup, 'test-skip-group');
+    assert.equal(runner.globals.settings.output_folder, 'test-output-folder');
   });
 
   it('testSetOutputFolder', function() {

--- a/test/src/runner/cli/testCliRunner.js
+++ b/test/src/runner/cli/testCliRunner.js
@@ -286,14 +286,14 @@ describe('Test CLI Runner', function() {
     assert.strictEqual(runner.test_settings.custom_commands_path, null);
     assert.strictEqual(runner.test_settings.custom_assertions_path, null);
     assert.strictEqual(runner.test_settings.output, true);
-    assert.equal(runner.test_settings.tag_filter, null);
-    assert.equal(runner.test_settings.skiptags, '');
-    assert.equal(runner.test_settings.filename_filter, undefined);
-    assert.equal(runner.test_settings.skipgroup, '');
-    assert.equal(runner.globals.settings.output_folder, 'tests_output');
-    assert.equal(runner.globals.settings.parallel_mode, false);
-    assert.equal(runner.isWebDriverManaged(), false);
-    assert.equal(runner.globals.settings.start_session, true);
+    assert.strictEqual(runner.test_settings.tag_filter, undefined);
+    assert.strictEqual(runner.test_settings.skiptags, '');
+    assert.strictEqual(runner.test_settings.filename_filter, undefined);
+    assert.strictEqual(runner.test_settings.skipgroup, '');
+    assert.strictEqual(runner.globals.settings.output_folder, 'tests_output');
+    assert.strictEqual(runner.globals.settings.parallel_mode, false);
+    assert.strictEqual(runner.isWebDriverManaged(), false);
+    assert.strictEqual(runner.globals.settings.start_session, true);
   });
 
   it('should override settings with CLI arguments', function() {
@@ -310,11 +310,11 @@ describe('Test CLI Runner', function() {
     }).setup();
 
     assert.strictEqual(runner.test_settings.silent, false);
-    assert.equal(runner.test_settings.tag_filter, 'danger');
-    assert.equal(runner.test_settings.skiptags, 'home,arctic');
-    assert.equal(runner.test_settings.filename_filter, 'test-filename-filter');
-    assert.equal(runner.test_settings.skipgroup, 'test-skip-group');
-    assert.equal(runner.globals.settings.output_folder, 'test-output-folder');
+    assert.strictEqual(runner.test_settings.tag_filter, 'danger');
+    assert.strictEqual(runner.test_settings.skiptags, 'home,arctic');
+    assert.strictEqual(runner.test_settings.filename_filter, 'test-filename-filter');
+    assert.deepEqual(runner.test_settings.skipgroup, ['test-skip-group']);
+    assert.strictEqual(runner.globals.settings.output_folder, 'test-output-folder');
   });
 
   it('testSetOutputFolder', function() {

--- a/test/src/runner/testTagsMatcher.js
+++ b/test/src/runner/testTagsMatcher.js
@@ -5,6 +5,26 @@ const TagsMatcher = common.require('runner/matchers/tags.js');
 
 describe('test TagsMatcher', function() {
 
+  describe('reading tag settings', function() {
+    const testCases = [
+      ['undefined', undefined, []],
+      ['null', null, []],
+      ['empty string', '', []],
+      ['string with one tag', 'a', ['a']],
+      ['string with multiple tags', 'a,b,c', ['a', 'b', 'c']],
+      ['empty array', [], []],
+      ['array with one tag', ['a'], ['a']],
+      ['array with multiple tags', ['a','b','c'], ['a', 'b', 'c']],
+    ];
+
+    testCases.forEach(([description, given, expected]) => {
+      it(`${description}`, function() {
+        const result = TagsMatcher.convertTags(given);
+        expect(result).to.deep.equal(expected);
+      });
+    });
+  });
+
   it('tag: test matching tags', function() {
     let tags = ['home', 'login', 'sign-up'];
     let testModule = {

--- a/test/src/runner/testTagsMatcher.js
+++ b/test/src/runner/testTagsMatcher.js
@@ -175,6 +175,18 @@ describe('test TagsMatcher', function() {
     expect(matched).to.equal(false);
   });
 
+  it('tag filter does not find module, and skiptag does not and excludes it', function() {
+    let matcher = new TagsMatcher({
+      tag_filter: ['other'],
+      skiptags: ['777']
+    });
+    let matched = matcher.checkModuleTags({
+      tags: ['room', 101]
+    });
+
+    expect(matched).to.equal(false);
+  });
+
   it('tag filter finds module, skiptag also does and excludes it', function() {
     let matcher = new TagsMatcher({
       tag_filter: ['room'],

--- a/test/src/runner/testTagsMatcher.js
+++ b/test/src/runner/testTagsMatcher.js
@@ -9,12 +9,14 @@ describe('test TagsMatcher', function() {
     const testCases = [
       ['undefined', undefined, []],
       ['null', null, []],
+      ['number', 777, ['777']],
+      ['number array', [777, 888], ['777', '888']],
       ['empty string', '', []],
       ['string with one tag', 'a', ['a']],
-      ['string with multiple tags', 'a,b,c', ['a', 'b', 'c']],
+      ['string with multiple tags', 'A,b,C,777', ['a', 'b', 'c', '777']],
       ['empty array', [], []],
       ['array with one tag', ['a'], ['a']],
-      ['array with multiple tags', ['a','b','c'], ['a', 'b', 'c']],
+      ['array with multiple tags', ['a','B','c', 777], ['a', 'b', 'c', '777']],
     ];
 
     testCases.forEach(([description, given, expected]) => {

--- a/test/src/runner/testTagsMatcher.js
+++ b/test/src/runner/testTagsMatcher.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const expect = require('chai').expect;
 const path = require('path');
 const common = require('../../common.js');
 const TagsMatcher = common.require('runner/matchers/tags.js');
@@ -16,7 +16,7 @@ describe('test TagsMatcher', function() {
     });
     let matched = matcher.checkModuleTags(testModule);
 
-    assert.ok(matched === true);
+    expect(matched).to.equal(true);
   });
 
   it('tag: test non-matching tags', function() {
@@ -30,7 +30,7 @@ describe('test TagsMatcher', function() {
     });
     let matched = matcher.checkModuleTags(testModule);
 
-    assert.ok(matched === false);
+    expect(matched).to.equal(false);
   });
 
   it('tag: test undefined tags', function() {
@@ -42,7 +42,7 @@ describe('test TagsMatcher', function() {
     });
     let matched = matcher.checkModuleTags(testModule);
 
-    assert.ok(matched === false);
+    expect(matched).to.equal(false);
   });
 
   it('tag: test loading module with tags', function() {
@@ -53,7 +53,7 @@ describe('test TagsMatcher', function() {
     });
     let matched = matcher.match(path.join(__dirname, '../../sampletests/tags/sample.js'));
 
-    assert.ok(matched === true);
+    expect(matched).to.equal(true);
   });
 
   it('tag: test loading modules containing an error should not be silent', function() {
@@ -63,7 +63,7 @@ describe('test TagsMatcher', function() {
     });
     let matched = matcher.match(path.join(__dirname, '../../extra/mock-errors/sample-error.js'));
 
-    assert.strictEqual(matched, false);
+    expect(matched).to.equal(false);
   });
 
   it('tag: test matching numeric tags', function() {
@@ -76,7 +76,7 @@ describe('test TagsMatcher', function() {
       tag_filter: tags
     });
     let matched = matcher.checkModuleTags(testModule);
-    assert.ok(matched === true);
+    expect(matched).to.equal(true);
   });
 
   it('tag: test matching numeric tags single', function() {
@@ -89,7 +89,7 @@ describe('test TagsMatcher', function() {
       tag_filter: tags
     });
     let matched = matcher.checkModuleTags(testModule);
-    assert.ok(matched === true);
+    expect(matched).to.equal(true);
   });
 
   it('skiptag test not matching', function() {
@@ -100,7 +100,7 @@ describe('test TagsMatcher', function() {
       tags: ['room', 101]
     });
 
-    assert.ok(matched === false);
+    expect(matched).to.equal(false);
   });
 
   it('skiptag test matching', function() {
@@ -111,7 +111,7 @@ describe('test TagsMatcher', function() {
       tags: ['room', 101]
     });
 
-    assert.ok(matched === true);
+    expect(matched).to.equal(true);
   });
 
   it('skiptag test matching - undefined local tags', function() {
@@ -120,7 +120,7 @@ describe('test TagsMatcher', function() {
     });
     let matched = matcher.checkModuleTags({});
 
-    assert.ok(matched === true);
+    expect(matched).to.equal(true)
   });
 
   it('skiptag test loading module with matching tags', function() {
@@ -129,7 +129,7 @@ describe('test TagsMatcher', function() {
     });
     let matched = matcher.match(path.join(__dirname, '../../sampletests/tags/sample.js'));
 
-    assert.ok(matched === false);
+    expect(matched).to.equal(false);
   });
 
   it('skiptag test loading module with no tags', function() {
@@ -138,7 +138,7 @@ describe('test TagsMatcher', function() {
     });
     let matched = matcher.match(path.join(__dirname, '../../sampletests/simple/test/sample.js'));
 
-    assert.ok(matched === true);
+    expect(matched).to.equal(true)
   });
 
   it('tag filter does not find module, but skiptag does and excludes it', function() {
@@ -150,7 +150,7 @@ describe('test TagsMatcher', function() {
       tags: ['room', 101]
     });
 
-    assert.ok(matched === false);
+    expect(matched).to.equal(false);
   });
 
   it('tag filter finds module, skiptag also does and excludes it', function() {
@@ -162,7 +162,7 @@ describe('test TagsMatcher', function() {
       tags: ['room', 101]
     });
 
-    assert.ok(matched === false);
+    expect(matched).to.equal(false);
   });
 
   it('tag filter finds module, and skiptag does not', function() {
@@ -174,6 +174,6 @@ describe('test TagsMatcher', function() {
       tags: ['room', 101]
     });
 
-    assert.ok(matched === true);
+    expect(matched).to.equal(true);
   });
 });


### PR DESCRIPTION
Hello, this pull request resolves the issue https://github.com/nightwatchjs/nightwatch/issues/1991

The problem was caused by the fact that settings.tag_filter and settings.skiptags were not used consistently. The values ranged from an empty string (default value when run from CLI) to undefined and empty array in unit tests. This caused skipping of tests without any tags when skiptags were defined.

I fixed the logic and refactored settings.tag_filter and settings.skiptags to always be arrays,
which makes the checks straightforward and less error-prone.