### PR TITLE
Add Buildkite to CI coloring support

### DIFF
--- a/lib/settings/settings.js
+++ b/lib/settings/settings.js
@@ -247,8 +247,8 @@ class Settings {
   }
 
   setColorOutput() {
-    const {isCI, CIRCLE, JENKINS, NETLIFY, TRAVIS, GITLAB} = CI_Info;
-    let coloringSupport = CIRCLE || JENKINS || NETLIFY || TRAVIS || GITLAB;
+    const {isCI, CIRCLE, JENKINS, NETLIFY, TRAVIS, GITLAB, BUILDKITE} = CI_Info;
+    let coloringSupport = CIRCLE || JENKINS || NETLIFY || TRAVIS || GITLAB || BUILDKITE;
 
     if (isCI && !coloringSupport) {
       this.settings.disable_colors = true;


### PR DESCRIPTION
This adds Buildkite to the list of CI providers that support coloring output.

Fixes #2422

No tests were updated because it doesn't appear there's any that cover this particular setting.