### PR TITLE
Issue 2004: Strip out control characters from Junit XML report prior to writing file

### DIFF
--- a/lib/runner/reporters/junit.js
+++ b/lib/runner/reporters/junit.js
@@ -119,6 +119,8 @@ class JUnitReporter {
       systemerr: this.results.errmessages.join('\n')
     });
 
+    rendered = Utils.stripControlChars(rendered);
+
     return this.writeReportFile(filename, rendered, shouldCreateFolder, output_folder)
       .then(_ => {
         Logger.info(`Wrote report file to: ${filename}.`);

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -402,13 +402,16 @@ class Utils {
   }
 
   /**
+   * Strips out all control characters from a string
+   * However, excludes newline and carriage return
+   * 
    * @param {string} input String to remove invisible chars from
    * @returns {string} Initial input string but without invisible chars
    */
   static stripControlChars(input) {
     return input && input.replace(
       // eslint-disable-next-line no-control-regex
-      /[\x00-\x1F\x7F-\x9F]/g,
+      /[\x00-\x09\x0B-\x0C\x0E-\x1F\x7F-\x9F]/g,
       ''
     );
   }

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -400,6 +400,18 @@ class Utils {
 
     return deferred;
   }
+
+  /**
+   * @param {string} input String to remove invisible chars from
+   * @returns {string} Initial input string but without invisible chars
+   */
+  static stripControlChars(input) {
+    return input && input.replace(
+      // eslint-disable-next-line no-control-regex
+      /[\x00-\x1F\x7F-\x9F]/g,
+      ''
+    );
+  }
 }
 
 function contains(str, text) {

--- a/test/src/util/testUtils.js
+++ b/test/src/util/testUtils.js
@@ -76,4 +76,13 @@ describe('test Utils', function() {
       Utils.flattenArrayDeep('test');
     }, Error);
   });
+
+  it('testStripControlChars', function() {
+
+    assert.doesNotThrow(() => Utils.stripControlChars(null));
+    assert.equal(Utils.stripControlChars('\x00rendered output'), 'rendered output');
+    assert.equal(Utils.stripControlChars('rendered \x1Foutput'), 'rendered output');
+    assert.equal(Utils.stripControlChars('rendered output\x7F'), 'rendered output');
+    assert.equal(Utils.stripControlChars('\x00rendered\x1F \x1Boutput\x9F\x00'), 'rendered output');
+  });
 });

--- a/test/src/util/testUtils.js
+++ b/test/src/util/testUtils.js
@@ -80,9 +80,33 @@ describe('test Utils', function() {
   it('testStripControlChars', function() {
 
     assert.doesNotThrow(() => Utils.stripControlChars(null));
-    assert.equal(Utils.stripControlChars('\x00rendered output'), 'rendered output');
-    assert.equal(Utils.stripControlChars('rendered \x1Foutput'), 'rendered output');
-    assert.equal(Utils.stripControlChars('rendered output\x7F'), 'rendered output');
-    assert.equal(Utils.stripControlChars('\x00rendered\x1F \x1Boutput\x9F\x00'), 'rendered output');
+    assert.equal(
+      Utils.stripControlChars('\x00rendered output'),
+      'rendered output'
+    );
+    assert.equal(
+      Utils.stripControlChars('rendered \x1Foutput'),
+      'rendered output'
+    );
+    assert.equal(
+      Utils.stripControlChars('rendered output\x7F'),
+      'rendered output'
+    );
+    assert.equal(
+      Utils.stripControlChars('\x00rendered\x1F \x1Boutput\x9F\x00'),
+      'rendered output'
+    );
+    assert.equal(
+      Utils.stripControlChars(
+        '\x00rendered output\nrendered \x1Foutput\nrendered output\x7F'
+      ),
+      'rendered output\nrendered output\nrendered output'
+    );
+    assert.equal(
+      Utils.stripControlChars(
+        '\x00rendered output\rrendered \x1Foutput\rrendered output\x7F'
+      ),
+      'rendered output\rrendered output\rrendered output'
+    );
   });
 });


### PR DESCRIPTION
This is a proposed fix for https://github.com/nightwatchjs/nightwatch/issues/2004.

Currently, there are rogue control characters being included in the JUnit XML report. I felt that it would be safer to target the entire XML report at point of writing, as this is the last possible place for ensuring it's safe to write.

I have added a test for the stripping out of control characters, but felt it was unnecessary to do a duplicated full end-to-end test case with an included control character.