### PR TITLE
fix defect 2168

### DIFF
--- a/lib/transport/webdriver/actions.js
+++ b/lib/transport/webdriver/actions.js
@@ -43,7 +43,8 @@ module.exports = lodashMerge({}, JsonWireActions, {
     },
 
     maximizeWindow(windowHandle) {
-      return TransportActions.post(`/window/${windowHandle}/maximize`);
+      //W3C deprecated /window/{handle}/maximize  @see https://w3c.github.io/webdriver/#endpoints
+      return TransportActions.post(`/window/maximize`);
     },
 
     setWindowPosition(windowHandle, offsetX, offsetY) {
@@ -62,7 +63,8 @@ module.exports = lodashMerge({}, JsonWireActions, {
 
     setWindowSize(windowHandle, width, height) {
       return TransportActions.post({
-        path: `/window/${windowHandle}/size`,
+        //W3C deprecated /window/{handle}/size . @see https://w3c.github.io/webdriver/#endpoints
+        path: `/window/rect`,
         data: {
           width : width,
           height : height

--- a/lib/transport/webdriver/actions.js
+++ b/lib/transport/webdriver/actions.js
@@ -44,7 +44,7 @@ module.exports = lodashMerge({}, JsonWireActions, {
 
     maximizeWindow(windowHandle) {
       //W3C deprecated /window/{handle}/maximize  @see https://w3c.github.io/webdriver/#endpoints
-      return TransportActions.post(`/window/maximize`);
+      return TransportActions.post('/window/maximize');
     },
 
     setWindowPosition(windowHandle, offsetX, offsetY) {
@@ -64,7 +64,7 @@ module.exports = lodashMerge({}, JsonWireActions, {
     setWindowSize(windowHandle, width, height) {
       return TransportActions.post({
         //W3C deprecated /window/{handle}/size . @see https://w3c.github.io/webdriver/#endpoints
-        path: `/window/rect`,
+        path: '/window/rect',
         data: {
           width : width,
           height : height


### PR DESCRIPTION
started a thread in https://groups.google.com/forum/#!topic/nightwatchjs/iUbYi0jHB_o
fixing issue https://github.com/nightwatchjs/nightwatch/issues/2168
wrong W3C REST API was called when using firefox+nightwatch 1.1.13
I fixed only setWindowSize and maximizeWindow actions however, more work is needed on the W3C Webdriver api.