### PR TITLE
Set discardStdin to false while initializing ora.

### DIFF
--- a/lib/api/protocol/url.js
+++ b/lib/api/protocol/url.js
@@ -37,7 +37,8 @@ module.exports = class Action extends ProtocolAction {
       if (this.settings.output) {
         spinner = ora({
           text: `Loading url: ${url}\n`,
-          prefixText: ' '
+          prefixText: ' ',
+          discardStdin: false
         }).start();
       }
 


### PR DESCRIPTION
Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.

- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [x] If you're fixing a bug also create an issue if one doesn't exist yet;
- [ ] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [x] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [x] Do not include changes that are not related to the issue at hand;
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [ ] Always add unit tests - PRs without tests are most of the times ignored.

Setting [`discardStdin`](https://github.com/sindresorhus/ora/issues/209) to `false` resolves #3268 as the `stdin` stream is no longer paused. And not discarding the `stdin` stream does not create any issue as such and the spinner still works fine.
