### PR TITLE
Expose status polling settings

### DIFF
--- a/lib/runner/wd-instances/base-wd-server.js
+++ b/lib/runner/wd-instances/base-wd-server.js
@@ -57,20 +57,6 @@ class BaseWDServer {
   /**
    * @return {number}
    */
-  static get maxStatusPollTries() {
-    return 5;
-  }
-
-  /**
-   * @return {number}
-   */
-  static get statusPollInterval() {
-    return 100;
-  }
-
-  /**
-   * @return {number}
-   */
   static get defaultGlobalStartTimeout() {
     return 120000;
   }
@@ -106,6 +92,24 @@ class BaseWDServer {
     process.on('exit', () => {
       this.stop();
     });
+  }
+
+  /**
+   * Maximum number of ping status check attempts before returning an error
+   * 
+   * @return {number}
+   */
+  get maxStatusPollTries() {
+    return this.settings.max_status_poll_tries || 5;
+  }
+
+  /**
+   * Interval (in ms) to use between 2 ping status checks
+   * 
+   * @return {number}
+   */
+  get statusPollInterval() {
+    return this.settings.status_poll_interval || 100;
   }
 
   /**

--- a/test/src/wd-manager/testSelenium.js
+++ b/test/src/wd-manager/testSelenium.js
@@ -135,6 +135,8 @@ describe('Webdriver Manager', function () {
       let settings = Settings.parse({
         selenium: {
           check_process_delay: 1000,
+          max_status_poll_tries: 10,
+          status_poll_interval: 200,
           start_process: true,
           server_path: './selenium.jar',
           log_path: false,


### PR DESCRIPTION
This exposes settings for the selenium server connection, to allow the configuration of the `maxStatusPollTries` value as well and the `statusPollInterval` value.

We ran into issues when using a Selenium server for our Nightwatch tests on Travis because Nightwatch would time out trying to connect to the Selenium server. For now, we are making use of the  `check_process_delay` setting which gives our environment more time to spin up the Selenium server, but this relies on a javascript timeout and a set amount of attempts that cannot be configured. It would be good to let developers configure those values as well to give them more flexibility in their setup.

If anything is missing or this PR does not make sense, please comment and let me know what's wrong or needs to be changed.