### PR TITLE
fix: value is not cleared before setting value

### DIFF
--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -530,7 +530,7 @@ module.exports = class MethodMappings {
             const element = this.getWebElement(webElement);
 
             // clear Element value
-            await this.methods.session.clearElementValue.call(this, webElement);
+            await element.clear();
 
             await element.sendKeys(value);
 

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -528,6 +528,10 @@ module.exports = class MethodMappings {
 
           try {
             const element = this.getWebElement(webElement);
+
+            // clear Element value
+            await this.methods.session.clearElementValue.call(this, webElement);
+
             await element.sendKeys(value);
 
             return {

--- a/test/src/api/protocol/testSetValue.js
+++ b/test/src/api/protocol/testSetValue.js
@@ -6,7 +6,7 @@ describe('setValue command', function () {
     Globals.protocolBefore();
   });
 
-  it.only('should clear value and setValue', function () {
+  it('should clear value and setValue', function () {
     return Globals.protocolTest({
       commandName: 'setValue',
       args: [

--- a/test/src/api/protocol/testSetValue.js
+++ b/test/src/api/protocol/testSetValue.js
@@ -18,7 +18,7 @@ describe('setValue command', function () {
         }
       ],
       assertion: function (opts) {
-        assert.notStrictEqual(-1, ['findElements', 'clearElement', 'sendKeysToElement'].indexOf(opts.command));
+        assert.ok(['findElements', 'clearElement', 'sendKeysToElement'].includes(opts.command));
       }
     });
   });

--- a/test/src/api/protocol/testSetValue.js
+++ b/test/src/api/protocol/testSetValue.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const Globals = require('../../../lib/globals.js');
+
+describe('setValue command', function () {
+  before(function () {
+    Globals.protocolBefore();
+  });
+
+  it.only('should clear value and setValue', function () {
+    return Globals.protocolTest({
+      commandName: 'setValue',
+      args: [
+        'weblogin',
+        'nightwatch',
+        function (result) {
+          assert.deepStrictEqual(result.value, null);
+          assert.deepStrictEqual(result.status, 0);
+        }
+      ],
+      assertion: function (opts) {
+        assert.notStrictEqual(-1, ['findElements', 'clearElement', 'sendKeysToElement'].indexOf(opts.command));
+      }
+    });
+  });
+});


### PR DESCRIPTION
The previous value is now when we use `setValue`