### PR TITLE
Remove incorrect cli args from safaridriver. Issue #2375

### DIFF
--- a/lib/runner/wd-instances/safaridriver.js
+++ b/lib/runner/wd-instances/safaridriver.js
@@ -8,7 +8,7 @@ class SafariDriver extends BaseWDServer {
 
   static get acceptedCLIArgs() {
     return [
-      'port', 'p', 'enable', 'legacy', 'w3c'
+      'port', 'p', 'enable'
     ];
   }
 
@@ -66,15 +66,6 @@ class SafariDriver extends BaseWDServer {
       }, []);
 
       cliArgs.push(...argsReduced);
-    }
-
-    const use_legacy_jsonwire = this.settings.use_legacy_jsonwire === undefined ?
-      SafariDriver.useLegacyDriver : this.settings.use_legacy_jsonwire;
-
-    if (use_legacy_jsonwire) {
-      cliArgs.push('--legacy');
-    } else {
-      cliArgs.push('--w3c');
     }
 
     this.settings.cli_args = cliArgs;


### PR DESCRIPTION
Removed the incorrect cli args causing safari driver to exit immediately. Issue #2375. Let me know if there's anything that I've missed or need to update - thanks!

**ps. let me know if there's a need for a test in this PR. I did not find any tests related to safari at this level** 


- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [x] If you're fixing a bug also create an issue if one doesn't exist yet;

- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [ ] Always add unit tests - PRs without tests are most of the times ignored. 