### PR TITLE
Ensure api tests

### DIFF
--- a/lib/api/_loaders/ensure.js
+++ b/lib/api/_loaders/ensure.js
@@ -164,7 +164,7 @@ class EnsureAssertionLoader extends BaseLoader {
    * @param abortOnFailure
    * @returns {Function}
    */
-  createAssertion(commandName, abortOnFailure) {
+  createAssertion(parent, commandName, abortOnFailure) {
     return function assertFn({negate, args}) {
       const {reporter, transport} = this;
       const startTime = new Date();
@@ -202,15 +202,35 @@ class EnsureAssertionLoader extends BaseLoader {
 
         return runner.run();
       };
+      const element = args[0];
+      const shouldReturnPromise = element && (element.sessionId && element.elementId || element.driver_ && element.id_);
+      const deferred = Utils.createPromise();
+      const isES6Async = shouldReturnPromise || (Utils.isUndefined(this.isES6Async) ? this.nightwatchInstance.isES6AsyncTestcase : this.isES6Async);
 
-      this.commandQueue.add({
+      const node = this.commandQueue.add({
         commandName,
         commandFn,
         context: this.api,
         args: [],
         stackTrace: assertFn.stackTrace,
-        namespace
+        namespace,
+        deferred,
+        isES6Async
       });
+
+      if (isES6Async) {
+        this.commandQueue.tree.once('asynctree:finished', (err) => {
+          node.deferred.resolve();
+        });
+
+        if (parent && parent.__pageObjectItem__) {
+          Object.assign(node.deferred.promise, parent.__pageObjectItem__);
+        } else {
+          Object.assign(node.deferred.promise, this.api);
+        }
+
+        return node.deferred.promise;
+      }
 
       return this.api;
     }.bind(this);
@@ -229,7 +249,7 @@ class EnsureAssertionLoader extends BaseLoader {
       }
 
       this.nightwatchInstance.setApiMethod(propertyName, namespace || 'ensure', (function(commandName) {
-        return this.createAssertion(commandName, false);
+        return this.createAssertion(parent, commandName, false);
       }.bind(this))(propertyName));
     });
 

--- a/lib/api/_loaders/ensure.js
+++ b/lib/api/_loaders/ensure.js
@@ -112,7 +112,7 @@ class EnsureAssertionLoader extends BaseLoader {
       urlIs: 'url %s %s',
       urlContains: ['url %s %s', ['contains', 'does not contain']],
       urlMatches: ['url %s %s', ['matches', 'does not match']],
-      elementLocated: ['element "%s" %s located'],
+      elementLocated: ['element "%s" %s located', ['is', 'is not']],
       elementsLocated: ['elements "%s" %s located', ['are', 'are not']],
       stalenessOf: 'element "%s" %s stale',
       elementIsVisible: 'element "%s" %s visible',

--- a/test/lib/fakedriver.js
+++ b/test/lib/fakedriver.js
@@ -1,3 +1,5 @@
+const {WebElement} = require('selenium-webdriver');
+
 const CommandsExecutor = {
   findChildElement(args, assertion) {
     assertion({args, command: 'findChildElement'});
@@ -98,6 +100,22 @@ const fakeWebElement = function(elementId) {
       return Promise.resolve(elementId);
     }
   };
+};
+
+const fakeSeleniumElement =  function(driver, elementId) {
+  driver.execute =  function(command) {
+    const commandName = command.getName();
+    const params = command.getParameters();
+
+    let result = CommandsExecutor[commandName](params, function(){});
+    if (!(result instanceof Promise)) {
+      result = Promise.resolve(result);
+    }
+
+    return result;
+  };
+
+  return new WebElement(driver, elementId);
 };
 
 const TEST_ELEMENT_ID = '12345-6789';
@@ -266,6 +284,7 @@ const createNavigateCommandMocks = function(assertion) {
 
 module.exports = {
   fakeWebElement,
+  fakeSeleniumElement,
   create(assertion, mockDriverOverrides, args) {
     const driver = {
       execute(command) {

--- a/test/lib/fakedriver.js
+++ b/test/lib/fakedriver.js
@@ -135,6 +135,64 @@ const createGenericCommandMocks = function(assertion) {
   };
 };
 
+const createWaitCommandMocks =  function(assertion, args) {
+  return {
+    async wait(condn) {
+      assertion({description: condn.description(), result: await condn.fn({
+        
+        getCurrentUrl() {
+          return Promise.resolve(...args);
+        },
+        getTitle() {
+          return Promise.resolve(...args);
+        },
+        findElements(locator) {    
+          const element = fakeWebElement(TEST_ELEMENT_ID);
+    
+          return Promise.resolve([
+            element
+          ]);
+        },
+        switchTo(){
+          return {
+            frame(){
+              return Promise.resolve(null);
+            },
+            alert() {
+              return Promise.resolve({
+                accept() {
+    
+                  return null;
+                },
+                dismiss() {
+    
+                  return null;
+                },
+                getText() {
+    
+                  return Promise.resolve('alert text');
+                },
+                sendKeys(value) {
+    
+                  return null;
+                }
+              });
+            }
+
+          };
+        }
+       
+      })});
+
+    
+
+     
+
+      return Promise.resolve();
+    }
+  };
+};
+
 const createManageCommandMocks = function(assertion) {
   return {
     manage() {
@@ -208,7 +266,7 @@ const createNavigateCommandMocks = function(assertion) {
 
 module.exports = {
   fakeWebElement,
-  create(assertion, mockDriverOverrides) {
+  create(assertion, mockDriverOverrides, args) {
     const driver = {
       execute(command) {
         const commandName = command.getName();
@@ -268,6 +326,7 @@ module.exports = {
     Object.assign(driver, createNavigateCommandMocks(assertion));
     Object.assign(driver, createManageCommandMocks(assertion));
     Object.assign(driver, createGenericCommandMocks(assertion));
+    Object.assign(driver, createWaitCommandMocks(assertion, args));
     Object.assign(driver, mockDriverOverrides);
 
     return driver;

--- a/test/lib/globals.js
+++ b/test/lib/globals.js
@@ -29,34 +29,37 @@ class ExtendedReporter extends Reporter {
 
 class FakeExecutor {
   constructor() {
-    this.commands_ = new Map()
+    this.commands_ = new Map();
   }
 
   execute(command) {
-    let expectations = this.commands_.get(command.getName())
+    let expectations = this.commands_.get(command.getName());
     if (!expectations || !expectations.length) {
-      assert.fail('unexpected command: ' + command.getName())
-      return
+      assert.fail('unexpected command: ' + command.getName());
+
+      return;
     }
 
-    let next = expectations[0]
-    let result = next.execute(command)
+    let next = expectations[0];
+    let result = next.execute(command);
     if (next.times_ !== Infinity) {
-      next.times_ -= 1
+      next.times_ -= 1;
       if (!next.times_) {
-        expectations.shift()
+        expectations.shift();
       }
     }
-    return result
+
+    return result;
   }
 
   expect(commandName, opt_parameters) {
     if (!this.commands_.has(commandName)) {
-      this.commands_.set(commandName, [])
+      this.commands_.set(commandName, []);
     }
-    let e = new Expectation(this, commandName, opt_parameters)
-    this.commands_.get(commandName).push(e)
-    return e
+    let e = new Expectation(this, commandName, opt_parameters);
+    this.commands_.get(commandName).push(e);
+
+    return e;
   }
 
   createDriver() {
@@ -140,7 +143,7 @@ class Globals {
         assertion(opts);
       };
 
-      client.transport.driver = FakeDriver.create(assertion, mockDriverOverrides);
+      client.transport.driver = FakeDriver.create(assertion, mockDriverOverrides, args);
 
       client.queue.once('queue:finished', err => {
         if (err) {

--- a/test/lib/globals.js
+++ b/test/lib/globals.js
@@ -144,6 +144,9 @@ class Globals {
       };
 
       client.transport.driver = FakeDriver.create(assertion, mockDriverOverrides, args);
+      if (args[0]==='@seleniumElement') {
+        args[0] = FakeDriver.fakeSeleniumElement(client.transport.driver, '12345-6789');
+      }
 
       client.queue.once('queue:finished', err => {
         if (err) {

--- a/test/src/api/protocol/testEnsure.js
+++ b/test/src/api/protocol/testEnsure.js
@@ -95,6 +95,115 @@ describe('client.ensure', function() {
 
   });
 
+  it('test ensure.elementLocated',  function() {
+    return Globals.protocolTest({
+      assertion: function(opts){
+        assert.strictEqual(opts.description, 'Waiting for element to be located By(css selector, element)');
+        assert.notStrictEqual(opts.result, null);
+      },
+      commandName: 'ensure.elementLocated',
+      args: ['element']
+    });
+  });
 
+  it('test ensure.elementsLocated', function(){
+    return Globals.protocolTest({
+      assertion: function(opts){
+        assert.strictEqual(opts.description, 'Waiting for at least one element to be located By(css selector, element)');
+        assert.notStrictEqual(opts.result, null);
+
+      },
+      commandName: 'ensure.elementsLocated',
+      args: ['element']
+    });
+  });
+
+  it('test ensure.elementIsVisible', function(){
+    return Globals.protocolTest({
+      assertion: function(opts){
+        assert.strictEqual(opts.description, 'Waiting until element is visible');
+        assert.notStrictEqual(opts.result, null);
+
+      },
+      commandName: 'ensure.elementIsVisible',
+      args: ['@seleniumElement']
+    });
+  });
+
+  it('test ensure.elementIsEnabled', function() {
+    return Globals.protocolTest({
+      assertion: function(opts){
+        assert.strictEqual(opts.description, 'Waiting until element is enabled');
+        assert.notStrictEqual(opts.result, null);
+
+      },
+      commandName: 'ensure.elementIsEnabled',
+      args: ['@seleniumElement']
+    });
+  });
+
+
+  it('test ensure.elementIsSelected', function() {
+    return Globals.protocolTest({
+      assertion: function(opts){
+        assert.strictEqual(opts.description, 'Waiting until element is selected');
+        assert.notStrictEqual(opts.result, null);
+
+      },
+      commandName: 'ensure.elementIsSelected',
+      args: ['@seleniumElement']
+    });
+  });
+
+  it.only('test ensure.elementIsDisabled', function() {
+    return Globals.protocolTest({
+      assertion: function(opts){
+        assert.strictEqual(opts.description, 'Waiting until element is disabled');
+        assert.strictEqual(opts.result, null);
+
+      },
+      commandName: 'ensure.elementIsDisabled',
+      args: ['@seleniumElement']
+    });
+  });
+
+  it('test ensure.elementTextContains', function() {
+    return Globals.protocolTest({
+      assertion: function(opts){
+        assert.strictEqual(opts.description, 'Waiting until element text contains');
+        assert.notStrictEqual(opts.result, null);
+
+      },
+      commandName: 'ensure.elementTextContains',
+      args: ['@seleniumElement', 'text']
+    });
+  });
+
+
+  it('test ensure.elementTextIs', function() {
+    return Globals.protocolTest({
+      assertion: function(opts){
+        assert.strictEqual(opts.description, 'Waiting until element text is');
+        assert.notStrictEqual(opts.result, null);
+
+      },
+      commandName: 'ensure.elementTextIs',
+      args: ['@seleniumElement', 'text']
+    });
+  });
+
+  it('test ensure.elementTextMatches', function() {
+    return Globals.protocolTest({
+      assertion: function(opts){
+        assert.strictEqual(opts.description, 'Waiting until element text matches');
+        assert.notStrictEqual(opts.result, null);
+
+      },
+      commandName: 'ensure.elementTextMatches',
+      args: ['@seleniumElement', /text/]
+    });
+  });
+
+  
 
 });

--- a/test/src/api/protocol/testEnsure.js
+++ b/test/src/api/protocol/testEnsure.js
@@ -1,0 +1,100 @@
+const assert = require('assert');
+const Globals = require('../../../lib/globals.js');
+
+describe('client.ensure', function() {
+  before(function() {
+    Globals.protocolBefore();
+  });
+
+  it('test ensure.titleIs', function() {
+    return Globals.protocolTest({
+      assertion: function(opts) {
+        assert.strictEqual(opts.description, 'Waiting for title to be "sample text"');
+        assert.strictEqual(opts.result, true);
+      },
+      commandName: 'ensure.titleIs',
+      args: ['sample text']
+    });
+  });
+
+  it('test ensure.ableToSwitchToFrame', function(){
+    return Globals.protocolTest({
+      assertion: function(opts) {
+        assert.strictEqual(opts.description, 'Waiting to be able to switch to frame');
+        assert.strictEqual(opts.result, true);
+      },
+      commandName: 'ensure.ableToSwitchToFrame'
+    });
+    
+  });
+
+  it('test ensure.alertIsPresent', function(){
+    return Globals.protocolTest({
+      assertion: function(opts) {
+        assert.strictEqual(opts.description, 'Waiting for alert to be present');
+      },
+      commandName: 'ensure.alertIsPresent'
+    });
+    
+  });
+
+  it('test ensure.titleContains', function() {
+    return Globals.protocolTest({
+      assertion: function(opts) {
+        assert.strictEqual(opts.description, 'Waiting for title to contain "sample"');
+        assert.strictEqual(opts.result, true);
+      },
+      commandName: 'ensure.titleContains',
+      args: ['sample']
+    });
+  });
+
+  it('test ensure.titleMatches', function(){
+    return Globals.protocolTest({
+      assertion: function(opts) {
+        assert.strictEqual(opts.description, 'Waiting for title to match /sample/');
+        assert.strictEqual(opts.result, true);
+      },
+      commandName: 'ensure.titleMatches',
+      args: [/sample/]
+    });
+    
+  });
+
+  it('test ensure.urlIs', function(){
+    return Globals.protocolTest({
+      assertion: function(opts) {
+        assert.strictEqual(opts.description, 'Waiting for URL to be "https://nightwatchjs.org"');
+        assert.strictEqual(opts.result, true);
+      },
+      commandName: 'ensure.urlIs',
+      args: ['https://nightwatchjs.org']
+    });
+  });
+
+  it('test ensure.urlContains', function(){
+    return Globals.protocolTest({
+      assertion: function(opts) {
+        assert.strictEqual(opts.description, 'Waiting for URL to contain "nightwatchjs"');
+        assert.strictEqual(opts.result, true);
+      },
+      commandName: 'ensure.urlContains',
+      args: ['nightwatchjs']
+    });
+  });
+
+  it('test ensure.urlMatches', function(){
+    return Globals.protocolTest({
+      assertion: function(opts) {
+        assert.strictEqual(opts.description, 'Waiting for URL to match /nightwatchjs/');
+        assert.strictEqual(opts.result, true);
+      },
+      commandName: 'ensure.urlMatches',
+      args: [/nightwatchjs/]
+    });
+
+  });
+
+
+
+});

--- a/test/src/api/protocol/testEnsure.js
+++ b/test/src/api/protocol/testEnsure.js
@@ -155,7 +155,7 @@ describe('client.ensure', function() {
     });
   });
 
-  it.only('test ensure.elementIsDisabled', function() {
+  it('test ensure.elementIsDisabled', function() {
     return Globals.protocolTest({
       assertion: function(opts){
         assert.strictEqual(opts.description, 'Waiting until element is disabled');


### PR DESCRIPTION
- updated `ensure` loaders to support promises.
- added protocol tests for `ensure` element commands.