### PR TITLE
Don't use the Safari work around if it's not a local Safaridriver

### DIFF
--- a/lib/api/element-commands/isVisible.js
+++ b/lib/api/element-commands/isVisible.js
@@ -51,9 +51,18 @@ class IsVisible extends BaseElementCommand {
   protocolAction() {
     if (this.api.capabilities) {
       // FIXME: temporary fix to get safari working
-      const {browserName, browserVersion} = this.api.capabilities;
-      // Are we running Safaridriver locally and is it Safari 12 or newer?
-      if (browserName.toLowerCase() === 'safari' && this.settings.webdriver.start_process === true && parseInt(browserVersion, 10) >= 12) {
+      const {browserName, browserVersion, version} = this.api.capabilities;
+          
+      var safariVersion;
+      if (version) {
+        safariVersion = version
+      }
+      else if (browserVersion){
+        safariVersion = browserVersion 
+      }
+
+      // Are we running 12 or newer?
+      if (browserName.toLowerCase() === 'safari' && parseInt(safariVersion, 10) >= 12 && this.settings.webdriver.start_process === true) {
         return this.executeProtocolAction('getElementProperty', ['hidden']).then(result => ({
           value: result.value === false
         }));

--- a/lib/api/element-commands/isVisible.js
+++ b/lib/api/element-commands/isVisible.js
@@ -52,7 +52,7 @@ class IsVisible extends BaseElementCommand {
     if (this.api.capabilities) {
       // FIXME: temporary fix to get safari working
       const {browserName} = this.api.capabilities;
-      if (browserName.toLowerCase() === 'safari') {
+      if (browserName.toLowerCase() === 'safari' && this.settings.webdriver.start_process === true) {
         return this.executeProtocolAction('getElementProperty', ['hidden']).then(result => ({
           value: result.value === false
         }));

--- a/lib/api/element-commands/isVisible.js
+++ b/lib/api/element-commands/isVisible.js
@@ -51,11 +51,16 @@ class IsVisible extends BaseElementCommand {
   protocolAction() {
     if (this.api.capabilities) {
       // FIXME: temporary fix to get safari working
-      const {browserName} = this.api.capabilities;
+      const {browserName, browserVersion} = this.api.capabilities;
+      // Are we running Safaridriver locally?
       if (browserName.toLowerCase() === 'safari' && this.settings.webdriver.start_process === true) {
-        return this.executeProtocolAction('getElementProperty', ['hidden']).then(result => ({
-          value: result.value === false
-        }));
+        // Is it Safari 12 or newer?
+        if (parseInt(browserVersion, 10) >= 12) { 
+          // Then we need to use this w3c protocol action
+          return this.executeProtocolAction('getElementProperty', ['hidden']).then(result => ({
+            value: result.value === false
+          }));
+        }
       }
     }
 

--- a/lib/api/element-commands/isVisible.js
+++ b/lib/api/element-commands/isVisible.js
@@ -52,15 +52,11 @@ class IsVisible extends BaseElementCommand {
     if (this.api.capabilities) {
       // FIXME: temporary fix to get safari working
       const {browserName, browserVersion} = this.api.capabilities;
-      // Are we running Safaridriver locally?
-      if (browserName.toLowerCase() === 'safari' && this.settings.webdriver.start_process === true) {
-        // Is it Safari 12 or newer?
-        if (parseInt(browserVersion, 10) >= 12) { 
-          // Then we need to use this w3c protocol action
-          return this.executeProtocolAction('getElementProperty', ['hidden']).then(result => ({
-            value: result.value === false
-          }));
-        }
+      // Are we running Safaridriver locally and is it Safari 12 or newer?
+      if (browserName.toLowerCase() === 'safari' && this.settings.webdriver.start_process === true && parseInt(browserVersion, 10) >= 12) {
+        return this.executeProtocolAction('getElementProperty', ['hidden']).then(result => ({
+          value: result.value === false
+        }));
       }
     }
 


### PR DESCRIPTION

Fixes #2308 

Additional logic around the conditional that uses `getElementProperty` instead of `isVisible` on Safari, as Safari dropped support for JsonWireProtocol in Safaridriver for version 12 and above in favour of w3c support only (see [here](https://developer.apple.com/documentation/webkit/macos_webdriver_commands_for_safari_12_and_later)). However, this breaks support for Appium, which appears to use only JWP, and is used to drive Safari for testing on iOS. It also breaks support in Browserstack, and potentially other device farms. The added logic checks whether `start_process` is set, and if it is, will drop into the workaround, otherwise will use the same logic as non-Safari browsers.

This might cause issues for users calling safaridriver for Safari 12+ through a Selenium Grid. It also may not work for users testing against safaridriver for Safari 11.1 and earlier, as these only appear to support JWP commands. However, in this instance the existing workaround also won't work for these users.

A better solution might be to determine whether a driver being connected to supports w3c, JWP, or both. I don't know if nightwatch already does this (if so, I'm happy to revise this PR if I can be pointed in the right direction), or if it's feasible to do it, but I can't think of a better way of doing it without adding considerable conditional logic that changes as browser drivers get upgraded, or breaking support for some browser configurations.

Finally, the area of the API is currently uncovered by the unit tests (I checked with `npm run mocha-coverage`), I'm sorry to say I didn't add tests to this PR, but #2308 provides a reliable way to test this change end-to-end