### PR TITLE
Eliminate type errors due to bad BrowserStack response.

### DIFF
--- a/lib/transport/selenium3.js
+++ b/lib/transport/selenium3.js
@@ -26,21 +26,21 @@ class SeleniumProtocol extends Selenium2 {
       this.reporter && this.reporter.saveErrorScreenshot(result, screenshotContent);
     }
 
-    if (result.value && result.value.message) {
+    if (result && result.value && result.value.message) {
       errorMessage = result.value.message;
     } else if (result && result.state && WebdriverErrors.Response[result.state]) {
       errorMessage = WebdriverErrors.Response[result.state].message;
-    } else if (response.status && response.statusMessage) {
+    } else if (response && response.status && response.statusMessage) {
       errorMessage += ` ${response.status} ${response.statusMessage}`;
     }
 
     return {
       status: -1,
-      state: result.state || '',
+      state: result && result.state || '',
       value : result && result.value || null,
       errorStatus: result && result.status || '',
       error : errorMessage,
-      httpStatusCode: response.statusCode
+      httpStatusCode: response && response.statusCode || -1
     };
   }
 }


### PR DESCRIPTION
This PR fixes #2464. All I'm doing is adding some checks to make sure that values are truthy before trying to reference a member on them.