### PR TITLE
Fixed switchToWindow function

### DIFF
--- a/lib/transport/jsonwire/actions.js
+++ b/lib/transport/jsonwire/actions.js
@@ -105,7 +105,7 @@ module.exports = {
       return TransportActions.post({
         path: '/window',
         data: {
-          name : handle
+          handle
         }
       });
     },


### PR DESCRIPTION
## Issue
During run `browser.switchToWindow` function using Chrome Webdriver, you are getting error 
```
invalid argument 'handle' must be a string
```
even if `handle` was correct.
