### PR TITLE
Update property.js

### DIFF
--- a/lib/api/expect/assertions/element/property.js
+++ b/lib/api/expect/assertions/element/property.js
@@ -3,11 +3,11 @@
  *
  * @example
  * this.demoTest = function (browser) {
- *   browser.expect.element('body').to.have.propery('className').equals('test-class');
- *   browser.expect.element('body').to.have.propery('className').matches(/^something\ else/);
- *   browser.expect.element('body').to.not.have.propery('classList').equals('test-class');
- *   browser.expect.element('body').to.have.propery('classList').deep.equal(['class-one', 'class-two']);
- *   browser.expect.element('body').to.have.propery('classList').contain('class-two');
+ *   browser.expect.element('body').to.have.property('className').equals('test-class');
+ *   browser.expect.element('body').to.have.property('className').matches(/^something\ else/);
+ *   browser.expect.element('body').to.not.have.property('classList').equals('test-class');
+ *   browser.expect.element('body').to.have.property('classList').deep.equal(['class-one', 'class-two']);
+ *   browser.expect.element('body').to.have.property('classList').contain('class-two');
  * };
  *
  * @method property


### PR DESCRIPTION
Fix typo in API definition examples

Should fix #2329 

No change to code behaviour but, assuming the comment block is used to build the API reference doc, should remove a typo.
