### PR TITLE
Check for locator strategy in waitFor* commands

### DIFF
--- a/lib/api/element-commands/_waitFor.js
+++ b/lib/api/element-commands/_waitFor.js
@@ -24,13 +24,9 @@ class WaitForElement extends ElementCommand {
     this.expectedValue = 'found';
   }
 
-  validateArgsCount() {}
-
-  setStrategyFromArgs() {
-    if (Utils.isString(this.args[0]) && Utils.isString(this.args[1])) {
-      const strategy = this.args.shift();
-      LocateStrategy.validate(strategy, this.commandName);
-      this.setStrategy(strategy);
+  validateArgsCount() {
+    if (Utils.isString(this.args[0]) && (Utils.isString(this.args[1]) || ElementCommand.isSelectorObject(this.args[1]))) {
+      this.setStrategyFromArgs();
     }
   }
 

--- a/lib/api/element-commands/_waitFor.js
+++ b/lib/api/element-commands/_waitFor.js
@@ -1,5 +1,6 @@
 const Utils = require('../../utils');
 const {AssertionRunner} = require('../../assertion');
+const LocateStrategy = require('../../element').LocateStrategy;
 const ElementCommand = require('../../element').Command;
 
 /*!
@@ -24,6 +25,14 @@ class WaitForElement extends ElementCommand {
   }
 
   validateArgsCount() {}
+
+  setStrategyFromArgs() {
+    if (Utils.isString(this.args[0]) && Utils.isString(this.args[1])) {
+      const strategy = this.args.shift();
+      LocateStrategy.validate(strategy, this.commandName);
+      this.setStrategy(strategy);
+    }
+  }
 
   setupActions() {
     const validate = (result) => this.isResultSuccess(result);

--- a/lib/element/command.js
+++ b/lib/element/command.js
@@ -240,18 +240,19 @@ class ElementCommand extends EventEmitter {
       }
 
       if (Utils.isString(this.args[0]) && (expectedArgs === this.args.length || ElementCommand.isSelectorObject(this.args[1]))) {
-        const strategy = this.args.shift();
-        LocateStrategy.validate(strategy, this.commandName);
-        this.setStrategy(strategy);
+        this.setStrategyFromArgs()
       }
     }
   }
 
-  setStrategyFromArgs() {}
+  setStrategyFromArgs() {
+    const strategy = this.args.shift();
+    LocateStrategy.validate(strategy, this.commandName);
+    this.setStrategy(strategy);
+  }
 
   setArguments(requireValidation) {
     this.validateArgsCount(requireValidation);
-    this.setStrategyFromArgs();
 
     this.__selector = this.args.shift();
 

--- a/test/src/api/commands/testWaitForElementVisible.js
+++ b/test/src/api/commands/testWaitForElementVisible.js
@@ -223,4 +223,43 @@ describe('waitForElementVisible', function() {
       assert.ok(err.message.includes('waitForElement expects second parameter to have a global default (waitForConditionTimeout) to be specified if not passed as the second parameter'));
     });
   });
+
+  it('client.waitForElementVisible() success with custom locator strategy', function () {
+    MockServer
+      .addMock({
+        url: '/wd/hub/session/1352110219202/elements',
+        postdata : '{"using":"xpath","value":"//*div[2]/button"}',
+        method: 'POST',
+        response: JSON.stringify({
+          status: 0,
+          state: 'success',
+          value: [{ELEMENT: '99'}]
+        })
+      })
+      .addMock({
+        url: '/wd/hub/session/1352110219202/element/99/displayed',
+        method: 'GET',
+        response: JSON.stringify({
+          state: 'success',
+          status: 0,
+          value: true
+        })
+      }, true);
+
+    this.client.api.waitForElementVisible('xpath', '//*div[2]/button', function callback(result, instance) {
+      assert.strictEqual(instance.elementId, '99');
+      assert.strictEqual(result.value, true);
+    });
+
+    return this.client.start(function(err) {
+      MockServer.removeMock({
+        url: '/wd/hub/session/1352110219202/elements',
+        method: 'POST'
+      });
+
+      if (err) {
+        throw err;
+      }
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/nightwatchjs/nightwatch/issues/2194

When specifying a locator strategy in a `waitFor*` command, the locator strategy was not taken into account. This PR implements the `setStrategyFromArgs()` method for `WaitForElement` class and sets the locator strategy if the first 2 arguments are of string type.