### PR TITLE
feature:  Hide "waitForElement" warnings when "detailed_output:" is set to "false"

### DIFF
--- a/lib/transport/transport.js
+++ b/lib/transport/transport.js
@@ -243,7 +243,7 @@ class Transport extends EventEmitter {
           throw new Error(message);
         }
 
-        if (this.settings.output) {
+        if (this.settings.output  && this.settings.detailed_output) {
           console.warn(Logger.colors.green(`  Warning: ${message} Only the first one will be used.`));
         }
       }

--- a/lib/transport/transport.js
+++ b/lib/transport/transport.js
@@ -243,7 +243,7 @@ class Transport extends EventEmitter {
           throw new Error(message);
         }
 
-        if (this.settings.output  && this.settings.detailed_output) {
+        if (this.settings.output && this.settings.detailed_output) {
           console.warn(Logger.colors.green(`  Warning: ${message} Only the first one will be used.`));
         }
       }


### PR DESCRIPTION
I noticed this feature request #2060 so I decided to create pull request.

I added an additional condition to check **detailed_output** before print warning for waitForElements