### PR TITLE
Issue 2010 Fixes a typo (getOriginalStrackTrace -> getOriginalStackTrace)

### DIFF
--- a/lib/api-loader/_base-loader.js
+++ b/lib/api-loader/_base-loader.js
@@ -29,7 +29,7 @@ class BaseLoader extends EventEmitter {
     return typeof instance[method] == type;
   }
 
-  static getOriginalStrackTrace(commandFn) {
+  static getOriginalStackTrace(commandFn) {
     let originalStackTrace;
 
     if (commandFn.stackTrace) {
@@ -220,7 +220,7 @@ class BaseLoader extends EventEmitter {
 
     const commandName = this.commandName;
     const args = [function commandFn(...args) {
-      let originalStackTrace = BaseLoader.getOriginalStrackTrace(commandFn);
+      let originalStackTrace = BaseLoader.getOriginalStackTrace(commandFn);
 
       this.commandQueue.add(commandName, this.commandFn, this, args, originalStackTrace, namespace);
 

--- a/lib/api-loader/expect-element.js
+++ b/lib/api-loader/expect-element.js
@@ -108,7 +108,7 @@ class ExpectElementLoader extends BaseCommandLoader {
 
     nightwatchInstance.setApiMethod(commandName, namespace, function commandFn(...args) {
       let expectInstance = new ExpectElementLoader(nightwatchInstance);
-      let originalStackTrace = ExpectElementLoader.getOriginalStrackTrace(commandFn);
+      let originalStackTrace = ExpectElementLoader.getOriginalStackTrace(commandFn);
 
       nightwatchInstance.session.commandQueue.add(commandName, expectInstance.commandFn, expectInstance, args, originalStackTrace);
 


### PR DESCRIPTION
[Issue 2010](https://github.com/nightwatchjs/nightwatch/issues/2010)
Fixes a typo (getOriginalStrackTrace -> getOriginalStackTrace)
