### PR TITLE
Emit error if perform command times out

### DIFF
--- a/lib/api/client-commands/perform.js
+++ b/lib/api/client-commands/perform.js
@@ -52,9 +52,9 @@ class Perform extends EventEmitter {
     let doneCallback;
     let asyncHookTimeout = this.client.settings.globals.asyncHookTimeout;
 
-    this.timeoutId = setTimeout(function() {
-      throw new Error(`Timeout while waiting (${asyncHookTimeout}ms) for the .perform() command callback to be called.`);
-    }, asyncHookTimeout);
+    this.timeoutId = setTimeout(function(parent) {
+      parent.emit('error', new Error(`Timeout while waiting (${asyncHookTimeout}ms) for the .perform() command callback to be called.`));
+    }, asyncHookTimeout, this);
 
     if (callback.length === 0) {
       const cbResult = this.runCallback(callback, [this.api]);

--- a/lib/api/client-commands/perform.js
+++ b/lib/api/client-commands/perform.js
@@ -52,9 +52,9 @@ class Perform extends EventEmitter {
     let doneCallback;
     let asyncHookTimeout = this.client.settings.globals.asyncHookTimeout;
 
-    this.timeoutId = setTimeout(function(parent) {
-      parent.emit('error', new Error(`Timeout while waiting (${asyncHookTimeout}ms) for the .perform() command callback to be called.`));
-    }, asyncHookTimeout, this);
+    this.timeoutId = setTimeout(() => {
+      this.emit('error', new Error(`Timeout while waiting (${asyncHookTimeout}ms) for the .perform() command callback to be called.`));
+    }, asyncHookTimeout);
 
     if (callback.length === 0) {
       const cbResult = this.runCallback(callback, [this.api]);


### PR DESCRIPTION
When running `.perform` command with `done` callback, the command has default timeout as defined in `asyncHookTimeout` setting. If this timeout is exceeded test fails with 0 exit code, producing a false positive result (see #1301 ). By passing `this` to timeout function, we allow that function to emit error which will then be gracefully caught and exit code won't be 0 if the command fails to finish within the timeout. 

This change likely breaks tests for those who assume this behaviour, but I believe that this behaviour is faulty and deserves to be fixed.
