### PR TITLE
fix(cli.js): webdriver spawning issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ output
 screenshot.png
 /sample
 /screens
-
+.vscode

--- a/lib/runner/cli/cli.js
+++ b/lib/runner/cli/cli.js
@@ -236,7 +236,6 @@ class CliRunner {
     const {start_process} = webdriver;
     const shouldStartSeleniumProcess = WebDriver.isUsingSeleniumServer(this.test_settings);
     const isTestWorker = this.testRunner.isTestWorker();
-    const testWorkersEnabled = this.isTestWorkersEnabled();
 
     if (shouldStartSeleniumProcess) {
       return true;
@@ -246,7 +245,7 @@ class CliRunner {
       return true;
     }
 
-    return start_process && !Concurrency.isChildProcess() && !testWorkersEnabled;
+    return start_process && !Concurrency.isChildProcess();
   }
 
   isConcurrencyEnabled(modules) {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -380,6 +380,14 @@ class Utils {
     return Utils.checkPath(source, null, false).then(stats => stats.isDirectory());
   }
 
+  static isFolderSync(source) {
+    try {
+      return fs.lstatSync(source).isDirectory(); 
+    } catch (e) {
+      return false;
+    }
+  }
+
   /**
    * @param {string} source
    * @return {Promise}
@@ -394,6 +402,14 @@ class Utils {
         resolve(list);
       });
     });
+  }
+
+  static readDirSync(source) {
+    try {
+      return fs.readdirSync(source);
+    } catch (e) {
+      throw Error(e);
+    }
   }
 
   /**
@@ -430,7 +446,21 @@ class Utils {
       return Utils.fileExistsSync(test);
     }
 
-    return Array.isArray(_source) && _source.length === 1 && Utils.fileExistsSync(_source[0]);
+    if (Array.isArray(_source) && _source.length === 1) {
+      // Check if the source is folder, and contains only a single file
+      const isFolder = Utils.isFolderSync(_source[0]);
+
+      if (isFolder) {
+        // check if single file is present
+        const files = Utils.readDirSync(_source[0]);
+
+        if (files.length === 1) {
+          return Utils.fileExistsSync(_source[0]);
+        }
+      } else {
+        return Utils.fileExistsSync(_source[0]);
+      }
+    }
   }
 
   static getConfigFolder(argv) {

--- a/test/src/runner/cli/testCliRunner.js
+++ b/test/src/runner/cli/testCliRunner.js
@@ -23,7 +23,7 @@ describe('Test CLI Runner', function() {
     let config = {
       src_folders: ['tests'],
       test_settings: {
-        'default': {
+        default: {
           silent: true
         }
       }
@@ -36,9 +36,27 @@ describe('Test CLI Runner', function() {
       src_folders: ['tests'],
       output_folder: false,
       test_settings: {
-        'default': {
+        default: {
           silent: true
         }
+      }
+    });
+
+    mockery.registerMock('./test_worker_enabled.json', {
+      src_folders: ['tests'],
+      output_folder: false,
+      test_settings: {
+        default: {
+          silent: true
+        }
+      },
+      webdriver: {
+        start_process: true,
+        start_session: false
+      },
+      test_workers: {
+        enabled: true,
+        workers: 'auto'
       }
     });
 
@@ -326,6 +344,19 @@ describe('Test CLI Runner', function() {
     assert.strictEqual(runner.globals.settings.output_folder, 'test-output-folder');
     assert.strictEqual(runner.test_settings.globals.waitForConditionTimeout, 11);
     assert.strictEqual(runner.test_settings.globals.retryAssertionTimeout, 11);
+  });
+
+  it('should spawn instance of webdriver when folder with single file is passed', function() {
+    registerNoSettingsJsonMock();
+    const CliRunner = common.require('runner/cli/cli.js');
+    let runner = new CliRunner({
+      config: './test_worker_enabled.json',
+      skiptags: 'home,arctic',
+      tag: 'danger'
+    }).setup();
+
+    assert.strictEqual(runner.isWebDriverManaged(), true);
+    assert.strictEqual(runner.test_settings.tag_filter, 'danger');
   });
 
   it('testSetOutputFolder', function() {
@@ -901,4 +932,3 @@ describe('Test CLI Runner', function() {
   });
 
 });
-


### PR DESCRIPTION
Issue: Nightwatch refuses to start a new session when the test folder is passed to Nightwatch which contains a single test file, or when we pass a tag to Nightwatch CLI, where the tag exists in a single test file.

Possible Solution: Currently, we check if a test worker is enabled and a single file is present, then we don't spawn the Webdriver. I think we shouldn't check for single/multiple files

closes https://github.com/nightwatchjs/nightwatch/issues/2791

Remaining:
 - Tests for `singleSourceFile`