### PR TITLE
fix: xml output generation for parallel tests

### DIFF
--- a/lib/reporter/global-reporter.js
+++ b/lib/reporter/global-reporter.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const Concurrency = require('../runner/concurrency/concurrency.js');
 const DefaultSettings = require('../settings/defaults.js');
 const Utils = require('../utils');
 const Results = require('./results.js');
@@ -49,10 +50,12 @@ module.exports = class GlobalReporter {
   }
 
   setupChildProcessListener(emitter) {
-    emitter.on('message', data => {
-      data = JSON.parse(data);
-      this.addTestSuiteResults(data.results);
-    });
+    if (!Concurrency.isTestWorker()) {
+      emitter.on('message', data => {
+        data = JSON.parse(data);
+        this.addTestSuiteResults(data.results);
+      });
+    }
   }
 
   create(startTime) {

--- a/lib/reporter/global-reporter.js
+++ b/lib/reporter/global-reporter.js
@@ -51,7 +51,7 @@ module.exports = class GlobalReporter {
   setupChildProcessListener(emitter) {
     const Concurrency = require('../runner/concurrency/concurrency.js');
 
-    if (Concurrency.isMasterProcess()) {
+    if (Concurrency.isMasterProcess() || Concurrency.isChildProcess()) {
       emitter.on('message', data => {
         data = JSON.parse(data);
         this.addTestSuiteResults(data.results);
@@ -265,4 +265,3 @@ module.exports = class GlobalReporter {
     ]);
   }
 };
-

--- a/lib/reporter/global-reporter.js
+++ b/lib/reporter/global-reporter.js
@@ -49,14 +49,10 @@ module.exports = class GlobalReporter {
   }
 
   setupChildProcessListener(emitter) {
-    const Concurrency = require('../runner/concurrency/concurrency.js');
-
-    if (Concurrency.isMasterProcess() || Concurrency.isChildProcess()) {
-      emitter.on('message', data => {
-        data = JSON.parse(data);
-        this.addTestSuiteResults(data.results);
-      });
-    }
+    emitter.on('message', data => {
+      data = JSON.parse(data);
+      this.addTestSuiteResults(data.results);
+    });
   }
 
   create(startTime) {


### PR DESCRIPTION
Fixes #2728 

**Overview**
XML output files are not generated when running parallel tests on multiple browsers, because when we run concurrent tests, we only check the master process to push the results to the 'GlobalReporter', but in fact, the tests are spawn through the child process.