### PR TITLE
docs: Fix simple typo, stragy -> strategy

### DIFF
--- a/lib/api/protocol/element.js
+++ b/lib/api/protocol/element.js
@@ -4,7 +4,7 @@ const ProtocolAction = require('./_base-action.js');
  * Search for an element on the page, starting from the document root. The located element will be returned as a web element JSON object.
  * First argument to be passed is the locator strategy, which is detailed on the [WebDriver docs](https://www.w3.org/TR/webdriver/#locator-strategies).
  *
- * The locator stragy can be one of:
+ * The locator strategy can be one of:
  * - `css selector`
  * - `link text`
  * - `partial link text`


### PR DESCRIPTION
There is a small typo in lib/api/protocol/element.js.

Should read `strategy` rather than `stragy`.

