### PR TITLE
Fixed #3132 - Mark test scenarios passed/failed and send reason to Browserstack while using Cucumber as a test-runner

### DIFF
--- a/cucumber-js/_setup_cucumber_runner.js
+++ b/cucumber-js/_setup_cucumber_runner.js
@@ -68,7 +68,7 @@ After(async function(testCase) {
   //send test-case result to cloud provider
   const {result} = testCase;
   if (this.client.transport && this.client.transport.usingBrowserstack && result) {
-    this.client.transport.sendReasonToBrowserstack((result.status === 'FAILED'), result.message);
+    await this.client.transport.sendReasonToBrowserstack((result.status === 'FAILED'), result.message);
   }
 
   if (this.browser) {

--- a/cucumber-js/_setup_cucumber_runner.js
+++ b/cucumber-js/_setup_cucumber_runner.js
@@ -67,8 +67,9 @@ After(async function(testCase) {
 
   //send test-case result to cloud provider
   const {result} = testCase;
-  if (this.client.transport && this.client.transport.usingBrowserstack && result) {
-    await this.client.transport.sendReasonToBrowserstack((result.status === 'FAILED'), result.message);
+  if (this.client && result) {
+    const error = result.status === 'FAILED' ? new Error(result.message) : null;
+    await this.client.transport.testSuiteFinished(error);
   }
 
   if (this.browser) {

--- a/cucumber-js/_setup_cucumber_runner.js
+++ b/cucumber-js/_setup_cucumber_runner.js
@@ -63,7 +63,14 @@ Before(function({pickle}) {
   }
 });
 
-After(async function() {
+After(async function(testCase) {
+
+  //send test-case result to cloud provider
+  const {result} = testCase;
+  if (this.client.transport && this.client.transport.usingBrowserstack && result) {
+    this.client.transport.sendReasonToBrowserstack((result.status === 'FAILED'), result.message);
+  }
+
   if (this.browser) {
     await this.browser.quit();
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,6 +131,11 @@ Nightwatch.createClient = function({
         return client.settings;
       }
     },
+    transport: {
+      get: function() {
+        return client.transport;
+      }
+    },
     nightwatch_client: {
       configurable: true,
       get: function() {

--- a/lib/transport/selenium-webdriver/browserstack.js
+++ b/lib/transport/selenium-webdriver/browserstack.js
@@ -121,14 +121,9 @@ class Browserstack extends Selenium {
   }
 
   async testSuiteFinished(failures) {
+    
     try {
-      let reason = failures instanceof Error;
-      if (reason) {
-        reason = `${failures.name}: ${failures.message}`;
-      } else {
-        reason = '';
-      }
-
+      const reason = failures instanceof Error ? `${failures.name}: ${failures.message}` : '';
       await this.sendReasonToBrowserstack(!!failures, reason);
       // eslint-disable-next-line no-console
       console.log('\n  ' + 'See more info, video, & screenshots on Browserstack:\n' +

--- a/lib/transport/selenium-webdriver/browserstack.js
+++ b/lib/transport/selenium-webdriver/browserstack.js
@@ -98,29 +98,38 @@ class Browserstack extends Selenium {
     }
   }
 
+  get usingBrowserstack() {
+    return true;
+  }
+
+  async sendReasonToBrowserstack(isFailure, reason) {
+    reason = stripAnsi(reason);
+    await this.sendHttpRequest({
+      url: `${Browserstack.ApiUrl}/sessions/${this.sessionId}.json`,
+      method: 'PUT',
+      use_ssl: true,
+      data: {
+        status: isFailure ? 'failed' : 'passed',
+        reason
+      },
+      auth: {
+        user: this.username,
+        pass: this.accessKey
+      }
+    });
+
+  }
+
   async testSuiteFinished(failures) {
     try {
       let reason = failures instanceof Error;
       if (reason) {
-        reason = stripAnsi(`${failures.name}: ${failures.message}`);
+        reason = `${failures.name}: ${failures.message}`;
       } else {
         reason = '';
       }
 
-      await this.sendHttpRequest({
-        url: `${Browserstack.ApiUrl}/sessions/${this.sessionId}.json`,
-        method: 'PUT',
-        use_ssl: true,
-        data: {
-          status: !!failures ? 'failed' : 'passed',
-          reason
-        },
-        auth: {
-          user: this.username,
-          pass: this.accessKey
-        }
-      });
-
+      await this.sendReasonToBrowserStack(!!failures, reason);
       // eslint-disable-next-line no-console
       console.log('\n  ' + 'See more info, video, & screenshots on Browserstack:\n' +
         '  ' + Logger.colors.light_cyan(`https://automate.browserstack.com/builds/${this.buildId}/sessions/${this.sessionId}`));

--- a/lib/transport/selenium-webdriver/browserstack.js
+++ b/lib/transport/selenium-webdriver/browserstack.js
@@ -102,7 +102,7 @@ class Browserstack extends Selenium {
     return true;
   }
 
-  async sendReasonToBrowserstack(isFailure, reason) {
+  async sendReasonToBrowserstack(isFailure = false, reason = '') {
     reason = stripAnsi(reason);
     await this.sendHttpRequest({
       url: `${Browserstack.ApiUrl}/sessions/${this.sessionId}.json`,
@@ -129,7 +129,7 @@ class Browserstack extends Selenium {
         reason = '';
       }
 
-      await this.sendReasonToBrowserStack(!!failures, reason);
+      await this.sendReasonToBrowserstack(!!failures, reason);
       // eslint-disable-next-line no-console
       console.log('\n  ' + 'See more info, video, & screenshots on Browserstack:\n' +
         '  ' + Logger.colors.light_cyan(`https://automate.browserstack.com/builds/${this.buildId}/sessions/${this.sessionId}`));

--- a/lib/transport/selenium-webdriver/browserstack.js
+++ b/lib/transport/selenium-webdriver/browserstack.js
@@ -98,10 +98,6 @@ class Browserstack extends Selenium {
     }
   }
 
-  get usingBrowserstack() {
-    return true;
-  }
-
   async sendReasonToBrowserstack(isFailure = false, reason = '') {
     reason = stripAnsi(reason);
     await this.sendHttpRequest({

--- a/test/extra/cucumber-config.js
+++ b/test/extra/cucumber-config.js
@@ -26,6 +26,23 @@ module.exports = {
       feature_path: path.join(__dirname, '../cucumber-integration-tests/sample_cucumber_tests/integration/sample.feature')
     }
   },
-  output: false,
-  silent: false
+  test_settings: {
+    test_runner: {
+      type: 'cucumber',
+      options: {
+        feature_path: path.join(__dirname, '../cucumber-integration-tests/browserstack/sampleBrowserstack.feature')
+      }
+    },
+    browserstack: {
+      selenium: {
+        host: 'hub-cloud.browserstack.com',
+        port: 443
+      },
+      desiredCapabilities: {
+        'browserstack.user': 'test-access-user',
+        'browserstack.key': 'test-access-key',
+        browserName: 'chrome'
+      }
+    }
+  }
 };

--- a/test/extra/cucumber-config.js
+++ b/test/extra/cucumber-config.js
@@ -27,12 +27,6 @@ module.exports = {
     }
   },
   test_settings: {
-    test_runner: {
-      type: 'cucumber',
-      options: {
-        feature_path: path.join(__dirname, '../cucumber-integration-tests/browserstack/sampleBrowserstack.feature')
-      }
-    },
     browserstack: {
       selenium: {
         host: 'hub-cloud.browserstack.com',

--- a/test/src/runner/cucumber-integration/testCucumberWithBrowserstack.js
+++ b/test/src/runner/cucumber-integration/testCucumberWithBrowserstack.js
@@ -1,0 +1,100 @@
+const path = require('path');
+const assert = require('assert');
+const nock = require('nock');
+const common = require('../../../common.js');
+const {runTests} = common.require('index.js');
+
+xdescribe('Cucumber  Browserstack integration', function() {
+  
+  before(function(done) {
+    try {
+      nock.activate();
+    // eslint-disable-next-line no-empty
+    } catch (err) {
+    }
+   
+    nock('https://hub-cloud.browserstack.com')
+      .post('/wd/hub/session')
+      .reply(201, {
+        status: 0,
+        sessionId: '1352110219202',
+        value: {
+          browserName: 'chrome'
+        }
+      });
+
+    nock('https://api.browserstack.com')
+      .get('/automate/builds.json')
+      .reply(200, []);
+
+    nock('https://hub-cloud.browserstack.com')
+      .post('/wd/hub/session/1352110219202/url')
+      .reply(200, {
+        value: null
+      });
+
+    nock('https://hub-cloud.browserstack.com')
+      .post('/wd/hub/session/1352110219202/elements')
+      .reply(200, {
+        status: 0,
+        sessionId: '1352110219202',
+        value: [{
+          'ELEMENT': '0'
+        }]
+      });
+
+    nock('https://hub-cloud.browserstack.com')
+      .delete('/wd/hub/session/1352110219202')
+      .reply(200, {
+        value: []
+      });
+
+    done();
+  });
+
+  after(function(done) {
+    nock.restore();
+    done();
+  });
+
+
+  it('testCucumberSampleTests - [Passed]', function() {
+   
+    nock('https://api.browserstack.com')
+      .put('/automate/sessions/1352110219202.json', body => body.status === 'passed')
+      .reply(200);
+
+    const source = [path.join(__dirname, '../../../cucumber-integration-tests/sample_cucumber_tests/integration/testSample.js')];
+    
+    return runTests({
+      source,
+      tags: ['@pass'],
+      verbose: false,
+      config: path.join(__dirname, '../../../extra/cucumber-config.js'),
+      env: 'browserstack'
+    }, {}).then(failures => {
+      assert.strictEqual(failures, false, 'Cucumber has test failures. Run with verbose to investigate.');
+    });
+  });
+
+  it('testCucumberSampleTests with failures', function() {
+
+
+    nock('https://api.browserstack.com')
+      .put('/automate/sessions/1352110219202.json', body => body.status === 'failed')
+      .reply(200);
+    
+    const source = [path.join(__dirname, '../../../cucumber-integration-tests/sample_cucumber_tests/integration/testWithFailures.js')];
+    
+    return runTests({
+      source,
+      env: 'browserstack',
+      tags: ['@fail'],
+      verbose: false,
+      config: path.join(__dirname, '../../../extra/cucumber-config.js')
+    }, {}).then(failures => {
+      assert.strictEqual(failures, true, 'Cucumber tests should have failed. Run with verbose to investigate.');
+    });
+  });
+});
+


### PR DESCRIPTION
### Changes
- extracted scenarios results in the `After` hook and send to BrowserStack.
- exposed `transport` from Nightwatch `createClient`.
- added tests for the change.

### Impacts
- fixes #3132 