### PR TITLE
Issue 955 treat multiple filter tags as AND selection

### DIFF
--- a/lib/runner/matchers/tags.js
+++ b/lib/runner/matchers/tags.js
@@ -22,10 +22,25 @@ class TagsMatcher {
     return tagsArray.map(tag => String(tag).toLowerCase());
   }
   
-  containsTag(moduleTags) {
-    return moduleTags.some(testTag => {
-      return this.tagsToIncludeArray.includes(testTag);
-    });
+  static convertFilterTags(tags) {
+    if (!tags) {
+      return [];
+    }
+    let tagsArray
+    if (Array.isArray(tags)) {
+      // when multiple --tag arguments, e.g.: --tag a --tag b
+      tagsArray = tags;
+    } else {
+      // when single --tag argument, e.g.: --tag a
+      tagsArray = [tags]
+    }
+
+    // now parse each --tag argument
+    return tagsArray.map(t=>this.convertTags(t));
+  }
+
+  matchesFilterTags(moduleTags) {
+    return this.tagsToIncludeArrayOfArray.some(tagsAndArray => tagsAndArray.every(tagToInclude => moduleTags.includes(tagToInclude)));
   }
 
   excludesTag(moduleTags) {
@@ -35,12 +50,12 @@ class TagsMatcher {
   }
   
   constructor(settings) {
-    this.tagsToIncludeArray = TagsMatcher.convertTags(settings.tag_filter);
+    this.tagsToIncludeArrayOfArray = TagsMatcher.convertFilterTags(settings.tag_filter);
     this.tagsToSkipArray = TagsMatcher.convertTags(settings.skiptags);
   }
   
   hasIncludeTagFilter() {
-    return this.tagsToIncludeArray.length > 0;   
+    return this.tagsToIncludeArrayOfArray.length > 0;
   }
   
   hasSkipTagFilter() {
@@ -51,7 +66,7 @@ class TagsMatcher {
     const moduleTags = TagsMatcher.convertTags(testModule['@tags'] || testModule.tags);
     
     // if we passed the --tag argument, check if the module contains the tag (or tags)
-    if (this.hasIncludeTagFilter() && !this.containsTag(moduleTags)) {
+    if (this.hasIncludeTagFilter() && !this.matchesFilterTags(moduleTags)) {
       return false;
     }
 

--- a/lib/runner/matchers/tags.js
+++ b/lib/runner/matchers/tags.js
@@ -5,77 +5,10 @@ class TagsMatcher {
   static get SEPARATOR() {
     return ',';
   }
-  /**
-   * @param {string|number|Array} tags
-   * @return {Array}
-   */
-  static convertTags(tags) {
-    let tagsArray = Array.isArray(tags) ? tags : [];
-    
-    if (Utils.isString(tags) && tags.length > 0) {
-      tagsArray = tags.split(TagsMatcher.SEPARATOR);
-    } else if (Utils.isNumber(tags)) {
-      tagsArray.push(tags);
-    }
 
-    // convert individual tags to strings
-    return tagsArray.map(tag => String(tag).toLowerCase());
-  }
-  
-  static convertFilterTags(tags) {
-    if (!tags) {
-      return [];
-    }
-    let tagsArray
-    if (Array.isArray(tags)) {
-      // when multiple --tag arguments, e.g.: --tag a --tag b
-      tagsArray = tags;
-    } else {
-      // when single --tag argument, e.g.: --tag a
-      tagsArray = [tags]
-    }
-
-    // now parse each --tag argument
-    return tagsArray.map(t=>this.convertTags(t));
-  }
-
-  matchesFilterTags(moduleTags) {
-    return this.tagsToIncludeArrayOfArray.some(tagsAndArray => tagsAndArray.every(tagToInclude => moduleTags.includes(tagToInclude)));
-  }
-
-  excludesTag(moduleTags) {
-    return moduleTags.every(testTag => {
-      return !this.tagsToSkipArray.includes(testTag);
-    });
-  }
-  
   constructor(settings) {
-    this.tagsToIncludeArrayOfArray = TagsMatcher.convertFilterTags(settings.tag_filter);
+    this.tagsToIncludeArrays = TagsMatcher.convertFilterTags(settings.tag_filter);
     this.tagsToSkipArray = TagsMatcher.convertTags(settings.skiptags);
-  }
-  
-  hasIncludeTagFilter() {
-    return this.tagsToIncludeArrayOfArray.length > 0;
-  }
-  
-  hasSkipTagFilter() {
-    return this.tagsToSkipArray.length > 0;   
-  }
-  
-  checkModuleTags(testModule) {
-    const moduleTags = TagsMatcher.convertTags(testModule['@tags'] || testModule.tags);
-    
-    // if we passed the --tag argument, check if the module contains the tag (or tags)
-    if (this.hasIncludeTagFilter() && !this.matchesFilterTags(moduleTags)) {
-      return false;
-    }
-
-    // if we passed the --skiptags argument, check if the module doesn't contain any of the tags in the skiptags array
-    if (this.hasSkipTagFilter() && !this.excludesTag(moduleTags)) {
-      return false;
-    }
-
-    return true;
   }
 
   /**
@@ -101,9 +34,129 @@ class TagsMatcher {
     return this.checkModuleTags(testModule);
   }
 
+  /**
+   * Verify if a given module contains or does not contain specific tags
+   * @param testModule
+   * @returns {boolean}
+   */
+  checkModuleTags(testModule) {
+    const moduleTags = TagsMatcher.convertTags(testModule['@tags'] || testModule.tags);
+
+    // if we passed the --tag argument, check if the module contains the tag (or tags)
+    if (this.hasIncludeTagFilter() && !this.matchesIncludeTagFilter(moduleTags)) {
+      return false;
+    }
+
+    // if we passed the --skiptags argument, check if the module doesn't contain any of the tags in the skiptags array
+    if (this.hasSkipTagFilter() && !excludesAllTags(moduleTags, this.tagsToSkipArray)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  matchesIncludeTagFilter(moduleTags) {
+    return this.tagsToIncludeArrays.some(tagsArray => containsAllTags(moduleTags, tagsArray));
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  hasIncludeTagFilter() {
+    return this.tagsToIncludeArrays.length > 0;
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  hasSkipTagFilter() {
+    return this.tagsToSkipArray.length > 0;
+  }
+
+  /**
+   * @returns {boolean}
+   */
   anyTagsDefined() {
     return this.hasIncludeTagFilter() || this.hasSkipTagFilter();
   }
+
+  /**
+   * @param {String|Number|Array} tags
+   * @return {Array}
+   */
+  static convertTags(tags) {
+    let tagsArray = Array.isArray(tags) ? tags : [];
+
+    if (Utils.isString(tags) && tags.length > 0) {
+      tagsArray = tags.split(TagsMatcher.SEPARATOR);
+    } else if (Utils.isNumber(tags)) {
+      tagsArray.push(tags);
+    }
+
+    // convert individual tags to strings
+    return tagsArray.map(tag => String(tag).toLowerCase());
+  }
+
+  /**
+   * @param {Array|String} tags
+   * @returns {*}
+   */
+  static convertFilterTags(tags) {
+    if (!tags) {
+      return [];
+    }
+
+    // when multiple --tag arguments are passed (e.g.: --tag a --tag b)
+    //  the resulting array is [a, b], otherwise it is [a]
+    let tagsArray = Array.isArray(tags) ? tags : [tags];
+
+    // now parse each --tag argument
+    return tagsArray.map(t => TagsMatcher.convertTags(t));
+  }
 }
+
+/**
+ * Whether a given list of tags contains one particular tag
+ *
+ * @param {Array} moduleTags
+ * @param {String} testTag
+ * @returns {boolean}
+ */
+const containsTag = function(moduleTags, testTag) {
+  return moduleTags.includes(testTag);
+};
+
+/**
+ * Whether a given list of tags does not contain one particular tag
+ *
+ * @param {Array} moduleTags
+ * @param {String} testTag
+ * @returns {boolean}
+ */
+const excludesSingleTag = function(moduleTags, testTag) {
+  return !containsTag(moduleTags, testTag);
+};
+
+/**
+ * Whether a given list of tags does not contain any tags in another list
+ *
+ * @param {Array} moduleTags
+ * @param {Array} tagsArray
+ * @returns {boolean}
+ */
+const excludesAllTags = function(moduleTags, tagsArray) {
+  return moduleTags.every(testTag => excludesSingleTag(tagsArray, testTag));
+};
+
+/**
+ * Whether a given list of tags contains aall tags in another list
+ *
+ * @param {Array} moduleTags
+ * @param {Array} tagsArray
+ * @returns {boolean}
+ */
+const containsAllTags = function(moduleTags, tagsArray) {
+  return tagsArray.every(testTag => containsTag(moduleTags, testTag));
+};
 
 module.exports = TagsMatcher;

--- a/test/src/runner/testTagsMatcher.js
+++ b/test/src/runner/testTagsMatcher.js
@@ -5,7 +5,7 @@ const TagsMatcher = common.require('runner/matchers/tags.js');
 
 describe('test TagsMatcher', function() {
 
-  describe('reading tag settings', function() {
+  describe('reading module tags and skiptags from settings', function() {
     const testCases = [
       ['undefined', undefined, []],
       ['null', null, []],
@@ -27,6 +27,28 @@ describe('test TagsMatcher', function() {
     });
   });
 
+  describe('reading filter tags from settings', function () {
+    const testCases = [
+      ['undefined', undefined, []],
+      ['null', null, []],
+      ['empty string', '', []],
+      ['empty array', [], []],
+      ['number', 777, [['777']]],
+      ['number array: --tag 777 --tag 888', [777, 888], [['777'], ['888']]],
+      ['string with one tag: --tag a', 'a', [['a']]],
+      ['AND tags: --tag A,b,C,777', 'A,b,C,777', [['a', 'b', 'c', '777']]],
+      ['OR tags: --tag A --tag b --tag C --tag 777', ['A', 'b', 'C', '777'], [['a'], ['b'], ['c'], ['777']]],
+      ['AND and OR tags: --tag A,b --tag c,D --tag e,777', ['A,b', 'c,D', 'e,777'], [['a', 'b'], ['c', 'd'], ['e', '777']]],
+    ];
+
+    testCases.forEach(([description, given, expected]) => {
+      it(`${description}`, function () {
+        const result = TagsMatcher.convertFilterTags(given);
+        expect(result).to.deep.equal(expected);
+      });
+    });
+  });
+
   describe('matching', function () {
     const testCases = [
       [
@@ -35,6 +57,27 @@ describe('test TagsMatcher', function() {
         ['home', 'siberia'],
         undefined,
         true,
+      ],
+      [
+        'matching single filter tag',
+        ['home', 'login', 'sign-up'],
+        ['home'],
+        undefined,
+        true,
+      ],
+      [
+        'multiple filter tags as AND match',
+        ['home', 'login', 'siberia', 'sign-up'],
+        ['home,siberia'],
+        undefined,
+        true,
+      ],
+      [
+        'multiple filter tags as AND do not match',
+        ['home', 'login', 'sign-up'],
+        ['home,siberia'],
+        undefined,
+        false,
       ],
       [
         'non-matching tags',
@@ -138,6 +181,20 @@ describe('test TagsMatcher', function() {
         'module with tags',
         'sampletests/tags/sample.js',
         ['home', 'login', 'sign-up'],
+        undefined,
+        true,
+      ],
+      [
+        'module with tags single filter tag',
+        'sampletests/tags/sample.js',
+        ['login'],
+        undefined,
+        true,
+      ],
+      [
+        'module with tags multiple AND filter tags',
+        'sampletests/tags/sample.js',
+        ['login,other'],
         undefined,
         true,
       ],

--- a/test/src/runner/testTagsMatcher.js
+++ b/test/src/runner/testTagsMatcher.js
@@ -27,187 +27,156 @@ describe('test TagsMatcher', function() {
     });
   });
 
-  it('tag: test matching tags', function() {
-    let tags = ['home', 'login', 'sign-up'];
-    let testModule = {
-      tags: ['home', 'siberia']
-    };
+  describe('matching', function () {
+    const testCases = [
+      [
+        'matching tags',
+        ['home', 'login', 'sign-up'],
+        ['home', 'siberia'],
+        undefined,
+        true,
+      ],
+      [
+        'non-matching tags',
+        ['boroboro', 'siberia'],
+        ['home', 'login', 'sign-up'],
+        undefined,
+        false,
+      ],
+      [
+        'undefined module tags',
+        undefined,
+        ['home', 'login', 'sign-up'],
+        undefined,
+        false,
+      ],
+      [
+        'numeric tags',
+        ['101'],
+        ['room', 101],
+        undefined,
+        true,
+      ],
+      [
+        'numeric tags single',
+        ['101'],
+        101,
+        undefined,
+        true,
+      ],
+      [
+        'skiptag not matching',
+        ['room', 101],
+        undefined,
+        ['101'],
+        false,
+      ],
+      [
+        'skiptag matching',
+        ['room', 101],
+        undefined,
+        ['other'],
+        true,
+      ],
+      [
+        'skiptag matching - undefined local tags',
+        undefined,
+        undefined,
+        ['other'],
+        true,
+      ],
+      [
+        'tag filter does not find module, but skiptag does and excludes it',
+        ['room', 101],
+        ['other'],
+        ['101'],
+        false,
+      ],
+      [
+        'tag filter does not find module, and skiptag does not and excludes it',
+        ['room', 101],
+        ['other'],
+        ['777'],
+        false,
+      ],
+      [
+        'tag filter finds module, skiptag also does and excludes it',
+        ['room', 101],
+        ['room'],
+        ['101'],
+        false,
+      ],
+      [
+        'tag filter finds module, and skiptag does not',
+        ['room', 101],
+        ['room'],
+        ['other'],
+        true,
+      ],
+    ];
+    testCases.forEach(([description, moduleTags, tag_filter, skiptags, expected]) => {
+      it(`${description}`, function () {
+        const testModule = {
+          tags: moduleTags
+        };
 
-    let matcher = new TagsMatcher({
-      tag_filter: tags
+        const matcher = new TagsMatcher({
+          tag_filter: tag_filter,
+          skiptags: skiptags,
+        });
+
+        const matched = matcher.checkModuleTags(testModule);
+
+        expect(matched).to.equal(expected);
+      });
     });
-    let matched = matcher.checkModuleTags(testModule);
-
-    expect(matched).to.equal(true);
   });
 
-  it('tag: test non-matching tags', function() {
-    let tags = ['home', 'login', 'sign-up'];
-    let testModule = {
-      tags: ['boroboro', 'siberia']
-    };
+  describe('loading and matching', function(){
+    const testCases = [
+      [
+        'module with tags',
+        'sampletests/tags/sample.js',
+        ['home', 'login', 'sign-up'],
+        undefined,
+        true,
+      ],
+      [
+        'loading modules containing an error should not be silent',
+        'extra/mock-errors/sample-error.js',
+        ['home', 'login', 'sign-up'],
+        undefined,
+        false,
+      ],
+      [
+        'skiptag test loading module with matching tags',
+        'sampletests/tags/sample.js',
+        undefined,
+        ['login'],
+        false,
+      ],
+      [
+        'skiptag test loading module with no tags',
+        'sampletests/simple/test/sample.js',
+        undefined,
+        ['login'],
+        true,
+      ],
+    ];
 
-    let matcher = new TagsMatcher({
-      tag_filter: tags
+    testCases.forEach(([description, modulePath, tag_filter, skiptags, expected]) => {
+      it(`${description}`, function () {
+        const fullModulePath = path.join(__dirname, '../../' + modulePath);
+
+        const matcher = new TagsMatcher({
+          tag_filter: tag_filter,
+          skiptags: skiptags,
+        });
+
+        const matched = matcher.match(fullModulePath);
+
+        expect(matched).to.equal(expected);
+      });
     });
-    let matched = matcher.checkModuleTags(testModule);
-
-    expect(matched).to.equal(false);
-  });
-
-  it('tag: test undefined tags', function() {
-    let tags = ['home', 'login', 'sign-up'];
-    let testModule = {};
-
-    let matcher = new TagsMatcher({
-      tag_filter: tags
-    });
-    let matched = matcher.checkModuleTags(testModule);
-
-    expect(matched).to.equal(false);
-  });
-
-  it('tag: test loading module with tags', function() {
-    let tags = ['home', 'login', 'sign-up'];
-
-    let matcher = new TagsMatcher({
-      tag_filter: tags
-    });
-    let matched = matcher.match(path.join(__dirname, '../../sampletests/tags/sample.js'));
-
-    expect(matched).to.equal(true);
-  });
-
-  it('tag: test loading modules containing an error should not be silent', function() {
-    let tags = ['home', 'login', 'sign-up'];
-    let matcher = new TagsMatcher({
-      tag_filter: tags
-    });
-    let matched = matcher.match(path.join(__dirname, '../../extra/mock-errors/sample-error.js'));
-
-    expect(matched).to.equal(false);
-  });
-
-  it('tag: test matching numeric tags', function() {
-    let tags = ['room', 101];
-    let testModule = {
-      tags: ['101']
-    };
-
-    let matcher = new TagsMatcher({
-      tag_filter: tags
-    });
-    let matched = matcher.checkModuleTags(testModule);
-    expect(matched).to.equal(true);
-  });
-
-  it('tag: test matching numeric tags single', function() {
-    let tags = 101;
-    let testModule = {
-      tags: ['101']
-    };
-
-    let matcher = new TagsMatcher({
-      tag_filter: tags
-    });
-    let matched = matcher.checkModuleTags(testModule);
-    expect(matched).to.equal(true);
-  });
-
-  it('skiptag test not matching', function() {
-    let matcher = new TagsMatcher({
-      skiptags: ['101']
-    });
-    let matched = matcher.checkModuleTags({
-      tags: ['room', 101]
-    });
-
-    expect(matched).to.equal(false);
-  });
-
-  it('skiptag test matching', function() {
-    let matcher = new TagsMatcher({
-      skiptags: ['other']
-    });
-    let matched = matcher.checkModuleTags({
-      tags: ['room', 101]
-    });
-
-    expect(matched).to.equal(true);
-  });
-
-  it('skiptag test matching - undefined local tags', function() {
-    let matcher = new TagsMatcher({
-      skiptags: ['other']
-    });
-    let matched = matcher.checkModuleTags({});
-
-    expect(matched).to.equal(true)
-  });
-
-  it('skiptag test loading module with matching tags', function() {
-    let matcher = new TagsMatcher({
-      skiptags: ['login']
-    });
-    let matched = matcher.match(path.join(__dirname, '../../sampletests/tags/sample.js'));
-
-    expect(matched).to.equal(false);
-  });
-
-  it('skiptag test loading module with no tags', function() {
-    let matcher = new TagsMatcher({
-      skiptags: ['login']
-    });
-    let matched = matcher.match(path.join(__dirname, '../../sampletests/simple/test/sample.js'));
-
-    expect(matched).to.equal(true)
-  });
-
-  it('tag filter does not find module, but skiptag does and excludes it', function() {
-    let matcher = new TagsMatcher({
-      tag_filter: ['other'],
-      skiptags: ['101']
-    });
-    let matched = matcher.checkModuleTags({
-      tags: ['room', 101]
-    });
-
-    expect(matched).to.equal(false);
-  });
-
-  it('tag filter does not find module, and skiptag does not and excludes it', function() {
-    let matcher = new TagsMatcher({
-      tag_filter: ['other'],
-      skiptags: ['777']
-    });
-    let matched = matcher.checkModuleTags({
-      tags: ['room', 101]
-    });
-
-    expect(matched).to.equal(false);
-  });
-
-  it('tag filter finds module, skiptag also does and excludes it', function() {
-    let matcher = new TagsMatcher({
-      tag_filter: ['room'],
-      skiptags: ['101']
-    });
-    let matched = matcher.checkModuleTags({
-      tags: ['room', 101]
-    });
-
-    expect(matched).to.equal(false);
-  });
-
-  it('tag filter finds module, and skiptag does not', function() {
-    let matcher = new TagsMatcher({
-      tag_filter: ['room'],
-      skiptags: ['other']
-    });
-    let matched = matcher.checkModuleTags({
-      tags: ['room', 101]
-    });
-
-    expect(matched).to.equal(true);
   });
 });


### PR DESCRIPTION
This pull request resolves this issue: https://github.com/nightwatchjs/nightwatch/issues/955

Old behavior (in 1.0.18): only one filter tag can be specified with `--tag`, e.g. `--tag example`.
New behavior: `--tag` accepts a comma-separated list of tags. Only tests having all of the filter tags will be run.

The pull request has two commits, I recommend to review them separately:
* the first commit is only a refactoring of testTagsMatcher.js with zero changes.
* the second commit implements the feature request from the referenced issue.

If you find the refactoring of testTagsMatcher.js unnecessary, please let me know, I will revert it and clean up.