### PR TITLE
suppress error log

### DIFF
--- a/lib/runner/cli/cli.js
+++ b/lib/runner/cli/cli.js
@@ -66,6 +66,7 @@ class CliRunner {
   setLoggingOptions() {
     Logger.setOutputEnabled(this.test_settings.output);
     Logger.setDetailedOutput(this.test_settings.detailed_output);
+    Logger.setErrorLog(this.test_settings.disable_error_log);
 
     if (this.test_settings.disable_colors) {
       Logger.disableColors();

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -3,6 +3,7 @@ const util = require('util');
 const Settings = {
   outputEnabled: true,
   detailedOutput: true,
+  disable_error_log: false,
   log_timestamp : false,
   colors : true,
   enabled : true
@@ -180,7 +181,7 @@ function logError(severity, errOrMessage, args) {
     errOrMessage = Utils.errorToStackTrace(errOrMessage);
   }
 
-  let alwaysDisplay = severity === Severity.ERROR;
+  let alwaysDisplay = !Settings.disable_error_log && severity === Severity.ERROR;
 
   logMessage(severity, errOrMessage, args, alwaysDisplay);
 }
@@ -239,6 +240,14 @@ const Logger = {
 
   isEnabled() {
     return Settings.enabled;
+  },
+
+  setErrorLog(val = false) {
+    Settings.disable_error_log = val;
+  },
+
+  isErrorLogDisabled() {
+    return Settings.disable_error_log;
   },
 
   logDetailedMessage(message, type = 'log') {


### PR DESCRIPTION
Hello everyone,
 
We have huge codebase for testing with Nightwatchjs in our company and when we were trying to update from version 0.9.21 to 1.2.1 we saw that "element" command logs a lot of information in the console. Sometimes when we analyse our test cases these unwanted logs are causing us a lot of discomfort because it's really hard to sift out the important logs.

Adding outputEnabled and other options to nightwatch.json didn't help us to suppress the log of the "element" command.

I guess that an option for disabling error logs is important feature and will help a lot for developers who are using Nightwatchjs to test the appearance of a dynamic content. For example, when using "element" command to verify a presence of an html element in order to decide the further test case steps. 

I added one small change to disable error logs.
I saw that there is a variable "alwaysDisplay" in logError function in logger.js that forces every log with severity 'ERROR' to be displayed always no matter what the "outputEnabled" option is set to, which is good but it's also good to have an option to disable even the error logs.

Disabling and enabling the error logs in this implementation can be done by adding a property "disable_error_log"  in "test_settings" part of nightwatch.json file as follows:

`"test_settings": {
    "default": {
      "selenium_port": 4444,
      "selenium_host": "localhost",
      "silent": true,
      "outputEnabled": false,
      "disable_error_log": true,
...
`

Best regards,
Zhivko Dimitrov