### PR TITLE
take screenshots on each verify or assertion failure

### DIFF
--- a/lib/api/client-commands/end.js
+++ b/lib/api/client-commands/end.js
@@ -1,5 +1,4 @@
 const EventEmitter = require('events');
-const {Logger, Screenshots} = require('../../utils');
 
 /**
  * Ends the session. Uses session protocol command.
@@ -20,27 +19,6 @@ class End extends EventEmitter {
     const client = this.client;
 
     if (this.api.sessionId) {
-      if (this.testFailuresExist() && this.shouldTakeScreenshot()) {
-        Logger.info(`Failures in "${this.api.currentTest.name}". Taking screenshot...`);
-
-        const prefix = `${this.api.currentTest.module}/${this.api.currentTest.name}`;
-        const fileNamePath = Screenshots.getFileName(prefix, false, client.options.screenshots.path);
-
-        this.api.saveScreenshot(fileNamePath, (result, err) => {
-          if (!err && this.client.transport.isResultSuccess(result))  {
-            const assertions = this.api.currentTest.results.assertions || [];
-            if (assertions.length > 0) {
-              const currentAssertion = assertions[assertions.length-1];
-              if (currentAssertion) {
-                currentAssertion.screenshots = currentAssertion.screenshots || [];
-                currentAssertion.screenshots.push(fileNamePath);
-              }
-            }
-          } else {
-            Logger.warn('Error saving screenshot...', err || result);
-          }
-        });
-      }
 
       this.api.session('delete', result => {
         client.session.clearSession();

--- a/lib/api/client-commands/end.js
+++ b/lib/api/client-commands/end.js
@@ -35,20 +35,6 @@ class End extends EventEmitter {
     return this.client.api;
   }
 
-  testFailuresExist() {
-    let currentTest = this.api.currentTest || {};
-
-    if (currentTest.results) {
-      return currentTest.results.errors > 0 || currentTest.results.failed > 0;
-    }
-
-    return null;
-  }
-
-  shouldTakeScreenshot() {
-    return this.api.options.screenshots.enabled && this.api.options.screenshots.on_failure;
-  }
-
   complete(callback, result) {
     if (typeof callback === 'function') {
       callback.call(this.api, result);

--- a/lib/assertion/assertion-runner.js
+++ b/lib/assertion/assertion-runner.js
@@ -47,9 +47,7 @@ module.exports = class AssertionRunner {
     reporter.logAssertResult(this.assertion.getAssertResult());
 
     if (isError) {
-      if (reporter.shouldTakeScreenshot) {
-        await reporter.saveScreenshot(this.assertion.abortOnFailure);     
-      }
+      await reporter.saveFailureScreenshot(this.assertion.abortOnFailure);     
 
       return Promise.reject(assertResult);
     }

--- a/lib/assertion/assertion-runner.js
+++ b/lib/assertion/assertion-runner.js
@@ -1,4 +1,5 @@
 const NightwatchAssertion = require('./assertion.js');
+const {Logger, Screenshots} = require('../utils');
 
 module.exports = class AssertionRunner {
   /**
@@ -46,6 +47,10 @@ module.exports = class AssertionRunner {
     reporter.logAssertResult(this.assertion.getAssertResult());
 
     if (isError) {
+      if (reporter.shouldTakeScreenshot) {
+        await reporter.saveScreenshot(isError, this.assertion);     
+      }
+
       return Promise.reject(assertResult);
     }
 

--- a/lib/assertion/assertion-runner.js
+++ b/lib/assertion/assertion-runner.js
@@ -48,7 +48,7 @@ module.exports = class AssertionRunner {
 
     if (isError) {
       if (reporter.shouldTakeScreenshot) {
-        await reporter.saveScreenshot(isError, this.assertion);     
+        await reporter.saveScreenshot(this.assertion.abortOnFailure);     
       }
 
       return Promise.reject(assertResult);

--- a/lib/index.js
+++ b/lib/index.js
@@ -221,6 +221,9 @@ class NightwatchClient extends EventEmitter {
 
   setReporter(reporter) {
     this.__reporter = reporter;
+    if (reporter && typeof reporter.setClient === 'function') {
+      reporter.setClient(this);
+    }
 
     return this;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ const Settings = require('./settings/settings.js');
 const Transport = require('./transport/transport.js');
 const Element = require('./element');
 const ApiLoader = require('./api');
+const { setNightwatchInstance } = require('./transport/services');
 
 const {LocateStrategy, Locator} = Element;
 const {Logger} = Utils;
@@ -221,9 +222,6 @@ class NightwatchClient extends EventEmitter {
 
   setReporter(reporter) {
     this.__reporter = reporter;
-    if (reporter && typeof reporter.setClient === 'function') {
-      reporter.setClient(this);
-    }
 
     return this;
   }
@@ -388,6 +386,7 @@ class NightwatchClient extends EventEmitter {
     this
       .loadKeyCodes()
       .loadNightwatchApis();
+    setNightwatchInstance(this);
   }
 
   setCurrentTest() {

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -275,14 +275,11 @@ class Reporter extends SimplifiedReporter {
   /**
    * @property check whether take screeenshot on assert failure
    */
-  get shouldTakeScreenshot() {
+  get shouldTakeFailureScreenshot() {
     return !this.unitTestsMode && this.client && this.settings.screenshots && this.settings.screenshots.enabled && this.settings.screenshots.on_failure;
   }
 
-  saveScreenshot(isError) {
-    const prefix = `${this.currentTest.module}/${this.currentTest.name}-test-${this.currentTest.results.tests}`;
-    const fileName = Screenshots.getFileName(prefix, isError, this.settings.screenshots.path);
-    
+  saveScreenshot(fileName) {
     return  new Promise(resolve => {
       this.client.api.saveScreenshot(fileName, (result, err) => {
         if (!err)  {
@@ -294,6 +291,14 @@ class Reporter extends SimplifiedReporter {
         }
       });
     });
+  }
+  
+  async saveFailureScreenshot(isError) {
+    if(this.shouldTakeFailureScreenshot) {
+      const prefix = `${this.currentTest.module}/${this.currentTest.name}-test-${this.currentTest.results.tests}`;
+      const fileName = Screenshots.getFileName(prefix, isError, this.settings.screenshots.path);
+      return this.saveScreenshot(fileName);
+    }
   }
 }
 

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -24,7 +24,7 @@ class Reporter extends SimplifiedReporter {
       testName: '',
       group: addOpts.groupName
     });
-  };
+  }
 
   /**
    * This is the exported property on the Nightwatch api object, which is passed on to tests
@@ -84,6 +84,16 @@ class Reporter extends SimplifiedReporter {
     this.currentContext = context;
 
     this.testResults.setCurrentTest(testcase);
+  }
+  /**
+   * 
+   * @param {NightwatchClient} client 
+   */
+  setClient(client) {
+    /**
+     * @property {NightwatchClient} client current Nightwatch Client instance
+     */
+    this.client = client;
   }
 
   setFileNamePrefix(prefix) {
@@ -261,6 +271,29 @@ class Reporter extends SimplifiedReporter {
 
       this.testResults.logScreenshotFile(fileName);
     }
+  }
+  /**
+   * @property check whether take screeenshot on assert failure
+   */
+  get shouldTakeScreenshot() {
+    return !this.unitTestsMode && this.client && this.settings.screenshots && this.settings.screenshots.enabled && this.settings.screenshots.on_failure;
+  }
+
+  saveScreenshot(isError) {
+    const prefix = `${this.currentTest.module}/${this.currentTest.name}-test-${this.currentTest.results.tests}`;
+    const fileName = Screenshots.getFileName(prefix, isError, this.settings.screenshots.path);
+    
+    return  new Promise(resolve => {
+      this.client.api.saveScreenshot(fileName, (result, err) => {
+        if (!err)  {
+          this.testResults.logScreenshotFile(fileName);
+          resolve(fileName);
+        } else {
+          Logger.warn('Error saving screenshot...', err || result);
+          resolve();
+        }
+      });
+    });
   }
 }
 

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -2,6 +2,7 @@ const Utils = require('../utils');
 const TestResults = require('./results.js');
 const SimplifiedReporter = require('./simplified.js');
 const {Logger, Screenshots} = Utils;
+const { ScreenshotsService } = require('../transport/services');
 
 class Reporter extends SimplifiedReporter {
   /**
@@ -84,16 +85,6 @@ class Reporter extends SimplifiedReporter {
     this.currentContext = context;
 
     this.testResults.setCurrentTest(testcase);
-  }
-  /**
-   * 
-   * @param {NightwatchClient} client 
-   */
-  setClient(client) {
-    /**
-     * @property {NightwatchClient} client current Nightwatch Client instance
-     */
-    this.client = client;
   }
 
   setFileNamePrefix(prefix) {
@@ -276,28 +267,18 @@ class Reporter extends SimplifiedReporter {
    * @property check whether take screeenshot on assert failure
    */
   get shouldTakeFailureScreenshot() {
-    return !this.unitTestsMode && this.client && this.settings.screenshots && this.settings.screenshots.enabled && this.settings.screenshots.on_failure;
+    return !this.unitTestsMode && this.settings.screenshots && this.settings.screenshots.enabled && this.settings.screenshots.on_failure;
   }
-
-  saveScreenshot(fileName) {
-    return  new Promise(resolve => {
-      this.client.api.saveScreenshot(fileName, (result, err) => {
-        if (!err)  {
-          this.testResults.logScreenshotFile(fileName);
-          resolve(fileName);
-        } else {
-          Logger.warn('Error saving screenshot...', err || result);
-          resolve();
-        }
-      });
-    });
-  }
-  
   async saveFailureScreenshot(isError) {
     if(this.shouldTakeFailureScreenshot) {
       const prefix = `${this.currentTest.module}/${this.currentTest.name}-test-${this.currentTest.results.tests}`;
       const fileName = Screenshots.getFileName(prefix, isError, this.settings.screenshots.path);
-      return this.saveScreenshot(fileName);
+      this.testResults.logScreenshotFile(fileName);
+
+      return new Promise((resolve) => {
+        ScreenshotsService.saveScreenshot(fileName, resolve);
+      });
+     
     }
   }
 }

--- a/lib/transport/services.js
+++ b/lib/transport/services.js
@@ -1,0 +1,37 @@
+const {Screenshots, Logger} = require('../utils');
+let __nightwatchInstance = null;
+
+class ScreenshotsService {
+  static saveScreenshot(fileName, callback) {
+    if(__nightwatchInstance) {
+      __nightwatchInstance.transportActions.getScreenshot(
+        __nightwatchInstance.settings.log_screenshot_data,
+        (result) => {
+          Screenshots.writeScreenshotToFile(fileName, result.value, (err) => {
+            if (err) {
+              Logger.error(`Couldn't save screenshot to "${fileName}":`);
+              Logger.error(err);
+            }
+          });
+          callback(result);
+        }
+      );  
+    }
+  }
+}
+
+
+module.exports.ScreenshotsService = ScreenshotsService;
+
+/**
+   * @method set current nightwatch client instance to provide the service
+   * @param {NightwatchClient} instance current nightwatch client instanse
+   */
+module.exports.setNightwatchInstance =   function setNightwatchInstance(instance) {
+  const previousInstance = __nightwatchInstance;
+  __nightwatchInstance = instance;
+
+  return function restoreNightwatchInstance() {
+    __nightwatchInstance = previousInstance;
+  };
+};


### PR DESCRIPTION
In current version, screenshots will be taken only when `.end` command is called,  which means only last failed assertion will contain screenshots. However, in many case, one will expect save screenshots on each failed assertion or verification if they set screenshot options `on_failure` to be `true`. It may fix #2402 and #998. 