### PR TITLE
api-docs: update css

### DIFF
--- a/lib/api/expect/assertions/element/css.js
+++ b/lib/api/expect/assertions/element/css.js
@@ -15,7 +15,7 @@
  *
  * @method css
  * @param {string} property The css property name
- * @param {string} [message] Optional log message to display in the output. If missing, one is displayed by default.*
+ * @param {string} [message] Optional log message to display in the output. If missing, one is displayed by default.
  * @display .css(property)
  * @since v0.7
  * @api expect.element


### PR DESCRIPTION
Typo: An asterisk in the wrong place that was getting rendered into the docs.
