### PR TITLE
Fix: value is redacted in HTTP log in setPassword command

### DIFF
--- a/lib/core/treenode.js
+++ b/lib/core/treenode.js
@@ -1,4 +1,5 @@
 const EventEmitter = require('events');
+const HttpRequest = require('../http/request');
 const Utils = require('../utils');
 
 class TreeNode {
@@ -104,6 +105,8 @@ class TreeNode {
     }
 
     const {args, stackTrace, options} = this;
+
+    HttpRequest.globalSettings = Object.assign({}, HttpRequest.globalSettings, {redactParams: false});
 
     commandFn.stackTrace = stackTrace;
     this.__instance = commandFn.call(this.context, {args, stackTrace, options});

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -84,7 +84,7 @@ class HttpRequest extends EventEmitter {
     this.reqOptions = this.createHttpOptions(options);
     this.hostname = Formatter.formatHostname(this.reqOptions.host, this.reqOptions.port, this.use_ssl);
     this.retryAttempts = this.httpOpts.retry_attempts;
-    this.redact = options.redact || false;
+    this.redact = options.redact || global._redactParams || false;
 
     return this;
   }

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -84,7 +84,7 @@ class HttpRequest extends EventEmitter {
     this.reqOptions = this.createHttpOptions(options);
     this.hostname = Formatter.formatHostname(this.reqOptions.host, this.reqOptions.port, this.use_ssl);
     this.retryAttempts = this.httpOpts.retry_attempts;
-    this.redact = options.redact || global._redactParams || false;
+    this.redact = options.redact || this.__settings.redactParams || false;
 
     return this;
   }

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -515,7 +515,8 @@ module.exports = class MethodMappings {
         },
 
         setElementValueRedacted(...args) {
-          // FIXME: redact password in verbose HTTP logs, it's only redacted in the command logs
+          global._redactParams = true;
+
           return this.methods.session.setElementValue.call(this, ...args);
         },
 

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -516,8 +516,6 @@ module.exports = class MethodMappings {
         },
 
         setElementValueRedacted(...args) {
-          // global._redactParams = true;
-
           HttpRequest.globalSettings = Object.assign({}, HttpRequest.globalSettings, {redactParams: true});
 
           return this.methods.session.setElementValue.call(this, ...args);

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -1,6 +1,7 @@
 const {WebElement} = require('selenium-webdriver');
 const SeleniumWebdriver = require('./');
 const {Logger, isString} = require('../../utils');
+const HttpRequest = require('../../http/request');
 
 module.exports = class MethodMappings {
   get driver() {
@@ -515,7 +516,9 @@ module.exports = class MethodMappings {
         },
 
         setElementValueRedacted(...args) {
-          global._redactParams = true;
+          // global._redactParams = true;
+
+          HttpRequest.globalSettings = Object.assign({}, HttpRequest.globalSettings, {redactParams: true});
 
           return this.methods.session.setElementValue.call(this, ...args);
         },


### PR DESCRIPTION
Description: This PR redact password in verbose HTTP logs

Reference:

before:
![image](https://user-images.githubusercontent.com/8705386/126479250-9fca55bd-710c-4158-8ee1-f78125aaf50d.png)

after:
![image](https://user-images.githubusercontent.com/8705386/126479295-8de09f75-1101-48cb-bf08-8e7d29690326.png)

Remaining:
- need to unset `redactParams` in HttpRequest