### PR TITLE
Fixes/3085 failure while using wait for commands

### DIFF
--- a/lib/api/element-commands/_waitFor.js
+++ b/lib/api/element-commands/_waitFor.js
@@ -217,6 +217,7 @@ class WaitForElement extends ElementCommand {
     return runner.run(result)
       .catch(err => (err))
       .then(err => {
+        err.waitFor = true;
         if (Utils.isObject(result.value) && !Array.isArray(result.value)) {
           result.value = [result.value];
         }

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -87,7 +87,7 @@ class AsyncTree extends EventEmitter{
   }
 
   shouldRejectNodePromise(err) {
-    if (err.isExpect && this.currentNode.isES6Async) {
+    if ((err.isExpect || err.waitFor) && this.currentNode.isES6Async) {
       return true;
     }
 

--- a/test/cucumber-integration-tests/sample_cucumber_tests/withwaitFor/sample.feature
+++ b/test/cucumber-integration-tests/sample_cucumber_tests/withwaitFor/sample.feature
@@ -1,0 +1,6 @@
+Feature: Sample Feature
+
+@fail
+Scenario: Sample test with failures
+    Given I navigate to localhost
+    Then I wait for badElement to be present

--- a/test/cucumber-integration-tests/sample_cucumber_tests/withwaitFor/testWithFailures.js
+++ b/test/cucumber-integration-tests/sample_cucumber_tests/withwaitFor/testWithFailures.js
@@ -1,0 +1,13 @@
+const {Given, Then} = require('@cucumber/cucumber');
+
+Given('I navigate to localhost', function() {
+  browser.globals.test_calls++;
+
+  return browser.url('http://localhost');
+});
+
+Then('I wait for badElement to be present', function() {
+  browser.globals.test_calls++;
+
+  return browser.waitForElementPresent('#badElement');
+});

--- a/test/cucumber-integration-tests/testCucumberTestsWithWaitFor.js
+++ b/test/cucumber-integration-tests/testCucumberTestsWithWaitFor.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const assert = require('assert');
+const Globals = require('../lib/globals/commands.js');
+const common = require('../common.js');
+const MockServer = require('../lib/mockserver.js');
+const {runTests} = common.require('index.js');
+const {settings} = common;
+
+describe('Cucumber integration with .expect APIs', function() {
+  beforeEach(function(done) {
+    this.server = MockServer.init(null, {port: 10192});
+    this.server.on('listening', () => done());
+  });
+
+  afterEach(function(done) {
+    Globals.afterEach.call(this, done);
+  });
+
+  it('testCucumberSampleTests -- with waitFor failure', function() {
+    MockServer.addMock({
+      url: '/wd/hub/session/1352110219202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/text',
+      statusCode: 200,
+      method: 'GET',
+      response: {
+        value: 'jean sibelius'
+      },
+      times: 3
+    });
+
+    const source = [path.join(__dirname, './sample_cucumber_tests/withWaitFor/testWithFailures.js')];
+
+    return runTests({
+      source,
+      tags: ['@fail'],
+      verbose: false,
+      config: path.join(__dirname, '../extra/cucumber-config-waitFor.js')
+    }, settings({
+      silent: false,
+      output: false,
+      globals: {
+        waitForConditionTimeout: 10,
+        waitForConditionPollInterval: 50
+      }
+    })).then(failures => {
+      assert.strictEqual(failures, true, 'Cucumber should have test failures');
+    });
+  });
+
+});

--- a/test/extra/cucumber-config-waitFor.js
+++ b/test/extra/cucumber-config-waitFor.js
@@ -1,0 +1,31 @@
+const path = require('path');
+
+module.exports = {
+  selenium: {
+    port: 10192,
+    host: 'localhost'
+  },
+
+  persist_globals: true,
+  output_folder: false,
+
+  webdriver: {
+    start_process: false
+  },
+
+  globals: {
+    test_calls: 0,
+    waitForConditionTimeout: 20,
+    retryAssertionTimeout: 20,
+    waitForConditionPollInterval: 10
+  },
+
+  test_runner: {
+    type: 'cucumber',
+    options: {
+      feature_path: path.join(__dirname, '../cucumber-integration-tests/sample_cucumber_tests/withwaitFor/sample.feature')
+    }
+  },
+  output: false,
+  silent: false
+};


### PR DESCRIPTION
### Changes
- reject the  node promise if error is from `waitFor` commands 
- added tests supporting this

### Impact
- fixes #3085