### PR TITLE
Update transport.js

### DIFF
--- a/lib/transport/transport.js
+++ b/lib/transport/transport.js
@@ -314,7 +314,7 @@ class Transport extends EventEmitter {
     let {browserName} = settings.desiredCapabilities;
         
     // Better support for Appium, if the browserName has explicitly been set to null we can skip all further checks
-    if (browserName == null){
+    if (browserName === null) {
       return browserName;
     }
 

--- a/lib/transport/transport.js
+++ b/lib/transport/transport.js
@@ -312,6 +312,12 @@ class Transport extends EventEmitter {
 
   static getBrowserName(settings) {
     let {browserName} = settings.desiredCapabilities;
+        
+    // Better support for Appium, if the browserName has explicitly been set to null we can skip all further checks
+    if (browserName == null){
+      return browserName;
+    }
+
     if (browserName !== BrowserName.EDGE) {
       browserName = browserName.toLowerCase();
     }


### PR DESCRIPTION
Appium can get upset if you supply both a browserName and an appPackage as desiredCapabilities at the same time.

A brief reading of an Appium issue report from a few years ago suggests it _shouldn't_ complain, but this will fix the current behaviour to allow users to set a null browser

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.

Should resolve an issue raised in discussion #2881 
