### PR TITLE
remove node promise rejection in case of error

### DIFF
--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -77,7 +77,6 @@ class AsyncTree extends EventEmitter{
         let abortOnFailure = false;
 
         if (result instanceof Error) {
-          node.reject(result);
           abortOnFailure = result.abortOnFailure || Utils.isUndefined(result.abortOnFailure);
         } else {
           node.resolve(result);

--- a/test/sampletests/es6await/selenium/failures/verifyWithFailures.js
+++ b/test/sampletests/es6await/selenium/failures/verifyWithFailures.js
@@ -7,8 +7,8 @@ module.exports = {
       selector: '#badElement',
       timeout: 15,
       retryInterval: 15
-    });
-    await client.verify.elementPresent('#weblogin');
+    })
+      .verify.elementPresent('#weblogin');
 
     client.end();
   }

--- a/test/sampletests/es6await/selenium/failures/verifyWithFailures.js
+++ b/test/sampletests/es6await/selenium/failures/verifyWithFailures.js
@@ -1,0 +1,15 @@
+
+module.exports = {
+
+  demoTest: async function (client) {
+   
+    await client.verify.elementPresent({
+      selector: '#badElement',
+      timeout: 15,
+      retryInterval: 15
+    });
+    await client.verify.elementPresent('#weblogin');
+
+    client.end();
+  }
+};

--- a/test/src/runner/testRunnerEs6Async.js
+++ b/test/src/runner/testRunnerEs6Async.js
@@ -70,7 +70,7 @@ describe('testRunner ES6 Async', function() {
     });
   });
 
-  it('test Runner with ES6 async/await tests basic sample', function() {
+  it.only('test Runner with ES6 async/await tests basic sample', function() {
     let testsPath = path.join(__dirname, '../../sampletests/es6await/selenium');
     MockServer.addMock({
       url: '/wd/hub/session/1352110219202/cookie',
@@ -103,6 +103,11 @@ describe('testRunner ES6 Async', function() {
         if (results.modules['failures/sampleWithFailures'].completed.asyncGetCookiesTest.lastError) {
           throw results.modules['failures/sampleWithFailures'].completed.asyncGetCookiesTest.lastError;
         }
+
+        assert.ok('failures/verifyWithFailures' in results.modules);
+        assert.strictEqual(results.modules['failures/verifyWithFailures'].completed.demoTest.assertions.length, 2);
+        assert.ok(results.modules['failures/verifyWithFailures'].completed.demoTest.assertions[0].failure.includes('Expected "is present" but got: "not present"'));
+        assert.strictEqual(results.modules['failures/verifyWithFailures'].completed.demoTest.assertions[1].failure, false);
 
         assert.ok(results.lastError instanceof Error);
         assert.ok(results.lastError.message.includes('is present in 15ms'), results.lastError.message);

--- a/test/src/runner/testRunnerEs6Async.js
+++ b/test/src/runner/testRunnerEs6Async.js
@@ -70,7 +70,7 @@ describe('testRunner ES6 Async', function() {
     });
   });
 
-  it.only('test Runner with ES6 async/await tests basic sample', function() {
+  it('test Runner with ES6 async/await tests basic sample', function() {
     let testsPath = path.join(__dirname, '../../sampletests/es6await/selenium');
     MockServer.addMock({
       url: '/wd/hub/session/1352110219202/cookie',


### PR DESCRIPTION
### Changes
- remove rejection of node promise. It creates unhanded rejection error.

### Impact
- fixes #2794 