### PR TITLE
send last error to browserstack transport reason

### DIFF
--- a/lib/testsuite/index.js
+++ b/lib/testsuite/index.js
@@ -310,7 +310,7 @@ class TestSuite {
         results: this.reporter.exportResults()
       }));
     } 
-    this.client.transport.testSuiteFinished(failures);
+    this.client.transport.testSuiteFinished(failures, this.reporter.testResults.lastError);
     this.client.session.finished(failures ? 'FAILED' : '');
     
 

--- a/lib/transport/browserstack.js
+++ b/lib/transport/browserstack.js
@@ -1,6 +1,7 @@
 const request = require('request-promise');
+const stripAnsi = require('strip-ansi');
 const Selenium3 = require('./selenium3.js');
-const {Logger, stripControlChars, stripAnsiChars} = require('../utils');
+const {Logger} = require('../utils');
 
 class Browserstack extends Selenium3 {
   static get ApiUrl() {
@@ -103,7 +104,7 @@ class Browserstack extends Selenium3 {
         method: 'PUT',
         body: {
           status: failures ? 'failed' : 'passed',
-          reason: stripAnsiChars(lastError ? `${lastError.name}: ${lastError.message}`: '')
+          reason: stripAnsi(lastError ? `${lastError.name}: ${lastError.message}`: '')
         },
         auth: {
           user: this.username,

--- a/lib/transport/browserstack.js
+++ b/lib/transport/browserstack.js
@@ -92,7 +92,7 @@ class Browserstack extends Selenium3 {
     }
   }
 
-  async testSuiteFinished(failures, lastError = '') {
+  async testSuiteFinished(failures, lastError = {}) {
     try {
       // eslint-disable-next-line no-console
       console.log('\n  ' + 'See more info, video, & screenshots on Browserstack:\n' +

--- a/lib/transport/browserstack.js
+++ b/lib/transport/browserstack.js
@@ -1,6 +1,6 @@
 const request = require('request-promise');
 const Selenium3 = require('./selenium3.js');
-const {Logger, stripControlChars} = require('../utils');
+const {Logger, stripControlChars, stripAnsiChars} = require('../utils');
 
 class Browserstack extends Selenium3 {
   static get ApiUrl() {
@@ -92,7 +92,7 @@ class Browserstack extends Selenium3 {
     }
   }
 
-  async testSuiteFinished(failures, lastError = {}) {
+  async testSuiteFinished(failures, lastError) {
     try {
       // eslint-disable-next-line no-console
       console.log('\n  ' + 'See more info, video, & screenshots on Browserstack:\n' +
@@ -103,7 +103,7 @@ class Browserstack extends Selenium3 {
         method: 'PUT',
         body: {
           status: failures ? 'failed' : 'passed',
-          reason: stripControlChars(`${lastError.name}: ${lastError.message}`)
+          reason: stripAnsiChars(lastError ? `${lastError.name}: ${lastError.message}`: '')
         },
         auth: {
           user: this.username,

--- a/lib/transport/browserstack.js
+++ b/lib/transport/browserstack.js
@@ -1,7 +1,6 @@
 const request = require('request-promise');
 const Selenium3 = require('./selenium3.js');
-const {Logger} = require('../utils');
-const Utils = require('../utils');
+const {Logger, stripControlChars} = require('../utils');
 
 class Browserstack extends Selenium3 {
   static get ApiUrl() {
@@ -104,7 +103,7 @@ class Browserstack extends Selenium3 {
         method: 'PUT',
         body: {
           status: failures ? 'failed' : 'passed',
-          reason: Utils.stripControlChars(lastError.name+' '+lastError.message)
+          reason: stripControlChars(lastError.name+' '+lastError.message)
         },
         auth: {
           user: this.username,

--- a/lib/transport/browserstack.js
+++ b/lib/transport/browserstack.js
@@ -103,7 +103,7 @@ class Browserstack extends Selenium3 {
         method: 'PUT',
         body: {
           status: failures ? 'failed' : 'passed',
-          reason: stripControlChars(lastError.name+' '+lastError.message)
+          reason: stripControlChars(`${lastError.name} ${lastError.message}`)
         },
         auth: {
           user: this.username,

--- a/lib/transport/browserstack.js
+++ b/lib/transport/browserstack.js
@@ -103,7 +103,7 @@ class Browserstack extends Selenium3 {
         method: 'PUT',
         body: {
           status: failures ? 'failed' : 'passed',
-          reason: stripControlChars(`${lastError.name} ${lastError.message}`)
+          reason: stripControlChars(`${lastError.name}: ${lastError.message}`)
         },
         auth: {
           user: this.username,

--- a/lib/transport/browserstack.js
+++ b/lib/transport/browserstack.js
@@ -92,7 +92,7 @@ class Browserstack extends Selenium3 {
     }
   }
 
-  async testSuiteFinished(failures) {
+  async testSuiteFinished(failures, lastError) {
     try {
       // eslint-disable-next-line no-console
       console.log('\n  ' + 'See more info, video, & screenshots on Browserstack:\n' +
@@ -103,7 +103,7 @@ class Browserstack extends Selenium3 {
         method: 'PUT',
         body: {
           status: failures ? 'failed' : 'passed',
-          reason: ''
+          reason: lastError
         },
         auth: {
           user: this.username,

--- a/lib/transport/browserstack.js
+++ b/lib/transport/browserstack.js
@@ -92,7 +92,7 @@ class Browserstack extends Selenium3 {
     }
   }
 
-  async testSuiteFinished(failures, lastError) {
+  async testSuiteFinished(failures, lastError = '') {
     try {
       // eslint-disable-next-line no-console
       console.log('\n  ' + 'See more info, video, & screenshots on Browserstack:\n' +

--- a/lib/transport/browserstack.js
+++ b/lib/transport/browserstack.js
@@ -1,6 +1,7 @@
 const request = require('request-promise');
 const Selenium3 = require('./selenium3.js');
 const {Logger} = require('../utils');
+const Utils = require('../utils');
 
 class Browserstack extends Selenium3 {
   static get ApiUrl() {
@@ -103,7 +104,7 @@ class Browserstack extends Selenium3 {
         method: 'PUT',
         body: {
           status: failures ? 'failed' : 'passed',
-          reason: lastError
+          reason: Utils.stripControlChars(lastError.name+' '+lastError.message)
         },
         auth: {
           user: this.username,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const mkpath = require('mkpath');
+const stripAnsi = require('strip-ansi');
 
 const BrowserName = require('./browsername.js');
 const LocateStrategy = require('./locatestrategy.js');
@@ -492,6 +493,10 @@ class Utils {
       /[\x00-\x09\x0B-\x0C\x0E-\x1F\x7F-\x9F]/g,
       ''
     );
+  }
+
+  static stripAnsiChars(input) {
+    return stripAnsi(input);
   }
 
   static relativeUrl(url) {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -495,10 +495,6 @@ class Utils {
     );
   }
 
-  static stripAnsiChars(input) {
-    return stripAnsi(input);
-  }
-
   static relativeUrl(url) {
     return !(url.includes('://'));
   }

--- a/test/src/index/testCreateTransport.js
+++ b/test/src/index/testCreateTransport.js
@@ -548,11 +548,11 @@ describe('Transport.create()', function () {
         nock('https://api.browserstack.com')
           .put('/automate/sessions/1234567.json', {
             status: 'failed',
-            reason: ''
+            reason: 'NightwatchAssertError Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected "visible" but got: "not found"'
           })
           .reply(200, {});
 
-        result = await transport.testSuiteFinished(true);
+        result = await transport.testSuiteFinished(true, {name: 'NightwatchAssertError', message: 'Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected "visible" but got: "not found"'});
         assert.strictEqual(result, true);
         assert.strictEqual(transport.sessionId, null);
 

--- a/test/src/index/testCreateTransport.js
+++ b/test/src/index/testCreateTransport.js
@@ -548,11 +548,11 @@ describe('Transport.create()', function () {
         nock('https://api.browserstack.com')
           .put('/automate/sessions/1234567.json', {
             status: 'failed',
-            reason: 'NightwatchAssertError Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected "visible" but got: "not found"'
+            reason: 'NightwatchAssertError: Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected "visible" but got: "not found" (5400ms)'
           })
           .reply(200, {});
 
-        result = await transport.testSuiteFinished(true, {name: 'NightwatchAssertError', message: 'Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected "visible" but got: "not found"'});
+        result = await transport.testSuiteFinished(true, {name: 'NightwatchAssertError', message: 'Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected [0;32m"visible"[0m but got: [0;31m"not found"[0m [0;90m(5400ms)[0m'});
         assert.strictEqual(result, true);
         assert.strictEqual(transport.sessionId, null);
 


### PR DESCRIPTION
### Changes 
- send the reason of failure to BrowserStack transport.

### Impact
- Before: 
<img width="1144" alt="Screenshot 2021-07-06 at 4 15 04 PM" src="https://user-images.githubusercontent.com/28780767/124587813-b12d2d80-de75-11eb-90d1-69c51eeb76a7.png">

-After: 
<img width="1135" alt="Screenshot 2021-07-06 at 4 14 38 PM" src="https://user-images.githubusercontent.com/28780767/124587899-ce61fc00-de75-11eb-85a0-f4247cf3310b.png">
