### PR TITLE
Fix #2530: Add logs for missing element when running .click()

### DIFF
--- a/lib/api/element-commands/_baseElementCommand.js
+++ b/lib/api/element-commands/_baseElementCommand.js
@@ -88,6 +88,8 @@ class BaseElementCommand extends ElementCommand {
     };
 
     if (shouldRegister) {
+      Utils.Logger.error(err);
+
       this.reporter.registerTestError(err);
       err.registered = true;
     }


### PR DESCRIPTION
This PR fixes #2530 by adding a single log in cases when element was not found running an element command, such as `.click()` or `.getText()`. 
