### PR TITLE
fixed #2047 - .frame() or .frame(null) does not switch to top-level d…

### DIFF
--- a/lib/transport/jsonwire/actions.js
+++ b/lib/transport/jsonwire/actions.js
@@ -160,7 +160,7 @@ module.exports = {
         path: '/frame',
         data: {
           id: frameId
-        },
+        }
       });
     },
 

--- a/lib/transport/jsonwire/actions.js
+++ b/lib/transport/jsonwire/actions.js
@@ -153,14 +153,14 @@ module.exports = {
     ///////////////////////////////////////////////////////////
     switchToFrame(frameId) {
       if (frameId === undefined) {
-        return TransportActions.post('/frame');
+        frameId = null;
       }
 
       return TransportActions.post({
         path: '/frame',
         data: {
-          id: String(frameId)
-        }
+          id: frameId
+        },
       });
     },
 

--- a/test/src/api/protocol/testFrame.js
+++ b/test/src/api/protocol/testFrame.js
@@ -40,6 +40,30 @@ describe('client.frame', function() {
       args: [0]
     });
   });
+  
+  it('testFramePostWithNull', function () {
+    return Globals.protocolTest.call(this, {
+      assertion: function(opts) {
+        assert.equal(opts.method, 'POST');
+        assert.equal(opts.path, '/session/1352110219202/frame');
+        assert.deepEqual(opts.data, { id: null });
+      },
+      commandName: 'frame',
+      args: [null]
+    });
+  });
+
+  it('testFramePostWithUndefined', function () {
+    return Globals.protocolTest.call(this, {
+      assertion: function(opts) {
+        assert.equal(opts.method, 'POST');
+        assert.equal(opts.path, '/session/1352110219202/frame');
+        assert.deepEqual(opts.data, { id: null });
+      },
+      commandName: 'frame',
+      args: []
+    });
+  });
 
   it('testFrameParent', function () {
     return Globals.protocolTest.call(this, {


### PR DESCRIPTION
argument supplies to `.frame()` should allow either `null`, `undefined` as it's W3C spec https://www.w3.org/TR/webdriver/#switch-to-frame