### PR TITLE
update the status of testSuite in client transport

### DIFF
--- a/lib/testsuite/index.js
+++ b/lib/testsuite/index.js
@@ -309,10 +309,10 @@ class TestSuite {
         itemKey: process.env.__NIGHTWATCH_ENV_LABEL,
         results: this.reporter.exportResults()
       }));
-    } else {
-      this.client.transport.testSuiteFinished(failures);
-      this.client.session.finished(failures ? 'FAILED' : '');
-    }
+    } 
+    this.client.transport.testSuiteFinished(failures);
+    this.client.session.finished(failures ? 'FAILED' : '');
+    
 
     return this;
   }


### PR DESCRIPTION
## Issue
- When running tests in multiple environments in parallel on a cloud testing platform (e.g. BrowserStack), the status of the test is not sent. Even if the test ran successfully or failed the status at the cloud testing platform is unmarked.

### Steps to recreate the issue
- Run a positive test using env browserstack.chrome, browserstack.firefox `npx nightwatch <test_file> --env browserstack.firefox,browserstack.chrome`
- After the test runs successfully you can observe the status of the test marked as `unmarked` on the BrowserStack dashboard.

### Changes
- Running the test in multiple environments uses child processes and we need to update the status in the transport layer by calling `this.client.transport.testSuiteFinished(failures)` irrespective of whether it's a child process or not.
- So moved the lines `this.client.transport.testSuiteFinished(failures)` and `this.client.session.finished(failures ? 'FAILED' : '')` out of else condition 