### PR TITLE
Fixes/3138 handle rejected promise for expect commands

### DIFF
--- a/lib/api/_loaders/expect.js
+++ b/lib/api/_loaders/expect.js
@@ -110,7 +110,7 @@ class ExpectLoader extends BaseCommandLoader {
 
       if (isES6Async && (expectCommand.instance instanceof Promise)) {
         // prevent unhandledRejection errors
-        expectCommand.instance.catch(err=>{
+        expectCommand.instance.catch(err => {
           deferred.reject(err);
         });
       }

--- a/lib/api/_loaders/expect.js
+++ b/lib/api/_loaders/expect.js
@@ -108,7 +108,7 @@ class ExpectLoader extends BaseCommandLoader {
         stackTrace
       });
 
-      if (isES6Async && expectCommand.instance instanceof Promise) {
+      if (isES6Async && (expectCommand.instance instanceof Promise)) {
         // prevent unhandledRejection errors
         expectCommand.instance.catch(err=>{
           deferred.reject(err);

--- a/lib/api/_loaders/expect.js
+++ b/lib/api/_loaders/expect.js
@@ -108,7 +108,7 @@ class ExpectLoader extends BaseCommandLoader {
         stackTrace
       });
 
-      if (isES6Async) {
+      if (isES6Async && expectCommand.instance instanceof Promise) {
         // prevent unhandledRejection errors
         expectCommand.instance.catch(err=>{
           deferred.reject(err);

--- a/lib/api/_loaders/expect.js
+++ b/lib/api/_loaders/expect.js
@@ -108,6 +108,13 @@ class ExpectLoader extends BaseCommandLoader {
         stackTrace
       });
 
+      if (isES6Async) {
+        // prevent unhandledRejection errors
+        expectCommand.instance.catch(err=>{
+          deferred.reject(err);
+        });
+      }
+      
       return expectCommand.instance;
     }.bind(this));
   }

--- a/test/sampletests/asyncwithexpectfailures/sample.js
+++ b/test/sampletests/asyncwithexpectfailures/sample.js
@@ -1,9 +1,7 @@
-
 describe('browse.expect with failures in async step', function() {
   it('async step failure', async function() {
     browser.url('http://localhost');
     browser.expect.element('#weblogin').to.be.contain.text('some text');
-        
   });
 
   it('second step without failure', function() {

--- a/test/sampletests/asyncwithexpectfailures/sample.js
+++ b/test/sampletests/asyncwithexpectfailures/sample.js
@@ -1,0 +1,13 @@
+
+describe('browse.expect with failures in async step', function() {
+  it('async step failure', async function() {
+    browser.url('http://localhost');
+    browser.expect.element('#weblogin').to.be.contain.text('some text');
+        
+  });
+
+  it('second step without failure', function() {
+    browser.url('http://localhost');
+    browser.expect.element('#weblogin').to.be.present;
+  });
+});

--- a/test/src/runner/testRunnerEs6Async.js
+++ b/test/src/runner/testRunnerEs6Async.js
@@ -296,8 +296,6 @@ describe('testRunner ES6 Async', function () {
     };
 
     return runTests(testsPath, settings({
-      output: true,
-      silent: false,
       globals
     }));
   });

--- a/test/src/runner/testRunnerEs6Async.js
+++ b/test/src/runner/testRunnerEs6Async.js
@@ -271,4 +271,34 @@ describe('testRunner ES6 Async', function () {
       globals
     }));
   });
+
+  it('test runner with async expect failure', function() {
+    MockServer.addMock({
+      url: '/wd/hub/session/1352110219202/element/0/text',
+      method: 'GET',
+      response: JSON.stringify({
+        sessionId: '1352110219202',
+        status: 0,
+        value: 'Barn owl'
+      })
+    }, true);
+
+    const testsPath = path.join(__dirname, '../../sampletests/asyncwithexpectfailures');
+    const globals = {
+      waitForConditionPollInterval: 50,
+      waitForConditionTimeout: 100,
+      retryAssertionTimeout: 150,
+      reporter(results) {
+        assert.strictEqual(results.assertions, 2);
+        assert.strictEqual(results.failed, 1);
+        assert.strictEqual(results.passed, 1);
+      }
+    };
+
+    return runTests(testsPath, settings({
+      output: true,
+      silent: false,
+      globals
+    }));
+  });
 });


### PR DESCRIPTION
### Changes
- handled rejected promise for `browser.expect` assertions
- added tests for the same

### Impact
- fixes #3138