### PR TITLE
refactor transport testcases

### DIFF
--- a/lib/transport/factory.js
+++ b/lib/transport/factory.js
@@ -37,28 +37,25 @@ module.exports = class TransportFactory {
     const {settings, argv} = nightwatchInstance;
     let {browserName} = settings.desiredCapabilities;
 
-    if (argv.chrome) {
+    if (argv && argv.chrome) {
       browserName = Browser.CHROME;
-    } else if (argv.firefox) {
+    } else if (argv && argv.firefox) {
       browserName = Browser.FIREFOX;
-    } else if (argv.safari) {
+    } else if (argv && argv.safari) {
       browserName = Browser.SAFARI;
-    } else if (argv.edge) {
+    } else if (argv && argv.edge) {
       browserName = Browser.EDGE;
+    } else if (BrowsersLowerCase[browserName.toLowerCase()]) {
+      browserName = BrowsersLowerCase[browserName.toLowerCase()];
     } else {
-      let browserLowerCaseName = browserName.toLowerCase();
-      browserName = BrowsersLowerCase[browserLowerCaseName];
+      const didYouMean = require('didyoumean');
+      const browsersList = Object.values(Browser);
+      const resultMeant = didYouMean(browserName, browsersList);
+  
+      throw new Error(`Unknown browser: "${browserName}"${resultMeant ? ('; did you mean "' + resultMeant + '"?') : ''}`);
     }
 
-    if (browserName) {
-      return browserName;
-    }
-
-    const didYouMean = require('didyoumean');
-    const browsersList = Object.values(Browser);
-    const resultMeant = didYouMean(browserName, browsersList);
-
-    throw new Error(`Unknown browser: "${browserName}"${resultMeant ? ('; did you mean "' + resultMeant + '"?') : ''}`);
+    return browserName;
   }
 
   static create(nightwatchInstance) {

--- a/lib/transport/factory.js
+++ b/lib/transport/factory.js
@@ -34,16 +34,16 @@ module.exports = class TransportFactory {
   }
 
   static getBrowserName(nightwatchInstance) {
-    const {settings, argv} = nightwatchInstance;
+    const {settings, argv = {}} = nightwatchInstance;
     let {browserName} = settings.desiredCapabilities;
 
-    if (argv && argv.chrome) {
+    if (argv.chrome) {
       browserName = Browser.CHROME;
-    } else if (argv && argv.firefox) {
+    } else if (argv.firefox) {
       browserName = Browser.FIREFOX;
-    } else if (argv && argv.safari) {
+    } else if (argv.safari) {
       browserName = Browser.SAFARI;
-    } else if (argv && argv.edge) {
+    } else if (argv.edge) {
       browserName = Browser.EDGE;
     } else if (BrowsersLowerCase[browserName.toLowerCase()]) {
       browserName = BrowsersLowerCase[browserName.toLowerCase()];

--- a/test/src/index/testCreateTransport.js
+++ b/test/src/index/testCreateTransport.js
@@ -2,20 +2,20 @@ const assert = require('assert');
 const nock = require('nock');
 const common = require('../../common.js');
 const NightwatchClient = common.require('index.js');
-const Selenium2 = common.require('transport/jsonwire/selenium2.js');
 const WebDriver = common.require('transport/webdriver');
 const JsonWire = common.require('transport/jsonwire');
-const Selenium3 = common.require('transport/selenium3');
+const Selenium = common.require('transport/selenium-webdriver/selenium.js');
 const Browserstack = common.require('transport/browserstack');
 
 describe('Transport.create()', function () {
   before(function() {
     try {
       nock.activate();
+    // eslint-disable-next-line no-empty
     } catch (err) {}
   });
 
-  it('test create Transport for Selenium3 external with Firefox', function() {
+  it('test create Transport for Selenium external with Firefox', function() {
     const client = NightwatchClient.client({
       selenium: {
         start_process: false
@@ -27,11 +27,11 @@ describe('Transport.create()', function () {
       selenium_host: 'remote.url'
     });
 
-    assert.ok(client.transport instanceof Selenium3);
+    assert.ok(client.transport instanceof Selenium);
     assert.strictEqual(client.settings.webdriver.host, 'remote.url');
   });
 
-  it('test create Transport for Selenium3 external with Firefox - seleniumHost property', function() {
+  it('test create Transport for Selenium external with Firefox - seleniumHost property', function() {
     const client = NightwatchClient.client({
       selenium: {
         start_process: false
@@ -43,7 +43,7 @@ describe('Transport.create()', function () {
       seleniumHost: 'remote.url'
     });
 
-    assert.ok(client.transport instanceof Selenium3);
+    assert.ok(client.transport instanceof Selenium);
     assert.strictEqual(client.settings.webdriver.host, 'remote.url');
   });
 
@@ -61,7 +61,7 @@ describe('Transport.create()', function () {
     assert.strictEqual(client.settings.webdriver.host, 'remote.url');
   });
 
-  it('test create Transport for Selenium3 external with Chrome', function() {
+  it('test create Transport for Selenium external with Chrome', function() {
     const client = NightwatchClient.client({
       desiredCapabilities: {
         browserName: 'chrome'
@@ -69,11 +69,11 @@ describe('Transport.create()', function () {
       selenium_host: 'remote.url'
     });
 
-    assert.ok(client.transport instanceof Selenium2);
+    assert.ok(client.transport instanceof Selenium);
     assert.strictEqual(client.settings.webdriver.host, 'remote.url');
   });
 
-  it('test create Transport for Selenium3 managed', function() {
+  it('test create Transport for Selenium managed', function() {
     const client = NightwatchClient.client({
       selenium: {
         start_process: true
@@ -86,10 +86,10 @@ describe('Transport.create()', function () {
       }
     });
 
-    assert.ok(client.transport instanceof Selenium3);
+    assert.ok(client.transport instanceof Selenium);
   });
 
-  it('test create Transport for Selenium2 managed explicit version2 setting', function() {
+  xit('test create Transport for Selenium managed explicit version2 setting', function() {
     const client = NightwatchClient.client({
       selenium: {
         version2: true,
@@ -131,9 +131,7 @@ describe('Transport.create()', function () {
     });
 
     assert.ok(client.transport instanceof WebDriver);
-    assert.strictEqual(client.transport instanceof Selenium2, false);
-    assert.strictEqual(client.transport instanceof Selenium3, false);
-    assert.strictEqual(client.transport instanceof JsonWire, false);
+    assert.strictEqual(client.transport instanceof Selenium, false);
   });
 
   it('test create Transport for Chrome managed', function() {
@@ -146,13 +144,10 @@ describe('Transport.create()', function () {
       }
     });
 
-    assert.ok(client.transport instanceof JsonWire);
-    assert.strictEqual(client.transport instanceof Selenium2, false);
-    assert.strictEqual(client.transport instanceof Selenium3, false);
-    assert.strictEqual(client.transport instanceof WebDriver, false);
-    assert.deepStrictEqual(client.session.desiredCapabilities, {
-      browserName: 'chrome',
-      'goog:chromeOptions': {}
+    assert.ok(client.transport instanceof WebDriver);
+    assert.strictEqual(client.transport instanceof Selenium, false);
+    assert.deepStrictEqual(client.transport.desiredCapabilities, {
+      browserName: 'chrome'
     });
   });
 
@@ -163,17 +158,15 @@ describe('Transport.create()', function () {
       },
       desiredCapabilities: {
         browserName: 'chrome',
-        chromeOptions: {
+        'goog:chromeOptions': {
           w3c: true
         }
       }
     });
 
-    assert.strictEqual(client.transport instanceof JsonWire, false);
-    assert.strictEqual(client.transport instanceof Selenium2, false);
-    assert.strictEqual(client.transport instanceof Selenium3, false);
-    assert.strictEqual(client.transport instanceof WebDriver, true);
-    assert.deepStrictEqual(client.session.desiredCapabilities, {
+    assert.ok(client.transport instanceof WebDriver);
+    assert.strictEqual(client.transport instanceof Selenium, false);
+    assert.deepStrictEqual(client.transport.desiredCapabilities, {
       browserName: 'chrome',
       'goog:chromeOptions': {
         w3c: true
@@ -188,17 +181,15 @@ describe('Transport.create()', function () {
       },
       desiredCapabilities: {
         browserName: 'chrome',
-        chromeOptions: {
+        'goog:chromeOptions': {
           w3c: false
         }
       }
     });
 
-    assert.strictEqual(client.transport instanceof JsonWire, true);
-    assert.strictEqual(client.transport instanceof Selenium2, false);
-    assert.strictEqual(client.transport instanceof Selenium3, false);
-    assert.strictEqual(client.transport instanceof WebDriver, false);
-    assert.deepStrictEqual(client.session.desiredCapabilities, {
+    assert.ok(client.transport instanceof WebDriver);
+    assert.strictEqual(client.transport instanceof Selenium, false);
+    assert.deepStrictEqual(client.transport.desiredCapabilities, {
       browserName: 'chrome',
       'goog:chromeOptions': {
         w3c: false
@@ -213,17 +204,15 @@ describe('Transport.create()', function () {
       },
       desiredCapabilities: {
         browserName: 'MicrosoftEdge',
-        edgeOptions: {
+        'ms:edgeOptions': {
           w3c: true
         }
       }
     });
 
-    assert.strictEqual(client.transport instanceof JsonWire, false);
-    assert.strictEqual(client.transport instanceof Selenium2, false);
-    assert.strictEqual(client.transport instanceof Selenium3, false);
-    assert.strictEqual(client.transport instanceof WebDriver, true);
-    assert.deepStrictEqual(client.session.desiredCapabilities, {
+    assert.ok(client.transport instanceof WebDriver);
+    assert.strictEqual(client.transport instanceof Selenium, false);
+    assert.deepStrictEqual(client.transport.desiredCapabilities, {
       browserName: 'MicrosoftEdge',
       'ms:edgeOptions': {
         w3c: true
@@ -241,13 +230,10 @@ describe('Transport.create()', function () {
       }
     });
 
-    assert.ok(client.transport instanceof JsonWire);
-    assert.strictEqual(client.transport instanceof Selenium2, false);
-    assert.strictEqual(client.transport instanceof Selenium3, false);
-    assert.strictEqual(client.transport instanceof WebDriver, false);
-    assert.deepStrictEqual(client.session.desiredCapabilities, {
-      browserName: 'MicrosoftEdge',
-      'ms:edgeOptions': {}
+    assert.ok(client.transport instanceof WebDriver);
+    assert.strictEqual(client.transport instanceof Selenium, false);
+    assert.deepStrictEqual(client.transport.desiredCapabilities, {
+      browserName: 'MicrosoftEdge'
     });
   });
 
@@ -264,11 +250,9 @@ describe('Transport.create()', function () {
       }
     });
 
-    assert.strictEqual(client.transport instanceof JsonWire, true);
-    assert.strictEqual(client.transport instanceof Selenium2, false);
-    assert.strictEqual(client.transport instanceof Selenium3, false);
-    assert.strictEqual(client.transport instanceof WebDriver, false);
-    assert.deepStrictEqual(client.session.desiredCapabilities, {
+    assert.strictEqual(client.transport instanceof Selenium, false);
+    assert.strictEqual(client.transport instanceof WebDriver, true);
+    assert.deepStrictEqual(client.transport.desiredCapabilities, {
       browserName: 'MicrosoftEdge',
       'ms:edgeOptions': {
         w3c: false
@@ -277,9 +261,7 @@ describe('Transport.create()', function () {
   });
 
   it('test create Transport for Safari managed', function() {
-    const Transport = common.require('transport/index.js');
-
-    let safariDriver = Transport.create({
+    let client = NightwatchClient.client({
       settings: {
         selenium: {
           start_process: false
@@ -293,7 +275,7 @@ describe('Transport.create()', function () {
       }
     });
 
-    assert.ok(safariDriver instanceof WebDriver);
+    assert.ok(client.transport instanceof WebDriver);
   });
 
   it('test create Transport for Safari remote', function() {
@@ -301,6 +283,7 @@ describe('Transport.create()', function () {
 
     let safariDriver = Transport.create({
       settings: {
+        use_selenium_webdriver: true,
         selenium: {
           start_process: false
         },
@@ -314,10 +297,8 @@ describe('Transport.create()', function () {
       }
     });
 
-    assert.ok(safariDriver instanceof JsonWire);
-    assert.strictEqual(safariDriver instanceof Selenium2, false);
-    assert.strictEqual(safariDriver instanceof Selenium3, false);
-    assert.strictEqual(safariDriver instanceof WebDriver, false);
+    assert.ok(safariDriver instanceof WebDriver);
+    assert.strictEqual(safariDriver instanceof Selenium, false);
   });
 
   it('test create Transport for Chrome managed and no selenium settings', function() {
@@ -325,6 +306,7 @@ describe('Transport.create()', function () {
 
     let chromeDriver = Transport.create({
       settings: {
+        use_selenium_webdriver: true,
         webdriver: {
           start_process: true
         },
@@ -334,10 +316,8 @@ describe('Transport.create()', function () {
       }
     });
 
-    assert.ok(chromeDriver instanceof JsonWire);
-    assert.strictEqual(chromeDriver instanceof Selenium2, false);
-    assert.strictEqual(chromeDriver instanceof Selenium3, false);
-    assert.strictEqual(chromeDriver instanceof WebDriver, false);
+    assert.ok(chromeDriver instanceof WebDriver);
+    assert.strictEqual(chromeDriver instanceof Selenium, false);
   });
 
   it('test create Transport for WebDriver managed and no selenium settings', function() {
@@ -351,8 +331,7 @@ describe('Transport.create()', function () {
     });
 
     assert.ok(client.transport instanceof WebDriver);
-    assert.strictEqual(client.transport instanceof Selenium2, false);
-    assert.strictEqual(client.transport instanceof Selenium3, false);
+    assert.strictEqual(client.transport instanceof Selenium, false);
   });
 
   it('test check for ssl when webdriver port is 443', function () {
@@ -360,6 +339,7 @@ describe('Transport.create()', function () {
 
     const instance = {
       settings: {
+        use_selenium_webdriver: true,
         webdriver: {
           start_process: true,
           port: 443,
@@ -386,18 +366,12 @@ describe('Transport.create()', function () {
       selenium_host: 'remote.host'
     });
 
-    assert.ok(client.transport instanceof Selenium2);
+    assert.ok(client.transport instanceof Selenium);
 
     const elementId = client.transport.getElementId({
       'element-6066-11e4-a52e-4f735466cecf': 'abcd-123'
     });
     assert.strictEqual(elementId, 'abcd-123');
-
-    const elementId2 = client.transport.getElementId({
-      ELEMENT: 'abcd-1234'
-    });
-    assert.strictEqual(elementId2, 'abcd-1234');
-
     assert.strictEqual(client.settings.webdriver.host, 'remote.host');
     assert.strictEqual(client.settings.webdriver.default_path_prefix, '/wd/hub');
   });
@@ -413,12 +387,12 @@ describe('Transport.create()', function () {
       selenium_host: 'remote.host'
     });
 
-    assert.ok(client.transport instanceof Selenium2);
+    assert.ok(client.transport instanceof Selenium);
     assert.strictEqual(client.settings.webdriver.host, 'remote.host');
     assert.strictEqual(client.settings.webdriver.default_path_prefix, '/wd/hub');
-    assert.strictEqual(client.transport instanceof Selenium3, false);
   });
 
+  //TODO: Make the test pass after browserstack works with selenium-webdriver
   it('test create Transport for Browserstack', function(done) {
     assert.throws(function() {
       NightwatchClient.client({
@@ -508,6 +482,7 @@ describe('Transport.create()', function () {
 
   });
 
+  //TODO: Make the test pass after browserstack works with selenium-webdriver
   it('test create Transport for Browserstack with failures', function(done) {
     const client = NightwatchClient.client({
       webdriver: {

--- a/test/src/index/testCreateTransport.js
+++ b/test/src/index/testCreateTransport.js
@@ -89,24 +89,6 @@ describe('Transport.create()', function () {
     assert.ok(client.transport instanceof Selenium);
   });
 
-  xit('test create Transport for Selenium managed explicit version2 setting', function() {
-    const client = NightwatchClient.client({
-      selenium: {
-        version2: true,
-        start_process: true
-      },
-      webdriver: {
-        start_process: false
-      },
-      desiredCapabilities: {
-        browserName: 'firefox'
-      }
-    });
-
-    assert.ok(client.transport instanceof Selenium2);
-    assert.strictEqual(client.transport instanceof Selenium3, false);
-  });
-
   it('test create Transport with unknown browser', function() {
     assert.throws(function() {
       NightwatchClient.client({


### PR DESCRIPTION
### Changes
- refactor test cases to work with selenium-webdriver.
- refactor `/transport/factory.js` to support `didyoumean` in case of wrong browsername

### Needs Work
- need to refactor test cases in transport for browserstack.