### PR TITLE
Method mapping for timeouts

### DIFF
--- a/lib/api/protocol/timeouts.js
+++ b/lib/api/protocol/timeouts.js
@@ -32,7 +32,6 @@ module.exports = class Timeouts extends ProtocolAction {
     return [
       'script',
       'implicit',
-      'page load',
       'pageLoad'
     ];
   }

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -49,10 +49,9 @@ module.exports = class MethodMappings {
         // Timeouts
         ///////////////////////////////////////////////////////////
         async setTimeoutType(type, value) {
-
-          const waits = {};
-          waits[type] = value;
-          await this.driver.manage().setTimeouts(waits);
+          await this.driver.manage().setTimeouts({
+            [type]: value
+          });
 
           return {
             value: null

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -48,32 +48,31 @@ module.exports = class MethodMappings {
         ///////////////////////////////////////////////////////////
         // Timeouts
         ///////////////////////////////////////////////////////////
-        setTimeoutType(type, value) {
-          return TransportActions.post({
-            path: '/timeouts',
-            data: {
-              type: type,
-              ms: value
-            }
-          });
+        async setTimeoutType(type, value) {
+
+          const waits = {};
+          waits[type] = value;
+          await this.driver.manage().setTimeouts(waits);
+
+          return {
+            value: null
+          };
         },
 
-        setTimeoutsAsyncScript(value) {
-          return TransportActions.post({
-            path: '/timeouts/async_script',
-            data: {
-              ms: value
-            }
-          });
+        async setTimeoutsAsyncScript(value) {
+          await this.driver.manage().setTimeouts({script: value});
+
+          return  {
+            value: null
+          };
         },
 
-        setTimeoutsImplicitWait(value) {
-          return TransportActions.post({
-            path: '/timeouts/implicit_wait',
-            data: {
-              ms: value
-            }
-          });
+        async setTimeoutsImplicitWait(value) {
+          await this.driver.manage().setTimeouts({implicit: value});
+
+          return  {
+            value: null
+          };
         },
 
         getTimeouts: '/timeouts',


### PR DESCRIPTION
### Changes
- refactored method mapping for timeouts.
- dropped the support of `type=page load` for timeout as it is not supported by selenium-webdriver