### PR TITLE
Issue/fix 2049

### DIFF
--- a/lib/testsuite/reporter.js
+++ b/lib/testsuite/reporter.js
@@ -214,7 +214,8 @@ class Reporter {
    * @param {number} elapsedTime
    */
   printSimplifiedTestResult(ok, elapsedTime) {
-    let result = [Logger.colors[ok ? 'green': 'red'](Utils.symbols[ok ? 'ok' : 'fail'])];
+	let result = [Logger.colors[ok ? 'green': 'red'](Utils.symbols[ok ? 'ok' : 'fail'])];
+	result.push(Logger.colors.purple(`[${Utils.getBrowserString(this.settings)}]`));
     if (!this.unitTestsMode) {
       result.push(Logger.colors.cyan('[' + this.suiteName + ']'));
     }

--- a/lib/testsuite/reporter.js
+++ b/lib/testsuite/reporter.js
@@ -214,8 +214,8 @@ class Reporter {
    * @param {number} elapsedTime
    */
   printSimplifiedTestResult(ok, elapsedTime) {
-		let result = [Logger.colors[ok ? 'green': 'red'](Utils.symbols[ok ? 'ok' : 'fail'])];
-		sult.push(Logger.colors.purple(`[${Utils.getBrowserString(this.settings)}]`));
+    let result = [Logger.colors[ok ? 'green': 'red'](Utils.symbols[ok ? 'ok' : 'fail'])];
+    result.push(Logger.colors.purple(`[${Utils.getBrowserString(this.settings)}]`));
     if (!this.unitTestsMode) {
       result.push(Logger.colors.cyan('[' + this.suiteName + ']'));
     }

--- a/lib/testsuite/reporter.js
+++ b/lib/testsuite/reporter.js
@@ -214,8 +214,8 @@ class Reporter {
    * @param {number} elapsedTime
    */
   printSimplifiedTestResult(ok, elapsedTime) {
-	let result = [Logger.colors[ok ? 'green': 'red'](Utils.symbols[ok ? 'ok' : 'fail'])];
-	result.push(Logger.colors.purple(`[${Utils.getBrowserString(this.settings)}]`));
+		let result = [Logger.colors[ok ? 'green': 'red'](Utils.symbols[ok ? 'ok' : 'fail'])];
+		sult.push(Logger.colors.purple(`[${Utils.getBrowserString(this.settings)}]`));
     if (!this.unitTestsMode) {
       result.push(Logger.colors.cyan('[' + this.suiteName + ']'));
     }

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -537,12 +537,12 @@ class Utils {
   }
 
   static getBrowserString(settings) {
-		const cap = settings.desiredCapabilities;
-		const browserName = (cap.browser || cap.device || '').toUpperCase();
-		const browserVersion = cap.browser_version || '';
+    const cap = settings.desiredCapabilities;
+    const browserName = (cap.browser || cap.device || '').toUpperCase();
+    const browserVersion = cap.browser_version || '';
 
-		return browserVersion ? `${browserName} ${browserVersion}` : browserName;
-		}
+    return browserVersion ? `${browserName} ${browserVersion}` : browserName;
+  }
 }
 
 function contains(str, text) {

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -537,12 +537,12 @@ class Utils {
   }
 
   static getBrowserString(settings) {
-	const cap = settings.desiredCapabilities;
-	const browserName = (cap.browser || cap.device || '').toUpperCase();
-	const browserVersion = cap.browser_version || '';
+		const cap = settings.desiredCapabilities;
+		const browserName = (cap.browser || cap.device || '').toUpperCase();
+		const browserVersion = cap.browser_version || '';
 
-	return browserVersion ? `${browserName} ${browserVersion}` : browserName;
-  }
+		return browserVersion ? `${browserName} ${browserVersion}` : browserName;
+		}
 }
 
 function contains(str, text) {

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -535,6 +535,14 @@ class Utils {
       return prev;
     }, url);
   }
+
+  static getBrowserString(settings) {
+	const cap = settings.desiredCapabilities;
+	const browserName = (cap.browser || cap.device || '').toUpperCase();
+	const browserVersion = cap.browser_version || '';
+
+	return browserVersion ? `${browserName} ${browserVersion}` : browserName;
+  }
 }
 
 function contains(str, text) {

--- a/test/src/util/testUtils.js
+++ b/test/src/util/testUtils.js
@@ -109,4 +109,34 @@ describe('test Utils', function() {
       'rendered output\rrendered output\rrendered output'
     );
   });
+
+  it('testGetBrowserString', function() {
+		const settingsWithBrowserAndVersion = {
+			desiredCapabilities: {
+				browser: 'IE',
+				browser_version: '11.0'
+			}
+		}
+
+		const settingsWithBrowser = {
+			desiredCapabilities: {
+				browser: 'IE'
+			}
+		}
+
+		const settingsWithDevice = {
+			desiredCapabilities: {
+				device: 'Samsung Galaxy S8'
+			}
+		}
+
+		const settingsWithNothing = {
+			desiredCapabilities: {}
+		}
+
+		assert.equal(Utils.getBrowserString(settingsWithBrowserAndVersion), 'IE 11.0');
+		assert.equal(Utils.getBrowserString(settingsWithBrowser), 'IE');
+		assert.equal(Utils.getBrowserString(settingsWithDevice), 'SAMSUNG GALAXY S8');
+		assert.equal(Utils.getBrowserString(settingsWithNothing), '');
+	});
 });

--- a/test/src/util/testUtils.js
+++ b/test/src/util/testUtils.js
@@ -111,32 +111,32 @@ describe('test Utils', function() {
   });
 
   it('testGetBrowserString', function() {
-		const settingsWithBrowserAndVersion = {
-			desiredCapabilities: {
-				browser: 'IE',
-				browser_version: '11.0'
-			}
-		}
+    const settingsWithBrowserAndVersion = {
+      desiredCapabilities: {
+        browser: 'IE',
+        browser_version: '11.0'
+      }
+    }
 
-		const settingsWithBrowser = {
-			desiredCapabilities: {
-				browser: 'IE'
-			}
-		}
+    const settingsWithBrowser = {
+      desiredCapabilities: {
+        browser: 'IE'
+      }
+    }
 
-		const settingsWithDevice = {
-			desiredCapabilities: {
-				device: 'Samsung Galaxy S8'
-			}
-		}
+    const settingsWithDevice = {
+      desiredCapabilities: {
+        device: 'Samsung Galaxy S8'
+      }
+    }
 
-		const settingsWithNothing = {
-			desiredCapabilities: {}
-		}
+    const settingsWithNothing = {
+      desiredCapabilities: {}
+    }
 
-		assert.equal(Utils.getBrowserString(settingsWithBrowserAndVersion), 'IE 11.0');
-		assert.equal(Utils.getBrowserString(settingsWithBrowser), 'IE');
-		assert.equal(Utils.getBrowserString(settingsWithDevice), 'SAMSUNG GALAXY S8');
-		assert.equal(Utils.getBrowserString(settingsWithNothing), '');
-	});
+    assert.equal(Utils.getBrowserString(settingsWithBrowserAndVersion), 'IE 11.0');
+    assert.equal(Utils.getBrowserString(settingsWithBrowser), 'IE');
+    assert.equal(Utils.getBrowserString(settingsWithDevice), 'SAMSUNG GALAXY S8');
+    assert.equal(Utils.getBrowserString(settingsWithNothing), '');
+  });
 });


### PR DESCRIPTION
This PR solves https://github.com/nightwatchjs/nightwatch/issues/2049

It adds the browser or device name and the version (if set), to the test runner output when multiple tests are run in parallel. See screenshots below:

Before:
<img width="911" alt="Screenshot 2019-06-10 at 14 45 59" src="https://user-images.githubusercontent.com/3966773/59199816-c64c0b00-8b8e-11e9-8c33-8144f4fd5816.png">

After:
<img width="944" alt="Screenshot 2019-06-10 at 14 47 52" src="https://user-images.githubusercontent.com/3966773/59199835-cfd57300-8b8e-11e9-941e-017922e18d85.png">
