### PR TITLE
Add slot index when running concurrently.

### DIFF
--- a/lib/runner/concurrency/child-process.js
+++ b/lib/runner/concurrency/child-process.js
@@ -18,13 +18,14 @@ class ChildProcess extends EventEmitter {
     prevIndex = val;
   }
 
-  constructor(environment, index, env_output, settings, args) {
+  constructor(environment, index, slotIndex, env_output, settings, args) {
     super();
 
     this.settings = settings;
     this.env_output = env_output || [];
     this.mainModule = process.mainModule.filename;
     this.index = index;
+    this.slotIndex = slotIndex;
     this.itemKey = this.getChildProcessEnvKey(environment);
     this.startDelay = settings.parallel_process_delay || ChildProcess.defaultStartDelay;
     this.environment = environment;
@@ -112,6 +113,7 @@ class ChildProcess extends EventEmitter {
         env.__NIGHTWATCH_ENV = this.environment;
         env.__NIGHTWATCH_ENV_KEY = this.itemKey;
         env.__NIGHTWATCH_ENV_LABEL = this.env_itemKey;
+        env.__NIGHTWATCH_SLOT_INDEX = this.slotIndex;
 
         this.child = child_process.spawn(process.execPath, cliArgs, {
           cwd: process.cwd(),
@@ -120,7 +122,7 @@ class ChildProcess extends EventEmitter {
           stdio: [null, null, null, 'ipc']
         });
 
-        Logger.info('Started child process for:' + this.env_label);
+        Logger.info('Started child process for:' + this.env_label + ' in slot index ' + this.slotIndex);
 
         this.child.stdout.on('data', data => {
           this.writeToStdout(data);

--- a/lib/runner/concurrency/concurrency.js
+++ b/lib/runner/concurrency/concurrency.js
@@ -71,7 +71,7 @@ class Concurrency extends EventEmitter {
    */
   runTestEnvironments(envs, args, availColors) {
     return Promise.all(envs.map((environment, index) => {
-      let childProcess = this.createChildProcess(environment, args, ['--env', environment], index);
+      let childProcess = this.createChildProcess(environment, args, ['--env', environment], index, index);
 
       return this.runChildProcess(childProcess, environment + ' environment', availColors);
     }));
@@ -89,16 +89,16 @@ class Concurrency extends EventEmitter {
     Logger.log(`Launching up to ${workerCount} concurrent test worker processes...\n`);
 
     return new Promise((resolve, reject) => {
-      Concurrency.buildProcessQueue(workerCount, modules, (modulePath, index, next) => {
+      Concurrency.buildProcessQueue(workerCount, modules, (modulePath, index, next, slotIndex) => {
         let outputLabel = Utils.getModuleKey(modulePath, this.settings.src_folders, modules);
-        let childProcess = this.createChildProcess(outputLabel, args, ['--test', modulePath, '--test-worker'], index);
+        let childProcess = this.createChildProcess(outputLabel, args, ['--test', modulePath, '--test-worker'], index, slotIndex);
 
         return this.runChildProcess(childProcess, outputLabel, availColors)
           .then(_ => {
             remaining -=1;
 
             if (remaining > 0) {
-              next();
+              next(slotIndex);
             } else {
               resolve();
             }
@@ -133,11 +133,11 @@ class Concurrency extends EventEmitter {
    * @param {Number} index
    * @return {ChildProcess}
    */
-  createChildProcess(label, args, extraArgs, index) {
+  createChildProcess(label, args, extraArgs, index, slotIndex) {
     this.childProcessOutput[label] = [];
     let childArgs = args.slice().concat(extraArgs);
 
-    let childProcess = new ChildProcess(label, index, this.childProcessOutput[label], this.settings, childArgs);
+    let childProcess = new ChildProcess(label, index, slotIndex, this.childProcessOutput[label], this.settings, childArgs);
     childProcess.on('message', data => {
       this.emit('message', data);
     });
@@ -197,9 +197,11 @@ class Concurrency extends EventEmitter {
     let queue = modules.slice(0);
     let workers = 0;
     let index = 0;
+    let slots = new Array(maxWorkers).fill(false);
 
-    const next = function() {
+    const next = function(slot) {
       workers -= 1;
+      slots[slot] = false;
       process();
     };
 
@@ -209,7 +211,9 @@ class Concurrency extends EventEmitter {
 
         if (queue.length) {
           let item = queue.shift();
-          fn(item, index++, next);
+          let slotIndex = slots.findIndex(e => !e);
+          slots[slotIndex] = true;
+          fn(item, index++, next, slotIndex);
         } else {
           done();
         }


### PR DESCRIPTION
This PR adds an identifier (via environment variable) to each child process when running concurrently that I am calling the "slot index". The idea here is that, when running concurrently, the user specifies how many workers there can be total, and then each worker when it runs is given an index in the range [0, maxWorkers) such that only one worker is running using a given index at a time. This will enable consumers of Nightwatch to do things like specify an account to use for authenticating per worker thread and have a guarantee that no 2 tests will run using the same account at the same time.

I'm trying to figure out the best way to add unit tests for this. If you have any advice on that front, I'd appreciate it.