### PR TITLE
Fixed #2165 - detect non-http absolute url in Util.relativeUrl

### DIFF
--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -511,7 +511,7 @@ class Utils {
   }
 
   static relativeUrl(url) {
-    return !(url.startsWith('http://') || url.startsWith('https://'));
+    return !(url.includes('://'));
   }
 
   static uriJoin(baseUrl, uriPath) {

--- a/test/src/util/testUtils.js
+++ b/test/src/util/testUtils.js
@@ -109,4 +109,13 @@ describe('test Utils', function() {
       'rendered output\rrendered output\rrendered output'
     );
   });
+
+  it('testRelativeUrl', function() {
+    assert.equal(Utils.relativeUrl('https://nightwatchjs.org'), false);
+    assert.equal(Utils.relativeUrl('http://nightwatchjs.org'), false);
+    assert.equal(Utils.relativeUrl('chrome-extension://pkehgijcmpdhfbdbbnkijodmdjhbjlgp/skin/options.html'), false);
+    assert.equal(Utils.relativeUrl('nightwatchjs.org'), true);
+    assert.equal(Utils.relativeUrl('nightwatchjs.org/guide'), true);
+    assert.equal(Utils.relativeUrl('/guide'), true);
+  });
 });


### PR DESCRIPTION
Loosen the relative(absolute) URL checking to detect `://` in position > 0, instead of checking `http(s)://` such that we can support different protocols. e.g. `file://`, `chrome-extension://`