### PR TITLE
Fixed handling ECONNRESET errors (fixes #1936)

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -220,11 +220,11 @@ class HttpRequest extends EventEmitter {
     this.proxyEvents(this.httpRequest, ['error']);
 
     this.httpRequest.setTimeout(this.httpOpts.timeout, () => {
+      this.isAborted = true;
       this.httpRequest.abort();
 
       if (this.shouldRetryRequest()) {
         this.socket.unref();
-        this.isAborted = true;
         this.retryCount = this.retryCount + 1;
 
         this.send();

--- a/lib/testsuite/index.js
+++ b/lib/testsuite/index.js
@@ -371,6 +371,10 @@ class TestSuite {
     this.setReporterCurrentTest().emptyQueue();
 
     return this.createSession()
+      .catch(err => {
+        this.reporter.registerTestError(err);
+        throw err;
+      })
       .then(() => this.runHook('beforeEach'))
       .then(_ => {
         return this.handleRunnable(this.testcase.testName, () => this.testcase.run(this.client));

--- a/lib/transport/transport.js
+++ b/lib/transport/transport.js
@@ -139,6 +139,26 @@ class Transport extends EventEmitter {
     return this;
   }
 
+  onSessionRequestError(request, err) {
+    if (err.code === 'ECONNRESET' && !request.isAborted) {
+      // Request retry in progress.
+      return;
+    }
+    this.handleSessionCreateError(err);
+  }
+
+  onSessionRequestSuccess(request, data, response, isRedirect) {
+    const sessionData = this.parseSessionResponse(data);
+
+    if (sessionData.sessionId) {
+      this.emit('transport:session.create', sessionData, request, response);
+    } else if (isRedirect) {
+      this.followRedirect(request, response);
+    } else {
+      this.handleSessionCreateError(data);
+    }
+  }
+
   createSession() {
     const body = {};
     if (this.settings.capabilities) {
@@ -155,24 +175,8 @@ class Transport extends EventEmitter {
     });
 
     request
-      .on('error', err => {
-        if (err.code === 'ECONNRESET' && !request.isAborted) {
-          // Request retry in progress.
-          return;
-        }
-        this.handleSessionCreateError(err);
-      })
-      .on('success', (data, response, isRedirect) => {
-        const sessionData = this.parseSessionResponse(data);
-
-        if (sessionData.sessionId) {
-          this.emit('transport:session.create', sessionData, request, response);
-        } else if (isRedirect) {
-          this.followRedirect(request, response);
-        } else {
-          this.handleSessionCreateError(data);
-        }
-      })
+      .on('error', err => this.onSessionRequestError(request, err))
+      .on('success', (data, response, isRedirect) => this.onSessionRequestSuccess(request, data, response, isRedirect))
       .post();
 
     return this;

--- a/lib/transport/transport.js
+++ b/lib/transport/transport.js
@@ -155,7 +155,13 @@ class Transport extends EventEmitter {
     });
 
     request
-      .on('error', err => this.handleSessionCreateError(err))
+      .on('error', err => {
+        if (err.code === 'ECONNRESET' && !request.isAborted) {
+          // Request retry in progress.
+          return;
+        }
+        this.handleSessionCreateError(err);
+      })
       .on('success', (data, response, isRedirect) => {
         const sessionData = this.parseSessionResponse(data);
 

--- a/test/sampletests/multiple-tests-with-session-end/sample.js
+++ b/test/sampletests/multiple-tests-with-session-end/sample.js
@@ -1,0 +1,21 @@
+module.exports = {
+  '@desiredCapabilities': {
+    name: 'test-Name'
+  },
+
+  demoTest1: function (client) {
+    client.assert.equal(client.options.desiredCapabilities.name, 'test-Name');
+
+    client.url('http://localhost')
+      .assert.elementPresent('#webdriver')
+      .end();
+  },
+
+  demoTest2: function (client) {
+    client.assert.equal(client.options.desiredCapabilities.name, 'test-Name');
+
+    client.url('http://localhost')
+      .assert.elementPresent('#webdriver')
+      .end();
+  }
+};


### PR DESCRIPTION
- fixed handling of session creation errors during test case run to be reported as test errors
- fixed retries for session creation - errors are now reported only after retry limit is reached
- covered with test
