### PR TITLE
update port in Http global settings from webdriver httpClient

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -9,7 +9,7 @@ const HttpResponse = require('./response.js');
 const Utils = require('./../utils');
 const {Logger, isString} = Utils;
 
-let __defaultSettings__ = {
+const __defaultSettings__ = {
   credentials: null,
   use_ssl: false,
   proxy: null,
@@ -48,6 +48,10 @@ class HttpRequest extends EventEmitter {
 
   static get globalSettings() {
     return __globalSettings__ || HttpOptions.global.settings;
+  }
+
+  static updateGlobalSettings(settings={}) {
+    Object.assign(__globalSettings__, settings);
   }
 
   setHttpOpts() {
@@ -103,7 +107,7 @@ class HttpRequest extends EventEmitter {
   }
 
   setPathPrefix(options) {
-    let pathContainsPrefix = options.path && options.path.includes(this.httpOpts.default_path);
+    const pathContainsPrefix = options.path && options.path.includes(this.httpOpts.default_path);
     this.defaultPathPrefix = pathContainsPrefix ? '' : this.httpOpts.default_path;
 
     return this;
@@ -191,7 +195,7 @@ class HttpRequest extends EventEmitter {
   }
 
   logRequest() {
-    let retryStr = this.retryCount ? ` (retry ${this.retryCount})` : '';
+    const retryStr = this.retryCount ? ` (retry ${this.retryCount})` : '';
     const params = this.params;
     // Trim long execute script strings from params
     if (this.reqOptions.path.includes('/execute/') && params.script) {
@@ -353,7 +357,7 @@ class HttpRequest extends EventEmitter {
     if (this.httpOpts.proxy !== null) {
       try {
         const ProxyAgent = require('proxy-agent');
-        let proxyUri = this.httpOpts.proxy;
+        const proxyUri = this.httpOpts.proxy;
         this.reqOptions.agent = new ProxyAgent(proxyUri);
       } catch (err) {
         console.error('The proxy-agent module was not found. It can be installed from NPM with:\n\n' +

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -50,7 +50,7 @@ class HttpRequest extends EventEmitter {
     return __globalSettings__ || HttpOptions.global.settings;
   }
 
-  static updateGlobalSettings(settings={}) {
+  static updateGlobalSettings(settings = {}) {
     Object.assign(__globalSettings__, settings);
   }
 

--- a/lib/transport/selenium-webdriver/httpclient.js
+++ b/lib/transport/selenium-webdriver/httpclient.js
@@ -7,8 +7,7 @@ module.exports = function(settings, HttpResponse) {
   return class HttpClient {
     constructor(serverUrl, opt_agent, opt_proxy) {
       this.agent_ = opt_agent || null;
-      //eslint-disable-next-line
-      const options = url.parse(serverUrl);
+      const options = new URL(serverUrl);
       if (!options.hostname) {
         throw new Error('Invalid URL: ' + serverUrl);
       }
@@ -17,8 +16,6 @@ module.exports = function(settings, HttpResponse) {
       const {hostname: host, port, pathname: path, protocol} = options;      
       const {log_screenshot_data} = settings;
       
-      HttpRequest.updateGlobalSettings({port});
-
       this.options = {
         host,
         port: port ? Number(port) : (protocol === 'https' ? 443 : 80),
@@ -29,6 +26,8 @@ module.exports = function(settings, HttpResponse) {
         use_ssl: protocol === 'https:'
       };
       this.errorTimeoutId = null;
+      
+      HttpRequest.updateGlobalSettings({port: this.options.port});
     }
 
     /** @override */

--- a/lib/transport/selenium-webdriver/httpclient.js
+++ b/lib/transport/selenium-webdriver/httpclient.js
@@ -18,9 +18,7 @@ module.exports = function(settings, HttpResponse) {
 
       //Update the port in HttpRequest.globalSettings
       //This port is then used in commands which uses Nightwatch client requests instead of selenium webdriver
-      if (HttpRequest.globalSettings && !HttpRequest.globalSettings.port) {
-        HttpRequest.globalSettings.port = port;
-      }
+      HttpRequest.updateGlobalSettings({port});
       
       const {log_screenshot_data} = settings;
 

--- a/lib/transport/selenium-webdriver/httpclient.js
+++ b/lib/transport/selenium-webdriver/httpclient.js
@@ -13,12 +13,17 @@ module.exports = function(settings, HttpResponse) {
       }
       this.proxyOptions_ = opt_proxy ? {} : null;
 
-      const {hostname: host, port, pathname: path, protocol} = options;      
+      const {hostname: host, pathname: path, protocol} = options;           
       const {log_screenshot_data} = settings;
-      
+      let {port} = options;
+      if (port) {
+        port = Number(port);  
+        HttpRequest.updateGlobalSettings({port});
+      }
+    
       this.options = {
         host,
-        port: port ? Number(port) : (protocol === 'https' ? 443 : 80),
+        port: port ? port : (protocol === 'https' ? 443 : 80),
         path,
         addtOpts: {
           suppressBase64Data: !log_screenshot_data
@@ -26,8 +31,7 @@ module.exports = function(settings, HttpResponse) {
         use_ssl: protocol === 'https:'
       };
       this.errorTimeoutId = null;
-      
-      HttpRequest.updateGlobalSettings({port: this.options.port});
+     
     }
 
     /** @override */

--- a/lib/transport/selenium-webdriver/httpclient.js
+++ b/lib/transport/selenium-webdriver/httpclient.js
@@ -17,7 +17,7 @@ module.exports = function(settings, HttpResponse) {
       const {hostname: host, port, pathname: path, protocol} = options;
 
       //Update the port in HttpRequest.globalSettings
-      //this port is than used in commands which uses Nightwatch client requests instead of selenium webdriver
+      //This port is then used in commands which uses Nightwatch client requests instead of selenium webdriver
       if (HttpRequest.globalSettings && !HttpRequest.globalSettings.port) {
         HttpRequest.globalSettings.port = port;
       }

--- a/lib/transport/selenium-webdriver/httpclient.js
+++ b/lib/transport/selenium-webdriver/httpclient.js
@@ -7,7 +7,8 @@ module.exports = function(settings, HttpResponse) {
   return class HttpClient {
     constructor(serverUrl, opt_agent, opt_proxy) {
       this.agent_ = opt_agent || null;
-      const options = new URL(serverUrl);
+      // eslint-disable-next-line
+      const options = url.parse(serverUrl);
       if (!options.hostname) {
         throw new Error('Invalid URL: ' + serverUrl);
       }
@@ -19,11 +20,13 @@ module.exports = function(settings, HttpResponse) {
       if (port) {
         port = Number(port);  
         HttpRequest.updateGlobalSettings({port});
+      } else {
+        port = protocol === 'https' ? 443 : 80;  
       }
     
       this.options = {
         host,
-        port: port ? port : (protocol === 'https' ? 443 : 80),
+        port,
         path,
         addtOpts: {
           suppressBase64Data: !log_screenshot_data

--- a/lib/transport/selenium-webdriver/httpclient.js
+++ b/lib/transport/selenium-webdriver/httpclient.js
@@ -15,6 +15,13 @@ module.exports = function(settings, HttpResponse) {
       this.proxyOptions_ = opt_proxy ? {} : null;
 
       const {hostname: host, port, pathname: path, protocol} = options;
+
+      //Update the port in HttpRequest.globalSettings
+      //this port is than used in commands which uses Nightwatch client requests instead of selenium webdriver
+      if (HttpRequest.globalSettings && !HttpRequest.globalSettings.port) {
+        HttpRequest.globalSettings.port = port;
+      }
+      
       const {log_screenshot_data} = settings;
 
       this.options = {

--- a/lib/transport/selenium-webdriver/httpclient.js
+++ b/lib/transport/selenium-webdriver/httpclient.js
@@ -14,13 +14,10 @@ module.exports = function(settings, HttpResponse) {
       }
       this.proxyOptions_ = opt_proxy ? {} : null;
 
-      const {hostname: host, port, pathname: path, protocol} = options;
-
-      //Update the port in HttpRequest.globalSettings
-      //This port is then used in commands which uses Nightwatch client requests instead of selenium webdriver
-      HttpRequest.updateGlobalSettings({port});
-      
+      const {hostname: host, port, pathname: path, protocol} = options;      
       const {log_screenshot_data} = settings;
+      
+      HttpRequest.updateGlobalSettings({port});
 
       this.options = {
         host,

--- a/test/src/service-builders/testFirefoxDriver.js
+++ b/test/src/service-builders/testFirefoxDriver.js
@@ -30,7 +30,7 @@ describe('GeckoDriver Transport Tests', function () {
     mockery.resetCache();
   });
 
-  const RANDOM_PORT = '6732';
+  const RANDOM_PORT = 6732;
   
   const sessionData = {
     sessionId: '111',

--- a/test/src/service-builders/testFirefoxDriver.js
+++ b/test/src/service-builders/testFirefoxDriver.js
@@ -3,6 +3,8 @@ const mockery = require('mockery');
 const common = require('../../common.js');
 const NightwatchClient = common.require('index.js');
 const Settings = common.require('settings/settings.js');
+const HttpRequest = common.require('http/request.js');
+const HttpClient = common.require('transport/selenium-webdriver/httpclient.js')({});
 
 describe('GeckoDriver Transport Tests', function () {
   beforeEach(function() {
@@ -28,15 +30,17 @@ describe('GeckoDriver Transport Tests', function () {
     mockery.resetCache();
   });
 
+  const RANDOM_PORT = '6732';
+  
   const sessionData = {
     sessionId: '111',
     getId() {
-      return '1111'
+      return '1111';
     },
     getCapabilities() {
       return {
         getPlatform() {
-          return 'MAC'
+          return 'MAC';
         },
         getBrowserName() {
           return 'firefox';
@@ -50,7 +54,7 @@ describe('GeckoDriver Transport Tests', function () {
         keys() {
           return new Map();
         }
-      }
+      };
     }
   };
 
@@ -61,9 +65,9 @@ describe('GeckoDriver Transport Tests', function () {
     async getExecutor() {
       return {
         w3c: true
-      }
+      };
     }
-  }
+  };
 
   const fn = function() {};
   function deleteFromRequireCache(location) {
@@ -80,6 +84,8 @@ describe('GeckoDriver Transport Tests', function () {
     const {Builder} = require('selenium-webdriver');
     class MockBuilder extends Builder {
       build() {
+        const httpClient =  new HttpClient(`http://localhost:${RANDOM_PORT}`);
+
         return Promise.resolve(mockDriver);
       }
     }
@@ -128,9 +134,9 @@ describe('GeckoDriver Transport Tests', function () {
 
           },
           async start() {
-            return 'http://localhost'
+            return 'http://localhost';
           }
-        }
+        };
       }
     }
 
@@ -211,7 +217,7 @@ describe('GeckoDriver Transport Tests', function () {
       serverPath,
       serverPort,
       verboseLogging
-    }
+    };
   }
 
   it('test create session with firefox driver -- not found error', async function() {
@@ -282,6 +288,8 @@ describe('GeckoDriver Transport Tests', function () {
     });
     assert.strictEqual(serverPath, '/path/to/geckodriver');
     assert.strictEqual(serverPort, undefined);
-  });
 
+    //Global port should be set to random assigned Port
+    assert.strictEqual(HttpRequest.globalSettings.port, RANDOM_PORT);
+  });
 });


### PR DESCRIPTION
### Changes
- update the port in `http.globalSettings` which can be used in making requests for commands that don't use selenium-webdriver and uses Nightwatch client instead.
- fixes #3054 