### PR TITLE
#2344 Pass custom data into testCase.assertion

### DIFF
--- a/lib/api/_loaders/assertion-scheduler.js
+++ b/lib/api/_loaders/assertion-scheduler.js
@@ -50,6 +50,8 @@ class AssertionScheduler {
     const expected = Utils.isFunction(this.instance.expected) ? this.instance.expected() : this.instance.expected;
     const {abortOnFailure, stackTrace, reporter} = this.opts;
 
+    const { data } = this.instance;
+
     this.runner = new AssertionRunner({
       passed, err: {
         expected,
@@ -60,7 +62,8 @@ class AssertionScheduler {
       abortOnFailure,
       stackTrace,
       reporter,
-      elapsedTime
+      elapsedTime,
+      data
     });
   }
 
@@ -104,9 +107,10 @@ class AssertionScheduler {
       }
 
       const message = this.getFullMessage(passed, elapsedTime);
+      const data = this.data;
       const actual = instance.getActual();
 
-      this.createAssertionRunner({passed, actual, commandCallback, message, elapsedTime});
+      this.createAssertionRunner({passed, actual, commandCallback, message, elapsedTime, data});
 
       // FIXME: Returning the promise here in the event the it's needed in the assertion callback,
       // throws an unhandledRejection when using es6 async because there's no catch in the assertion callback

--- a/lib/api/assertions/_assertionInstance.js
+++ b/lib/api/assertions/_assertionInstance.js
@@ -27,7 +27,6 @@ class AssertionInstance {
 
     if (Utils.isFunction(this.formatMessage)) {
       const format = this.formatMessage();
-
       this.message = format.message;
       if (this.message.includes('%s')) {
         msgReplaceArgs = format.args;

--- a/lib/assertion/assertion-runner.js
+++ b/lib/assertion/assertion-runner.js
@@ -10,9 +10,9 @@ module.exports = class AssertionRunner {
   }
 
   create() {
-    const {passed, err, calleeFn = null, message = '', abortOnFailure = true, stackTrace = ''} = this.opts;
+    const {passed, err, calleeFn = null, message = '', abortOnFailure = true, stackTrace = '', data} = this.opts;
 
-    this.assertion = new NightwatchAssertion(message);
+    this.assertion = new NightwatchAssertion(message, data);
     this.assertion.expected = err.expected;
     this.assertion.actual = err.actual;
     this.assertion.passed = passed;

--- a/lib/assertion/assertion.js
+++ b/lib/assertion/assertion.js
@@ -10,7 +10,7 @@ class NightwatchAssertion {
     return ` - expected ${expectedMsg} but got: ${receivedMsg}`;
   }
 
-  constructor(message) {
+  constructor(message, customData = {}) {
     this.__err = new NightwatchAssertError(message);
     this.__stackTraceTitle = message;
     this.__abortOnFailure = true;
@@ -23,6 +23,7 @@ class NightwatchAssertion {
     this.expected = undefined;
     this.stackTrace = undefined;
     this.passed = undefined;
+    this.customData = customData;
   }
 
   get error() {
@@ -88,7 +89,8 @@ class NightwatchAssertion {
       message : this.message,
       stackTrace : this.passed ? '' : this.error.stack,
       fullMsg : this.message,
-      failure : this.failureMessage !== '' ? this.failureMessage : false
+      failure : this.failureMessage !== '' ? this.failureMessage : false,
+      ...this.customData
     };
   }
 


### PR DESCRIPTION
Issue:
Assert does not contain a screenshots field, which is required to insert a screenshot into the xml report, generated by junit.
Check for more details here https://github.com/nightwatchjs/nightwatch/issues/2344

It is fixed in this PR.

Repo with code example: https://github.com/Dolinskaya/nightwatch-extend-assert-example

@beatfactor 