### PR TITLE
Add setDeviceMetrics command.

### DIFF
--- a/lib/api/client-commands/setDeviceMetrics.js
+++ b/lib/api/client-commands/setDeviceMetrics.js
@@ -1,0 +1,55 @@
+const ClientCommand = require('./_base-command.js');
+const {Logger} = require('../../utils');
+
+/**
+ * Override Device Mode (override the device dimensions).
+ *
+ * @example
+ *  this.demoTest = function (browser) {
+ *    browser
+ *      .setDeviceMetrics({
+ *        width: 400,
+ *        height: 600,
+ *        deviceScaleFactor: 50,
+ *        mobile: true
+ *        })
+ *      .navigateTo('https://www.google.com');
+ *  };
+ *
+ * @method setDeviceMetrics
+ * @syntax .setDeviceMetrics({width, height, deviceScaleFactor, mobile}, [callback])
+ * @param {object} metrics
+ * @param {function} [callback] Optional callback function to be called when the command finishes.
+ */
+class SetDeviceMetrics extends ClientCommand {
+
+  performAction(callback) {
+
+    if (!this.api.isChrome()  && !this.api.isEdge()) {
+      const error =  new Error('SetDeviceMetrics is not supported while using this driver');
+      Logger.error(error);
+
+      return callback(error);
+    }
+
+    // The default values below disables the override for that property (if a user
+    // has not set a property, they'd want that property to not be overridden).
+    const {width=0, height=0, deviceScaleFactor=0, mobile=false} = this.metrics;
+    const metrics = {width, height, deviceScaleFactor, mobile};
+
+    this.transportActions
+      .setDeviceMetrics(metrics, callback)
+      .catch(err => {
+        return err;
+      })
+      .then(result => callback(result));
+  }
+
+  command(metrics, callback) {
+    this.metrics = metrics || {};
+
+    return super.command(callback);
+  }
+}
+
+module.exports = SetDeviceMetrics;

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -940,6 +940,23 @@ module.exports = class MethodMappings {
           return {
             value: null
           };
+        },
+        
+        ///////////////////////////////////////////////////////////////////////////
+        // CDP commands
+        ///////////////////////////////////////////////////////////////////////////
+
+        async setDeviceMetrics(metrics) {
+          const pageCdpConnection = await this.driver.createCDPConnection('page');
+
+          await pageCdpConnection.execute(
+            'Emulation.setDeviceMetricsOverride',
+            metrics
+          );
+
+          return {
+            value: null
+          };
         }
         
       }

--- a/test/src/api/commands/client/testSetDeviceMetrics.js
+++ b/test/src/api/commands/client/testSetDeviceMetrics.js
@@ -1,0 +1,184 @@
+const assert = require('assert');
+const CommandGlobals = require('../../../../lib/globals/commands.js');
+const MockServer = require('../../../../lib/mockserver.js');
+const Nightwatch = require('../../../../lib/nightwatch.js');
+
+describe('.setDeviceMetrics()', function () {
+  beforeEach(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  afterEach(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  // Should set device metrics when all four properties are provided.
+  it('browser.setDeviceMetrics({width, height, deviceScaleFactor, mobile})', function (done) {
+
+    MockServer.addMock({
+      url: '/session',
+      response: {
+        value: {
+          sessionId: '13521-10219-202',
+          capabilities: {
+            browserName: 'chrome',
+            browserVersion: '92.0'
+          }
+        }
+      },
+      method: 'POST',
+      statusCode: 201
+    }, true);
+
+    Nightwatch.initW3CClient({
+      desiredCapabilities: {
+        browserName: 'chrome',
+        'goog:chromeOptions': {}
+      }
+    }).then(client => {
+
+      let expectedCDPCommand;
+      let expectedWidth;
+      let expectedHeight;
+      let expectedDeviceScaleFactor;
+      let expectedMobile;
+
+      client.transport.driver.createCDPConnection = function() {
+        return Promise.resolve({
+          execute: function(command, metrics) {
+            expectedCDPCommand = command;
+            expectedWidth = metrics.width;
+            expectedHeight = metrics.height;
+            expectedDeviceScaleFactor = metrics.deviceScaleFactor;
+            expectedMobile = metrics.mobile;
+          }
+        });
+      };
+      client.api.setDeviceMetrics({width: 400, height: 600, deviceScaleFactor: 50, mobile: true}, function (){
+        assert.strictEqual(expectedCDPCommand, 'Emulation.setDeviceMetricsOverride');
+        assert.strictEqual(expectedWidth, 400);
+        assert.strictEqual(expectedHeight, 600);
+        assert.strictEqual(expectedDeviceScaleFactor, 50);
+        assert.strictEqual(expectedMobile, true);
+      });
+      client.start(done);
+    });
+  });
+
+  // Should set device metrics when just two properties are provided.
+  it('browser.setDeviceMetrics({width, height})', function (done) {
+
+    MockServer.addMock({
+      url: '/session',
+      response: {
+        value: {
+          sessionId: '13521-10219-202',
+          capabilities: {
+            browserName: 'chrome',
+            browserVersion: '92.0'
+          }
+        }
+      },
+      method: 'POST',
+      statusCode: 201
+    }, true);
+
+    Nightwatch.initW3CClient({
+      desiredCapabilities: {
+        browserName: 'chrome',
+        'goog:chromeOptions': {}
+      }
+    }).then(client => {
+
+      let expectedCDPCommand;
+      let expectedWidth;
+      let expectedHeight;
+      let expectedDeviceScaleFactor;
+      let expectedMobile;
+
+      client.transport.driver.createCDPConnection = function() {
+        return Promise.resolve({
+          execute: function(command, metrics) {
+            expectedCDPCommand = command;
+            expectedWidth = metrics.width;
+            expectedHeight = metrics.height;
+            expectedDeviceScaleFactor = metrics.deviceScaleFactor;
+            expectedMobile = metrics.mobile;
+          }
+        });
+      };
+      client.api.setDeviceMetrics({width: 400, deviceScaleFactor: 100}, function (){
+        assert.strictEqual(expectedCDPCommand, 'Emulation.setDeviceMetricsOverride');
+        assert.strictEqual(expectedWidth, 400);
+        assert.strictEqual(expectedHeight, 0);
+        assert.strictEqual(expectedDeviceScaleFactor, 100);
+        assert.strictEqual(expectedMobile, false);
+      });
+      client.start(done);
+    });
+  });
+
+  // Should clear the device metrics override when no property is provided.
+  it('browser.setDeviceMetrics()', function (done) {
+
+    MockServer.addMock({
+      url: '/session',
+      response: {
+        value: {
+          sessionId: '13521-10219-202',
+          capabilities: {
+            browserName: 'chrome',
+            browserVersion: '92.0'
+          }
+        }
+      },
+      method: 'POST',
+      statusCode: 201
+    }, true);
+
+    Nightwatch.initW3CClient({
+      desiredCapabilities: {
+        browserName: 'chrome',
+        'goog:chromeOptions': {}
+      }
+    }).then(client => {
+
+      let expectedCDPCommand;
+      let expectedMetrics;
+
+      client.transport.driver.createCDPConnection = function() {
+        return Promise.resolve({
+          execute: function(command, metrics) {
+            expectedCDPCommand = command;
+            expectedMetrics = metrics;
+          }
+        });
+      };
+
+      client.api.setDeviceMetrics({}, function () {
+        assert.strictEqual(expectedCDPCommand, 'Emulation.setDeviceMetricsOverride');
+        assert.deepEqual(expectedMetrics, {deviceScaleFactor: 0, height: 0, mobile: false, width: 0});
+      });
+
+      // Checks if setDeviceMetrics works (doesn't throw error) with not argument at all.
+      client.api.setDeviceMetrics();
+
+      client.start(done);
+    });
+  });
+
+  it('browser.setDeviceMetrics - driver not supported', function(done){
+    Nightwatch.initW3CClient({
+      desiredCapabilities: {
+        browserName: 'firefox'
+      }
+    }).then(client => {
+      client.api.setDeviceMetrics({width: 400, height: 600, deviceScaleFactor: 50}, function(result){
+        assert.strictEqual(result.status, -1);
+        assert.strictEqual(result.error, 'SetDeviceMetrics is not supported while using this driver');
+      });
+      client.start(done);
+    });
+  });
+
+}); 


### PR DESCRIPTION
Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.

- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [ ] If you're fixing a bug also create an issue if one doesn't exist yet;
- [x] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [ ] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [x] Do not include changes that are not related to the issue at hand;
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [x] Always add unit tests - PRs without tests are most of the times ignored.


### Working

* When alteast one of the four metrics are provided, it overrides the device mode for those properties, rest properties are not overridden (done by setting those properties to 0, `mobile` property to false).
* If none of the properties are provided, it disables the override for all the properties (by setting those properties to 0 and `mobile` to false).

**Note:** The second point above can also be done by using [`Emulation.clearDeviceMetricsOverride`](https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-clearDeviceMetricsOverride) CDP command, but to use this command, we'd need to use the same `CdpConnection` instance (the one created by `this.driver.createCDPConnection('page')` in method-mappings file) for both setting and clearing the DeviceMetricsOverride. So, for this to work, we'd need to figure out a way to use a single CDP connection for the entire test block.

One thing to note is that no matter how many `CDPConnection` instances we create, only a single WS connection is used for all of them.