### PR TITLE
Adds a --color arg to preserve color when running in parallel on CI

### DIFF
--- a/lib/runner/cli/argv-setup.js
+++ b/lib/runner/cli/argv-setup.js
@@ -171,6 +171,10 @@ module.exports = new (function() {
         .description('Where to save the (JUnit XML) test reports.')
         .alias('o');
 
+      // $ nightwatch --color
+      this.command('color')
+        .description('Enable colors, even when running on CI')
+
       // $ nightwatch --headless
       this.command('headless')
         .description('Launch the browser (Chrome or Firefox) in headless mode.');

--- a/lib/settings/settings.js
+++ b/lib/settings/settings.js
@@ -257,7 +257,7 @@ class Settings {
   }
 
   setColorOutput() {
-    if (isCI) {
+    if (isCI && !this.argv.color) {
       this.settings.disable_colors = true;
     }
   }

--- a/test/src/runner/cli/testCliRunner.js
+++ b/test/src/runner/cli/testCliRunner.js
@@ -317,6 +317,29 @@ describe('Test CLI Runner', function() {
     assert.strictEqual(runner.globals.settings.output_folder, 'test-output-folder');
   });
 
+  it('should disable color if running on CI', function() {
+    process.env.CI = 'true';
+    registerNoSettingsJsonMock();
+    const CliRunner = common.require('runner/cli/cli.js');
+    let runner = new CliRunner({
+      config: './nightwatch.json',
+    }).setup();
+
+    assert.strictEqual(runner.test_settings.disable_colors, true);
+  });
+
+  it('should not disable color if running on CI and CLI `--color` arg is provided', function() {
+    process.env.CI = 'true';
+    registerNoSettingsJsonMock();
+    const CliRunner = common.require('runner/cli/cli.js');
+    let runner = new CliRunner({
+      config: './nightwatch.json',
+      color: true,
+    }).setup();
+
+    assert.strictEqual(runner.test_settings.disable_colors, false);
+  });
+
   it('testSetOutputFolder', function() {
     mockery.registerMock('fs', {
       statSync: function(module) {


### PR DESCRIPTION
### What

This PR adds a long CLI option `--color`. If specified, it will skip disabling colors when CI is detected.
 
### Why
I noticed that in the newest Nightwatch version, if CI is detected we automatically set the `disable_colors` setting. This makes it harder to debug tests running on CI (especially in parallel) when color is desirable.

From my testing it also looks like the `is-ci` packages doesn't check for the value of .e.g `CI` env var, merely for it's existence. This is why it wasn't possible for me to enable colors by simply specifying `CI=false`.

I haven't found an existing setting for this, so I provided a new CLI argument. We can name it anyway you want, this is just a proposal.