### PR TITLE
Add missing space to new error line.

### DIFF
--- a/lib/reporter/reporters/junit.xml.ejs
+++ b/lib/reporter/reporters/junit.xml.ejs
@@ -16,7 +16,7 @@
     if (testcase.failed > 0 && testcase.stackTrace) { %>
       <failure message="<%= testcase.message %>"><%= testcase.stackTrace %></failure><% } 
     if (testcase.errors > 0 && testcase.stackTrace) { %>
-      <error<% if (testcase.lastError && testcase.lastError.message) { %> message="<%= testcase.lastError.message %>" <% } %>type="error"><%= testcase.stackTrace %></error>
+      <error <% if (testcase.lastError && testcase.lastError.message) { %>message="<%= testcase.lastError.message %>" <% } %>type="error"><%= testcase.stackTrace %></error>
     <% } %>
     </testcase>
   <% } %>


### PR DESCRIPTION
When `testcase.lastError` or `testcase.lastError.message` in junit.xml.ejs isn't truthy, Nightwatch is generating invalid XML. The line comes out like `<errortype="error">`, not `<error type="error">`.

This addresses #2396.