### PR TITLE
JUnit xml error messages in test runner report output

### DIFF
--- a/lib/runner/reporters/junit.xml.ejs
+++ b/lib/runner/reporters/junit.xml.ejs
@@ -13,7 +13,11 @@
       for (var i = 0; i < assertions.length; i++) { %><% if (assertions[i].failure) { %>  <failure message="<%= assertions[i].message %>"><%= assertions[i].stackTrace %></failure><% } %>
 <% if (assertions[i].screenshots && assertions[i].screenshots.length > 0) { %><system-out><% for (var j = 0; j < assertions[i].screenshots.length; j++) { %>[[ATTACHMENT|<%= assertions[i].screenshots[j] %>]]<% } %></system-out><% } %>
     <% }
-    if (testcase.failed > 0 && testcase.stackTrace) { %><failure message="<%= testcase.message %>"><%= testcase.stackTrace %></failure><% } %>
+    if (testcase.failed > 0 && testcase.stackTrace) { %>
+      <failure message="<%= testcase.message %>"><%= testcase.stackTrace %></failure><% } 
+    if (testcase.errors > 0 && testcase.stackTrace) { %>
+      <error<% if (testcase.lastError && testcase.lastError.message) { %> message="<%= testcase.lastError.message %>" <% } %>type="error"><%= testcase.stackTrace %></error>
+    <% } %>
     </testcase>
   <% } %>
 

--- a/test/sampletests/witherrors/sample.js
+++ b/test/sampletests/witherrors/sample.js
@@ -1,0 +1,32 @@
+module.exports = {
+  before : function(client, callback) {
+    client.globals.calls++;
+    callback();
+  },
+
+  beforeEach : function(client, callback) {
+    client.globals.calls++;
+    callback();
+  },
+
+  demoTest : function () {
+    throw new Error('Error in test script');
+  },
+
+  demoTest2 : function (client) {
+    client.url('http://localhost')
+      .assert.elementPresent('#weblogin')
+      .assert.elementPresent('#badElement')
+      .end();
+  },
+
+  afterEach : function(client, callback) {
+    client.globals.calls++;
+    callback();
+  },
+
+  after : function(client, callback) {
+    client.globals.calls++;
+    callback();
+  }
+};

--- a/test/src/runner/testRunner.js
+++ b/test/src/runner/testRunner.js
@@ -160,6 +160,48 @@ describe('testRunner', function() {
       });
   });
 
+  it('testRunWithJUnitOutputAndErrors', function () {
+
+    let testsPath = [
+      path.join(__dirname, '../../sampletests/witherrors')
+    ];
+
+    let settings = {
+      selenium: {
+        port: 10195,
+        version2: true,
+        start_process: true
+      },
+      output_folder: 'output',
+      silent: false,
+      globals: {
+        waitForConditionPollInterval: 20,
+        waitForConditionTimeout: 50,
+        retryAssertionTimeout: 50,
+        reporter: function () {
+        }
+      },
+      output: false,
+      screenshots: {
+        enabled: false
+      }
+    };
+
+    return NightwatchClient.runTests(testsPath, settings)
+      .then(_ => {
+        return readFilePromise('output/FIREFOX_TEST_TEST_sample.xml');
+      })
+      .then(data => {
+        let content = data.toString();
+        const regexErrorText = /(?:<error(?:[^>]*)>)([^>]*)(?:<\/error>)/; 
+        const regexResult = regexErrorText.exec(content);
+        const errorText = regexResult.length > 1 ? regexResult[1] : '';
+        
+        assert.ok(content.indexOf('<error message="Error in test script"') > 0, 'Report should contain error message');
+        assert.ok(errorText.indexOf('sample.js') > -1, 'Report should contain stack trace');
+      });
+  });
+
   it('testRunWithJUnitOutput', function() {
     let testsPath = [
       path.join(__dirname, '../../sampletests/withsubfolders')


### PR DESCRIPTION
Hi Team,

We've started using [BuildKite](https://buildkite.com) to run our Nightwatch tests and it has a great plugin for [JUnit xml report parsing](https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin). The only problem we encountered was that it wasn't picking up the errors from tests due to error information not added the the report output. I'm hoping that this pull request will benefit the community by adding both the error message and the stack trace. 

I have matched the Junit schema specified here: https://llg.cubic.org/docs/junit/

It appears in BuildKite like this:

<img width="807" alt="PortalIntergrationTestOutput" src="https://user-images.githubusercontent.com/697029/59433066-a1e76d00-8de0-11e9-8d35-d4fbfe1072d6.png">
