### PR TITLE
Correctly wait in waitForElementNotPresent for element not present

### DIFF
--- a/lib/api/element-commands/_waitFor.js
+++ b/lib/api/element-commands/_waitFor.js
@@ -39,11 +39,16 @@ class WaitForElement extends ElementCommand {
       .queueAction({
         action: () => this.findElement(),
         retryOnSuccess: this.retryOnSuccess,
+        retryOnFailure: !this.retryOnSuccess,
         validate,
         successHandler,
         errorHandler: (err) => {
           if (err.name !== 'TimeoutError') {
-            return err;
+            throw err;
+          }
+
+          if (err.response && err.response.value) {
+            return this.elementFound(err.response);
           }
 
           return this.elementNotFound(err.response);

--- a/lib/api/element-commands/waitForElementNotPresent.js
+++ b/lib/api/element-commands/waitForElementNotPresent.js
@@ -36,29 +36,6 @@ class WaitForElementNotPresent extends WaitForElement {
     this.expectedValue = 'not found';
   }
 
-  setupActions() {
-    const validate = (result) => this.isResultSuccess(result) && result.value === null;
-
-    this.executor
-      .queueAction({
-        action: () => this.findElement(),
-        retryOnSuccess: true,
-        retryOnFailure: false,
-        validate,
-        errorHandler: (err) => {
-          if (err.name !== 'TimeoutError') {
-            throw err;
-          }
-
-          if (err.response && err.response.value) {
-            return this.elementFound(err.response);
-          }
-
-          return this.elementNotFound(err.response);
-        }
-      });
-  }
-
   /**
    * Overriding elementFound to fail the test
    *

--- a/lib/api/element-commands/waitForElementPresent.js
+++ b/lib/api/element-commands/waitForElementPresent.js
@@ -34,6 +34,10 @@ const WaitForElement = require('./_waitFor.js');
  * @api protocol.elements
  */
 class WaitForElementPresent extends WaitForElement {
+  get retryOnSuccess() {
+    return false;
+  }
+
   constructor(opts) {
     super(opts);
 

--- a/test/src/element/testCommandsElementSelectors.js
+++ b/test/src/element/testCommandsElementSelectors.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const assert = require('assert');
 const nocks = require('../../lib/nockselements.js');
+const Nocks = require('../../lib/nocks.js');
 const Nightwatch = require('../../lib/nightwatch.js');
 
 describe('test commands element selectors', function() {
@@ -151,6 +152,44 @@ describe('test commands element selectors', function() {
       .useCss()
       .waitForElementPresent({selector: '//[@class="nock"]', locateStrategy: 'xpath'}, 1, false, function callback(result) {
         assert.strictEqual(result.value.length, 3, 'waitforPresent locateStrategy override to xpath found');
+      });
+
+    Nightwatch.start(done);
+  });
+
+  it('waitForElementNotPresent(<{selector}>) success', function(done) {
+    Nocks
+      .elementsFound('.nock-string')
+      .elementsNotFound('.nock-string')
+      .elementsFound('.nock-object')
+      .elementsNotFound('.nock-object');
+
+    Nightwatch.api()
+      .waitForElementNotPresent('.nock-string', 50, false, function callback(result) {
+        assert.equal(result.status, 0, 'waitForElementNotPresent succeeds');
+        assert.equal(result.value.length, 0, 'waitForElementNotPresent returns no elements');
+      })
+      .waitForElementNotPresent({ selector: '.nock-object', timeout: 50, retryInterval: 20, abortOnFailure: false }, function callback(result) {
+        assert.equal(result.status, 0, 'waitForElementNotPresent succeeds');
+        assert.equal(result.value.length, 0, 'waitForElementNotPresent returns no elements');
+      });
+
+    Nightwatch.start(done);
+  });
+
+  it('waitForElementNotPresent(<{selector}>) failure', function(done) {
+    nocks
+      .elementsFound('.nock-string')
+      .elementsFound('.nock-object');
+
+    Nightwatch.api()
+      .waitForElementNotPresent('.nock-string', 50, 20, false, function callback(result) {
+        assert.equal(result.status, 0, 'waitForElementNotPresent "succeeds"');
+        assert.equal(result.value.length, 3, 'waitForElementNotPresent returns the found elements');
+      })
+      .waitForElementNotPresent({ selector: '.nock-object', timeout: 50, retryInterval: 20, abortOnFailure: false }, function callback(result) {
+        assert.equal(result.status, 0, 'waitForElementNotPresent "succeeds"');
+        assert.equal(result.value.length, 3, 'waitForElementNotPresent returns the found elements');
       });
 
     Nightwatch.start(done);


### PR DESCRIPTION
see #2091 

```
[My Test] Test Suite
======================
Running:  present - success

✔ Element <#hplogo> was present after 7 milliseconds.

OK. 1 assertions passed. (10ms)
Running:  not present - success

✔ Element <#foo> was not present after 8 milliseconds.

OK. 1 assertions passed. (8ms)
Running:  present - failure

✖ Timed out while waiting for element <#foo> to be present for 5000 milliseconds. - expected "found" but got: "not found"
    at Object.present - failure (/home/lloiser/projects/nightwatch-testing-repo/test/wait-test.js:18:12)
    at Context.call (/home/lloiser/projects/nightwatch/lib/testsuite/context.js:213:32)
    at TestCase.run (/home/lloiser/projects/nightwatch/lib/testsuite/testcase.js:49:31)
    at Runnable.handleRunnable [as __runFn] (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:349:32)
    at Runnable.run (/home/lloiser/projects/nightwatch/lib/testsuite/runnable.js:123:21)
    at TestSuite.createRunnable (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:415:33)
    at TestSuite.handleRunnable (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:419:17)
    at createSession.then.then._ (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:348:21)
    at process._tickCallback (internal/process/next_tick.js:68:7) 


FAILED: 1 assertions failed (5.077s)
Running:  not present - failure

✖ Timed out while waiting for element <#hplogo> to be removed for 5000 milliseconds. - expected "not found" but got: "found"
    at Object.not present - failure (/home/lloiser/projects/nightwatch-testing-repo/test/wait-test.js:21:12)
    at Context.call (/home/lloiser/projects/nightwatch/lib/testsuite/context.js:213:32)
    at TestCase.run (/home/lloiser/projects/nightwatch/lib/testsuite/testcase.js:49:31)
    at Runnable.handleRunnable [as __runFn] (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:349:32)
    at Runnable.run (/home/lloiser/projects/nightwatch/lib/testsuite/runnable.js:123:21)
    at TestSuite.createRunnable (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:415:33)
    at TestSuite.handleRunnable (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:419:17)
    at createSession.then.then._ (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:348:21)
    at process._tickCallback (internal/process/next_tick.js:68:7) 


FAILED: 1 assertions failed (5.097s)
_________________________________________________

TEST FAILURE:  2 assertions failed, 2 passed. 13.492s

 ✖ wait-test
 – present - failure (5.077s)
   Timed out while waiting for element <#foo> to be present for 5000 milliseconds. - expected "found" but got: "not found"
       at Object.present - failure (/home/lloiser/projects/nightwatch-testing-repo/test/wait-test.js:18:12)
       at Context.call (/home/lloiser/projects/nightwatch/lib/testsuite/context.js:213:32)
       at TestCase.run (/home/lloiser/projects/nightwatch/lib/testsuite/testcase.js:49:31)
       at Runnable.handleRunnable [as __runFn] (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:349:32)
       at Runnable.run (/home/lloiser/projects/nightwatch/lib/testsuite/runnable.js:123:21)
       at TestSuite.createRunnable (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:415:33)
       at TestSuite.handleRunnable (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:419:17)
       at createSession.then.then._ (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:348:21)
       at process._tickCallback (internal/process/next_tick.js:68:7)
 – not present - failure (5.097s)
   Timed out while waiting for element <#hplogo> to be removed for 5000 milliseconds. - expected "not found" but got: "found"
       at Object.not present - failure (/home/lloiser/projects/nightwatch-testing-repo/test/wait-test.js:21:12)
       at Context.call (/home/lloiser/projects/nightwatch/lib/testsuite/context.js:213:32)
       at TestCase.run (/home/lloiser/projects/nightwatch/lib/testsuite/testcase.js:49:31)
       at Runnable.handleRunnable [as __runFn] (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:349:32)
       at Runnable.run (/home/lloiser/projects/nightwatch/lib/testsuite/runnable.js:123:21)
       at TestSuite.createRunnable (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:415:33)
       at TestSuite.handleRunnable (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:419:17)
       at createSession.then.then._ (/home/lloiser/projects/nightwatch/lib/testsuite/testsuite.js:348:21)
       at process._tickCallback (internal/process/next_tick.js:68:7)
```

The output above can be interpreted as:
* `present - success` succeeded after 10ms :heavy_check_mark: 
* `not present - success` succeeded after 8ms :heavy_check_mark: 
* `present - failure` failed after 5.077s :heavy_check_mark:
* `not present - failure` failed after 5.097s :heavy_check_mark:

/cc @beatfactor 