### PR TITLE
Fix route to respect W3C Recommandations

### DIFF
--- a/lib/transport/jsonwire/actions.js
+++ b/lib/transport/jsonwire/actions.js
@@ -112,9 +112,9 @@ module.exports = {
       return TransportActions.delete('/window');
     },
 
-    getWindowHandle: '/window_handle',
+    getWindowHandle: '/window/handle',
 
-    getAllWindowHandles: '/window_handles',
+    getAllWindowHandles: '/window/handles',
 
     getWindowPosition(windowHandle) {
       return `/window/${windowHandle}/position`;
@@ -316,7 +316,7 @@ module.exports = {
 
     executeScriptAsync(fn, args) {
       return TransportActions.post({
-        path: '/execute_async',
+        path: '/execute/async',
         data: {
           script: fn,
           args: args


### PR DESCRIPTION
Hello,

I noted theses routes does not work with Firefox as expected. However, according to the W3C recommandation linked on your documentation (https://www.w3.org/TR/webdriver/#get-window-handles), route should have a slash instead of an underscore.
I made two changes and *I'm sure* the fix for executeAsync method works with a slash.

This PR is a fix but also a question, do you know why there are theses "mistakes" ?
I specify that Chrome works well without any change and works the same with theses modifications. Theses changes repair errors with Firefox.

I would like to understand.
Thank you for your work. :)

Regards,
