### PR TITLE
Resolve path instead of joining to support absolute globals_path

### DIFF
--- a/lib/settings/globals.js
+++ b/lib/settings/globals.js
@@ -55,7 +55,7 @@ class GlobalsContext extends Context {
         super.loadModule();
       } catch (err) {
         if (err.code === 'MODULE_NOT_FOUND' && !isRetry) {
-          this.modulePath = path.join(Utils.getConfigFolder(this.argv), this.settings.globals_path);
+          this.modulePath = path.resolve(Utils.getConfigFolder(this.argv), this.settings.globals_path);
           this.loadModule(true);
 
           return this;


### PR DESCRIPTION
Fixes https://github.com/nightwatchjs/nightwatch/issues/2097

Using path.join here makes an assumption that globals_path is a relative path to a file.

However, this is not always true — users may configure it as an absolute path.

Using [path.resolve](https://nodejs.org/docs/latest/api/path.html#path_path_resolve_paths) handles both cases.

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.