### PR TITLE
 Add "id" in request body for jsonwire element commands

### DIFF
--- a/lib/transport/actions.js
+++ b/lib/transport/actions.js
@@ -77,7 +77,7 @@ class TransportActions {
       opts = TransportActions.createOptions(opts);
     }
 
-    opts.data = opts.data || '';
+    opts.data = opts.data || {};
     opts.method = Http.Method.POST;
 
     return opts;

--- a/lib/transport/jsonwire/actions.js
+++ b/lib/transport/jsonwire/actions.js
@@ -264,12 +264,7 @@ module.exports = {
     },
 
     clearElementValue(id) {
-      return TransportActions.post({
-        path: `/element/${id}/clear`,
-        data: {
-          id: id
-        }
-      });
+      return TransportActions.post(`/element/${id}/clear`);
     },
 
     setElementValue(id, value) {
@@ -288,21 +283,11 @@ module.exports = {
     },
 
     clickElement(id) {
-      return TransportActions.post({
-        path: `/element/${id}/click`,
-        data: {
-          id: id
-        }
-      });
+      return TransportActions.post(`/element/${id}/click`);
     },
 
     elementSubmit(id) {
-      return TransportActions.post({
-        path: `/element/${id}/submit`,
-        data: {
-          id: id
-        }
-      });
+      return TransportActions.post(`/element/${id}/submit`);
     },
 
     sendKeys(keys) {

--- a/lib/transport/jsonwire/actions.js
+++ b/lib/transport/jsonwire/actions.js
@@ -264,7 +264,12 @@ module.exports = {
     },
 
     clearElementValue(id) {
-      return TransportActions.post(`/element/${id}/clear`);
+      return TransportActions.post({
+        path: `/element/${id}/clear`,
+        data: {
+          id: id
+        }
+      });
     },
 
     setElementValue(id, value) {
@@ -283,11 +288,21 @@ module.exports = {
     },
 
     clickElement(id) {
-      return TransportActions.post(`/element/${id}/click`);
+      return TransportActions.post({
+        path: `/element/${id}/click`,
+        data: {
+          id: id
+        }
+      });
     },
 
     elementSubmit(id) {
-      return TransportActions.post(`/element/${id}/submit`);
+      return TransportActions.post({
+        path: `/element/${id}/submit`,
+        data: {
+          id: id
+        }
+      });
     },
 
     sendKeys(keys) {

--- a/test/src/api/protocol/testElementCommands.js
+++ b/test/src/api/protocol/testElementCommands.js
@@ -89,7 +89,7 @@ describe('element actions', function () {
       assertion: function (opts) {
         assert.equal(opts.method, 'POST');
         assert.equal(opts.path, '/session/1352110219202/element/TEST_ELEMENT/clear');
-        assert.deepEqual(opts.data, '');
+        assert.deepEqual(opts.data, {id: 'TEST_ELEMENT'});
       },
       commandName: 'elementIdClear',
       args: ['TEST_ELEMENT']
@@ -201,6 +201,7 @@ describe('element actions', function () {
       assertion: function (opts) {
         assert.equal(opts.method, 'POST');
         assert.equal(opts.path, '/session/1352110219202/element/TEST_ELEMENT/click');
+        assert.deepEqual(opts.data, {id: 'TEST_ELEMENT'});
       },
       commandName: 'elementIdClick',
       args: ['TEST_ELEMENT']

--- a/test/src/api/protocol/testElementCommands.js
+++ b/test/src/api/protocol/testElementCommands.js
@@ -77,7 +77,7 @@ describe('element actions', function () {
       assertion: function (opts) {
         assert.equal(opts.method, 'POST');
         assert.equal(opts.path, '/session/1352110219202/element/active');
-        assert.deepEqual(opts.data, '');
+        assert.deepEqual(opts.data, {});
       },
       commandName: 'elementActive',
       args: []
@@ -89,7 +89,7 @@ describe('element actions', function () {
       assertion: function (opts) {
         assert.equal(opts.method, 'POST');
         assert.equal(opts.path, '/session/1352110219202/element/TEST_ELEMENT/clear');
-        assert.deepEqual(opts.data, {id: 'TEST_ELEMENT'});
+        assert.deepEqual(opts.data, {});
       },
       commandName: 'elementIdClear',
       args: ['TEST_ELEMENT']
@@ -201,7 +201,7 @@ describe('element actions', function () {
       assertion: function (opts) {
         assert.equal(opts.method, 'POST');
         assert.equal(opts.path, '/session/1352110219202/element/TEST_ELEMENT/click');
-        assert.deepEqual(opts.data, {id: 'TEST_ELEMENT'});
+        assert.deepEqual(opts.data, {});
       },
       commandName: 'elementIdClick',
       args: ['TEST_ELEMENT']

--- a/test/src/api/protocol/testSubmit.js
+++ b/test/src/api/protocol/testSubmit.js
@@ -11,7 +11,7 @@ describe('client.submit', function() {
       assertion: function(opts) {
         assert.equal(opts.method, 'POST');
         assert.equal(opts.path, '/session/1352110219202/element/TEST_ELEMENT/submit');
-        assert.deepEqual(opts.data, '');
+        assert.deepEqual(opts.data, {id: 'TEST_ELEMENT'});
       },
       commandName: 'submit',
       args: ['TEST_ELEMENT']

--- a/test/src/api/protocol/testSubmit.js
+++ b/test/src/api/protocol/testSubmit.js
@@ -11,7 +11,7 @@ describe('client.submit', function() {
       assertion: function(opts) {
         assert.equal(opts.method, 'POST');
         assert.equal(opts.path, '/session/1352110219202/element/TEST_ELEMENT/submit');
-        assert.deepEqual(opts.data, {id: 'TEST_ELEMENT'});
+        assert.deepEqual(opts.data, {});
       },
       commandName: 'submit',
       args: ['TEST_ELEMENT']


### PR DESCRIPTION
Since chromedriver 75 release, tests have become unstable. Namely - chromedriver 75 has enabled w3c mode by default, and that very much contradicts the way how Nightwatch works together with Selenium grid. This can be solved by adding `w3c: false` to chrome options, but that does not fully work as chromedriver expects "id" in request body, not in path. This might be related to a [bugfix](https://bugs.chromium.org/p/chromedriver/issues/detail?id=2719) in chromedriver, although I am not sure.

This PR adds the "id" parameters in the request body to element related requests. This likely also fixes https://github.com/nightwatchjs/nightwatch/issues/2118.