### PR TITLE
Replacing old links to Selenium documentation with correct links

### DIFF
--- a/lib/api/client-commands/getCookie.js
+++ b/lib/api/client-commands/getCookie.js
@@ -1,7 +1,7 @@
 const ClientCommand = require('./_base-command.js');
 
 /**
- * Retrieve a single cookie visible to the current page. The cookie is returned as a cookie JSON object, as defined [here](https://code.google.com/p/selenium/wiki/JsonWireProtocol#Cookie_JSON_Object).
+ * Retrieve a single cookie visible to the current page. The cookie is returned as a cookie JSON object, as defined [here](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#cookie-json-object).
  *
  * Uses `cookie` protocol command.
  *

--- a/lib/api/client-commands/getCookies.js
+++ b/lib/api/client-commands/getCookies.js
@@ -1,7 +1,7 @@
 const ClientCommand = require('./_base-command.js');
 
 /**
- * Retrieve all cookies visible to the current page. The cookies are returned as an array of cookie JSON object, as defined [here](https://code.google.com/p/selenium/wiki/JsonWireProtocol#Cookie_JSON_Object).
+ * Retrieve all cookies visible to the current page. The cookies are returned as an array of cookie JSON object, as defined [here](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#cookie-json-object).
  *
  * Uses `cookie` protocol command.
  *

--- a/lib/api/client-commands/setCookie.js
+++ b/lib/api/client-commands/setCookie.js
@@ -1,7 +1,7 @@
 const ClientCommand = require('./_base-command.js');
 
 /**
- * Set a cookie, specified as a cookie JSON object, as defined [here](https://code.google.com/p/selenium/wiki/JsonWireProtocol#Cookie_JSON_Object).
+ * Set a cookie, specified as a cookie JSON object, as defined [here](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#cookie-json-object).
  *
  * Uses `cookie` protocol command.
  *


### PR DESCRIPTION
This is purely a documentation update. There are some links to the old Google Code Selenium wiki for the Cookies API reference, which no longer exists. I've found the correct links on the new wiki hosted on Github.