### PR TITLE
Do not disable colors in CI environments

### DIFF
--- a/lib/settings/settings.js
+++ b/lib/settings/settings.js
@@ -2,7 +2,6 @@ const dotenv = require('dotenv');
 const defaultsDeep = require('lodash.defaultsdeep');
 const lodashClone = require('lodash.clone');
 const lodashMerge = require('lodash.merge');
-const isCI = require('is-ci');
 const Defaults = require('./defaults.js');
 const Utils = require('../utils');
 const {Logger} = Utils;
@@ -256,12 +255,6 @@ class Settings {
     }
   }
 
-  setColorOutput() {
-    if (isCI) {
-      this.settings.disable_colors = true;
-    }
-  }
-
   /**
    * Validates and parses the test settings
    *
@@ -283,7 +276,6 @@ class Settings {
 
     this.sortSettings();
     this.setGlobalTimeout();
-    this.setColorOutput();
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -412,11 +412,6 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
-    "ci-info": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
-    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -1505,14 +1500,6 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "optional": true
-    },
-    "is-ci": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-      "requires": {
-        "ci-info": "^2.0.0"
-      }
     },
     "is-date-object": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "chai-nightwatch": "^0.4.0",
     "dotenv": "7.0.0",
     "ejs": "^2.5.9",
-    "is-ci": "^2.0.0",
     "lodash.clone": "3.0.3",
     "lodash.defaultsdeep": "^4.6.1",
     "lodash.merge": "^4.6.2",


### PR DESCRIPTION
This pull request addresses #2266 
Most modern CI environments support color output, which is very helpful when troubleshooting CI jobs.
If someone uses an outdated CI server, they should disable colors themselves, which is conveniently supported in the Nightwatch configuration.