### PR TITLE
Add cli option for showing timestamp in logs.

### DIFF
--- a/lib/settings/defaults.js
+++ b/lib/settings/defaults.js
@@ -148,6 +148,9 @@ module.exports = {
   // Set this to false if you'd like to only see the test case name displayed and pass/fail status.
   detailed_output: true,
 
+  // Set this to true if you'd like to see timestamps next to the logging output
+  output_timestamp: false,
+
   // Set this to true if you'd like to not display errors during the execution of the test (they are shown at the end always).
   disable_error_log: false,
 

--- a/lib/settings/settings.js
+++ b/lib/settings/settings.js
@@ -135,6 +135,7 @@ class Settings {
       this.settings.webdriver.start_session = false;
       this.settings.start_session = false;
       this.settings.detailed_output = false;
+      this.settings.output_timestamp = false;
     }
 
     return this;

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -191,6 +191,7 @@ const Logger = {
   setOptions(settings) {
     Logger.setOutputEnabled(settings.output);
     Logger.setDetailedOutput(settings.detailed_output);
+    Logger.setLogTimestamp(settings.output_timestamp);
     Logger.setErrorLog(settings.disable_error_log);
 
     if (settings.disable_colors) {
@@ -251,6 +252,14 @@ const Logger = {
 
   isDetailedOutput() {
     return Settings.outputEnabled && Settings.detailedOutput;
+  },
+
+  setLogTimestamp(val) {
+    Settings.log_timestamp = val;
+  },
+
+  isLogTimestamp() {
+    return Settings.log_timestamp;
   },
 
   isErrorLogEnabled() {


### PR DESCRIPTION
There is a setting in the logger to show the timestamp when outputting a log message, but there is no way via the CLI to activate that setting. This PR adds a way to do that.