### PR TITLE
added support for accessibility id locator strategy

### DIFF
--- a/lib/api/client-commands/useAccessibilityId.js
+++ b/lib/api/client-commands/useAccessibilityId.js
@@ -1,0 +1,26 @@
+const LocateStrategy = require('./_locateStrategy.js');
+const Strategies = require('../../element/strategy.js');
+
+/**
+ * Sets the locate strategy for selectors to accessibility id, therefore every following selector needs to be specified as accessibility id.
+ *
+ * @example
+ * this.demoTest = function (browser) {
+ *   browser
+ *     .useAccessibilityId() // every selector now must be acc
+ *     .click("submitButton");
+ * };
+ *
+ * @method useAccessibilityId
+ * @param {function} [callback] Optional callback function to be called when the command finishes.
+ * @api protocol.utilities
+ */
+
+class Command extends LocateStrategy {
+  constructor() {
+    super();
+    this.strategy = Strategies.ACCESSIBILITY_ID;
+  }
+}
+
+module.exports = Command;

--- a/lib/element/strategy.js
+++ b/lib/element/strategy.js
@@ -8,7 +8,8 @@ class LocateStrategy {
       LINK_TEST: 'link text',
       PARTIAL_LINK_TEXT: 'partial link text',
       TAG_NAME: 'tag name',
-      XPATH: 'xpath'
+      XPATH: 'xpath',
+      ACCESSIBILITY_ID: 'accessibility id'
     };
   }
 
@@ -28,6 +29,10 @@ class LocateStrategy {
 
   static get CSS_SELECTOR() {
     return LocateStrategy.Strategies.CSS_SELECTOR;
+  }
+
+  static get ACCESSIBILITY_ID() {
+    return LocateStrategy.Strategies.ACCESSIBILITY_ID;
   }
 
   static getDefault() {

--- a/lib/util/locatestrategy.js
+++ b/lib/util/locatestrategy.js
@@ -8,7 +8,8 @@ class LocateStrategy {
       LINK_TEST: 'link text',
       PARTIAL_LINK_TEXT: 'partial link text',
       TAG_NAME: 'tag name',
-      XPATH: 'xpath'
+      XPATH: 'xpath',
+      ACCESSIBILITY_ID: 'accessibility id'
     };
   }
 
@@ -28,6 +29,10 @@ class LocateStrategy {
 
   static get CSS_SELECTOR() {
     return LocateStrategy.Strategies.CSS_SELECTOR;
+  }
+
+  static get ACCESSIBILITY_ID() {
+    return LocateStrategy.Strategies.ACCESSIBILITY_ID;
   }
 
   static getDefault() {

--- a/test/extra/pageobjects/pages/simplePageObj.js
+++ b/test/extra/pageobjects/pages/simplePageObj.js
@@ -16,7 +16,8 @@ module.exports = {
     loginCss: {selector: '#weblogin'},
     loginIndexed: {selector: '#weblogin', index: 1},
     loginXpath: {selector: '//weblogin', locateStrategy: 'xpath'},
-    loginId: {selector: 'weblogin', locateStrategy: 'id'}
+    loginId: {selector: 'weblogin', locateStrategy: 'id'},
+    loginAccessibilityId: {selector: 'mobilelogin', locateStrategy: 'accessibility id'}
   },
   sections: {
     signUp: {

--- a/test/lib/nockselements.js
+++ b/test/lib/nockselements.js
@@ -135,6 +135,19 @@ module.exports = {
     return this;
   },
 
+  elementsByAccessibilityId(selector = 'nock', foundArray = [{ELEMENT: '0'}, {ELEMENT: '1'}, {ELEMENT: '2'}]) {
+    this._addNock(this._requestUri)
+      .persist()
+      .post(this._protocolUri + 'elements', {'using':'accessibility id', 'value':selector})
+      .reply(200, {
+        status: 0,
+        state: 'success',
+        value: foundArray
+      });
+
+    return this;
+  },
+
   elementId (id, selector, using, foundElem) {
     this._addNock(this._requestUri)
       .persist()

--- a/test/src/element/testCommandsElementSelectors.js
+++ b/test/src/element/testCommandsElementSelectors.js
@@ -36,6 +36,7 @@ describe('test commands element selectors', function() {
       .elementsFound('#nock')
       .elementsNotFound('#nock-none')
       .elementsByXpath('//[@id="nock"]')
+      .elementsByAccessibilityId('nock')
       .text(0, 'first')
       .text(1, 'second');
 
@@ -54,6 +55,9 @@ describe('test commands element selectors', function() {
       })
       .getText({selector: '//[@id="nock"]', locateStrategy: 'xpath'}, function callback(result) {
         assert.strictEqual(result.value, 'first');
+      })
+      .getText({selector: 'nock', locateStrategy: 'accessibility id'}, function callback(result) {
+        assert.strictEqual(result.value, 'first');
       });
 
     Nightwatch.start(done);
@@ -63,6 +67,7 @@ describe('test commands element selectors', function() {
     nocks
       .elementsFound('#nock')
       .elementsByXpath('//[@id="nock"]')
+      .elementsByAccessibilityId('nock')
       .text(0, 'first')
       .text(1, 'second');
 
@@ -89,6 +94,23 @@ describe('test commands element selectors', function() {
         assert.strictEqual(result.value, 'first');
       })
       .getText('xpath', {selector: '//[@id="nock"]'}, function callback(result) {
+        assert.strictEqual(result.value, 'first');
+      })
+      .useAccessibilityId()
+      .getText('nock', function callback(result) {
+        assert.strictEqual(result.value, 'first');
+      })
+      .useCss()
+      .getText({selector: 'nock', locateStrategy: 'accessibility id'}, function callback(result) {
+        assert.strictEqual(result.value, 'first');
+      })
+      .getText({selector: 'nock', locateStrategy: 'accessibility id', index: 1}, function callback(result) {
+        assert.strictEqual(result.value, 'second');
+      })
+      .getText('css selector', {selector: 'nock', locateStrategy: 'accessibility id'}, function callback(result) {
+        assert.strictEqual(result.value, 'first');
+      })
+      .getText('accessibility id', {selector: 'nock'}, function callback(result) {
         assert.strictEqual(result.value, 'first');
       });
 
@@ -138,7 +160,8 @@ describe('test commands element selectors', function() {
     nocks
       .elementsFound()
       .elementsNotFound()
-      .elementsByXpath();
+      .elementsByXpath()
+      .elementsByAccessibilityId();
 
     Nightwatch.api()
       .useCss()
@@ -152,6 +175,14 @@ describe('test commands element selectors', function() {
       .useCss()
       .waitForElementPresent({selector: '//[@class="nock"]', locateStrategy: 'xpath'}, 1, false, function callback(result) {
         assert.strictEqual(result.value.length, 3, 'waitforPresent locateStrategy override to xpath found');
+      })
+      .useAccessibilityId()
+      .waitForElementPresent('nock', 1, false, function callback(result) {
+        assert.strictEqual(result.value.length, 3, 'waitforPresent using accessibility id');
+      })
+      .useCss()
+      .waitForElementPresent({selector: 'nock', locateStrategy: 'accessibility id'}, 1, false, function callback(result) {
+        assert.strictEqual(result.value.length, 3, 'waitforPresent locateStrategy override to accessibility id found');
       });
 
     Nightwatch.start(done);

--- a/test/src/element/testExpectElementSelectors.js
+++ b/test/src/element/testExpectElementSelectors.js
@@ -26,7 +26,8 @@ describe('test expect element selectors', function() {
       .elementsFound()
       .elementsFound('#signupSection', [{ELEMENT: '0'}])
       .elementsId(0, '#helpBtn', [{ELEMENT: '0'}, {ELEMENT: '1'}])
-      .elementsByXpath();
+      .elementsByXpath()
+      .elementsByAccessibilityId();
 
     let api = Nightwatch.api();
     api.globals.abortOnAssertionFailure = false;
@@ -39,6 +40,7 @@ describe('test expect element selectors', function() {
       api.expect.element('.nock').to.be.present.before(1),
       api.expect.element({selector: '.nock'}).to.be.present.before(1),
       api.expect.element({selector: '//[@class="nock"]', locateStrategy: 'xpath'}).to.be.present.before(1),
+      api.expect.element({selector: 'nock', locateStrategy: 'accessibility id'}).to.be.present.before(1),
       page.expect.section('@signUp').to.be.present.before(1),
       page.expect.section({selector: '@signUp', locateStrategy: 'css selector'}).to.be.present.before(1),
       section.expect.element('@help').to.be.present.before(1)
@@ -63,6 +65,20 @@ describe('test expect element selectors', function() {
     api.globals.abortOnAssertionFailure = true;
 
     let expect = api.expect.element({selector: '.nock', locateStrategy: 'xpath'}).to.be.present.before(1);
+
+    Nightwatch.start(function(err) {
+      assert.equal(expect.assertion.passed, false);
+      assert.ok(expect.assertion.message.includes('element was not found'));
+      assert.ok(err instanceof Error);
+      done();
+    });
+  });
+
+  it('failing expect selectors - accessibility id .nock', function (done) {
+    let api = Nightwatch.api();
+    api.globals.abortOnAssertionFailure = true;
+
+    let expect = api.expect.element({selector: '.nock', locateStrategy: 'accessibility id'}).to.be.present.before(1);
 
     Nightwatch.start(function(err) {
       assert.equal(expect.assertion.passed, false);
@@ -102,6 +118,20 @@ describe('test expect element selectors', function() {
     } catch (err) {
       assert.ok(err instanceof Error);
       assert.equal(err.message, 'Section "signUp[locateStrategy=\'xpath\']" was not found in "simplePageObj". Available sections: signUp[locateStrategy=\'css selector\'], propTest[locateStrategy=\'css selector\']');
+    }
+    Nightwatch.start();
+  });
+
+  it('failing expect selectors - accessibility id @signUp', function () {
+    let api = Nightwatch.api();
+    api.globals.abortOnAssertionFailure = false;
+
+    let page = api.page.simplePageObj();
+    try {
+      page.expect.section({selector: '@signUp', locateStrategy: 'accessibility id'}).to.be.present;
+    } catch (err) {
+      assert.ok(err instanceof Error);
+      assert.equal(err.message, 'Section "signUp[locateStrategy=\'accessibility id\']" was not found in "simplePageObj". Available sections: signUp[locateStrategy=\'css selector\'], propTest[locateStrategy=\'css selector\']');
     }
     Nightwatch.start();
   });

--- a/test/src/element/testIndexedElementSelectors.js
+++ b/test/src/element/testIndexedElementSelectors.js
@@ -53,6 +53,7 @@ describe('test index in element selectors', function() {
     nocks
       .elementsFound()
       .elementsByXpath()
+      .elementsByAccessibilityId()
       .text(0, 'first')
       .text(1, 'second');
 
@@ -62,6 +63,9 @@ describe('test index in element selectors', function() {
       })
       .getText({selector: '//[@class="nock"]', locateStrategy: 'xpath', index: 1}, function callback(result) {
         assert.strictEqual(result.value, 'second', 'getText xpath locateStrategy index 1');
+      })
+      .getText({selector: 'nock', locateStrategy: 'accessibility id', index: 1}, function callback(result) {
+        assert.strictEqual(result.value, 'second', 'getText accessibility id locateStrategy index 1');
       })
       .getText({
         selector: '//[@class="nock"]',

--- a/test/src/element/testPageObjectElementSelectors.js
+++ b/test/src/element/testPageObjectElementSelectors.js
@@ -39,6 +39,7 @@ describe('test page object element selectors', function() {
       .elementsFound('weblogin', [{ELEMENT: '0'}], 'id')
       .elementsByXpath('//weblogin')
       .elementsByXpath('#weblogin', [])
+      .elementsByAccessibilityId('mobilelogin')
       .text(0, 'first')
       .text(1, 'second');
 
@@ -64,7 +65,12 @@ describe('test page object element selectors', function() {
       .getText('@loginId', function callback(result) {
         assert.strictEqual(result.status, 0, 'element selector id found');
         assert.strictEqual(result.value, 'first', 'element selector id value');
+      })
+      .getText('@loginAccessibilityId', function callback(result) {
+        assert.strictEqual(result.status, 0, 'element selector accessibility id found');
+        assert.strictEqual(result.value, 'first', 'element selector accessibility id value');
       });
+
 
     Nightwatch.start(done);
   });


### PR DESCRIPTION
Hi. 

Currently, the only way to test native mobile apps with Nightwatch is to use Xpath selectors that look ugly and have performance issues. The solution is to use accessibility id as a strategy. This PR adds support for the new locator strategy "accessibility id" which is widely used in mobile application testing via Appium.

http://appium.io/docs/en/commands/element/find-elements/