### PR TITLE
retain html report

### DIFF
--- a/lib/reporter/global-reporter.js
+++ b/lib/reporter/global-reporter.js
@@ -185,7 +185,7 @@ module.exports = class GlobalReporter {
   }
 
   async writeReport(reporter, globalResults) {
-    const {globals, output_folder, start_session, html_reporter = {}} = this.settings;
+    const {globals, output_folder, start_session, folder_format} = this.settings;
     const needsCallback = reporter.write.length === 3;
     const options = {
       filename_prefix: this.settings.report_prefix,
@@ -194,8 +194,7 @@ module.exports = class GlobalReporter {
       start_session,
       reporter,
       openReport: this.openReport,
-      folder_format: html_reporter.folder_format, 
-      retain_report: html_reporter.retain_report
+      folder_format
     };
 
     if (needsCallback) {

--- a/lib/reporter/global-reporter.js
+++ b/lib/reporter/global-reporter.js
@@ -185,7 +185,7 @@ module.exports = class GlobalReporter {
   }
 
   async writeReport(reporter, globalResults) {
-    const {globals, output_folder, start_session} = this.settings;
+    const {globals, output_folder, start_session, html_reporter} = this.settings;
     const needsCallback = reporter.write.length === 3;
     const options = {
       filename_prefix: this.settings.report_prefix,
@@ -193,7 +193,9 @@ module.exports = class GlobalReporter {
       globals,
       start_session,
       reporter,
-      openReport: this.openReport
+      openReport: this.openReport,
+      folder_format: html_reporter.folder_format || null,
+      retain_report: html_reporter.retain_report || false
     };
 
     if (needsCallback) {

--- a/lib/reporter/global-reporter.js
+++ b/lib/reporter/global-reporter.js
@@ -185,7 +185,7 @@ module.exports = class GlobalReporter {
   }
 
   async writeReport(reporter, globalResults) {
-    const {globals, output_folder, start_session, html_reporter} = this.settings;
+    const {globals, output_folder, start_session, html_reporter = {}} = this.settings;
     const needsCallback = reporter.write.length === 3;
     const options = {
       filename_prefix: this.settings.report_prefix,
@@ -194,8 +194,8 @@ module.exports = class GlobalReporter {
       start_session,
       reporter,
       openReport: this.openReport,
-      folder_format: html_reporter.folder_format || null,
-      retain_report: html_reporter.retain_report || false
+      folder_format: html_reporter.folder_format, 
+      retain_report: html_reporter.retain_report
     };
 
     if (needsCallback) {

--- a/lib/reporter/reporters/html.js
+++ b/lib/reporter/reporters/html.js
@@ -62,6 +62,20 @@ class HtmlReporter extends BaseReporter {
       });
   }
 
+  getFolderPrefix() {
+    let folderPrefix = '';
+    const {folder_format, retain_report} = this.options; 
+    if (retain_report) {
+      if (typeof folder_format === 'function') {
+        folderPrefix = folder_format(this.results);
+      } else if (typeof folder_format === 'string') {
+        folderPrefix = folder_format;
+      }
+    }
+
+    return folderPrefix;
+  }
+
   async writeReport(data) {
     const results = this.results;
     const {modules}  = results;
@@ -80,7 +94,9 @@ class HtmlReporter extends BaseReporter {
       return prev;
     }, {});
 
-    const destFolder = path.join(output_folder, 'nightwatch-html-report');
+    const destFolder = path.join(output_folder, this.getFolderPrefix(), 'nightwatch-html-report');
+
+    
     await Utils.createFolder(destFolder);
 
     const filename = path.join(destFolder, 'index.html');

--- a/lib/reporter/reporters/html.js
+++ b/lib/reporter/reporters/html.js
@@ -96,7 +96,6 @@ class HtmlReporter extends BaseReporter {
 
     const destFolder = path.join(output_folder, this.getFolderPrefix(), 'nightwatch-html-report');
 
-    
     await Utils.createFolder(destFolder);
 
     const filename = path.join(destFolder, 'index.html');

--- a/lib/reporter/reporters/html.js
+++ b/lib/reporter/reporters/html.js
@@ -64,8 +64,8 @@ class HtmlReporter extends BaseReporter {
 
   getFolderPrefix() {
     let folderPrefix = '';
-    const {folder_format, retain_report} = this.options; 
-    if (retain_report) {
+    const {folder_format} = this.options; 
+    if (folder_format) {
       if (typeof folder_format === 'function') {
         folderPrefix = folder_format(this.results);
       } else if (typeof folder_format === 'string') {

--- a/lib/runner/test-runners/mocha.js
+++ b/lib/runner/test-runners/mocha.js
@@ -134,7 +134,7 @@ class MochaRunner {
     }
 
     if (this.mochaOpts.reporter === 'mochawesome' && !this.mochaOpts.reporterOptions.reportDir) {
-      this.mochaOpts.reporterOptions.reportDir = 'html-report';
+      this.mochaOpts.reporterOptions.reportDir =  settings.reportDir || 'html-report';
     }
 
     const MochaNightwatch = MochaRunner.MochaNightwatch({settings, argv, addtOpts});

--- a/lib/settings/defaults.js
+++ b/lib/settings/defaults.js
@@ -1,36 +1,18 @@
 const filename_format = function ({testSuite = '', testCase = '', isError = false, dateObject = new Date()} = {}) {
   const fileName = [];
+  const dateParts = dateObject.toString().replace(/:/g, '').split(' ');
+  dateParts.shift();
+
+  const dateStamp = dateParts.slice(0, 5).join('-');
   if (testSuite) {
     fileName.push(testSuite);
   }
   if (testCase) {
     fileName.push(testCase);
   }
-  const dateStamp = getDateStamp(dateObject);
 
   return `${fileName.join('/')}${isError ? '_ERROR' : '_FAILED'}_${dateStamp}.png`;
 };
-
-const folder_format = function({failed, errors, dateObject = new Date()} = {}) {
-  const dateStamp = getDateStamp(dateObject);
-  
-  let prefix = '';
-  if (failed) {
-    prefix +='FAILED';
-  } else if (errors) {
-    prefix += 'ERRORS';
-  }
-
-  return `${prefix}_${dateStamp}`;
-};
-
-function getDateStamp(dateObject) {
-  const dateParts = dateObject.toString().replace(/:/g, '').split(' ');
-  dateParts.shift();
-
-  return dateParts.slice(0, 5).join('-');
-}
-
 
 module.exports = {
   // Location(s) where custom commands will be loaded from.
@@ -264,14 +246,6 @@ module.exports = {
     path: '',
     on_error: true,
     on_failure: true
-  },
-
-  // HTML report options that will be use by html report
-  html_reporter: {
-    // retain html report across test runs
-    retain_report: false,
-    // used to generate html assets
-    folder_format
   },
 
   // Used to enable showing the Base64 image data in the (verbose) log when taking screenshots.

--- a/lib/settings/defaults.js
+++ b/lib/settings/defaults.js
@@ -1,18 +1,36 @@
 const filename_format = function ({testSuite = '', testCase = '', isError = false, dateObject = new Date()} = {}) {
   const fileName = [];
-  const dateParts = dateObject.toString().replace(/:/g, '').split(' ');
-  dateParts.shift();
-
-  const dateStamp = dateParts.slice(0, 5).join('-');
   if (testSuite) {
     fileName.push(testSuite);
   }
   if (testCase) {
     fileName.push(testCase);
   }
+  const dateStamp = getDateStamp(dateObject);
 
   return `${fileName.join('/')}${isError ? '_ERROR' : '_FAILED'}_${dateStamp}.png`;
 };
+
+const folder_format = function({failed, errors, dateObject = new Date()} = {}) {
+  const dateStamp = getDateStamp(dateObject);
+  
+  let prefix = '';
+  if (failed) {
+    prefix +='FAILED';
+  } else if (errors) {
+    prefix += 'ERRORS';
+  }
+
+  return `${prefix}_${dateStamp}`;
+};
+
+function getDateStamp(dateObject) {
+  const dateParts = dateObject.toString().replace(/:/g, '').split(' ');
+  dateParts.shift();
+
+  return dateParts.slice(0, 5).join('-');
+}
+
 
 module.exports = {
   // Location(s) where custom commands will be loaded from.
@@ -246,6 +264,14 @@ module.exports = {
     path: '',
     on_error: true,
     on_failure: true
+  },
+
+  // HTML report options that will be use by html report
+  html_reporter: {
+    // retain html report across test runs
+    retain_report: false,
+    // used to generate html assets
+    folder_format
   },
 
   // Used to enable showing the Base64 image data in the (verbose) log when taking screenshots.

--- a/lib/settings/defaults.js
+++ b/lib/settings/defaults.js
@@ -108,8 +108,13 @@ module.exports = {
   // this can be useful when persisting data between test suites is needed, such as a cookie or session information
   persist_globals: false,
 
-  // The location where the JUnit XML report files will be saved. Set this to false if you want to disable XML reporting
-  output_folder: 'tests_output',
+  reporter_options: {
+    // The location where the JUnit XML and HTML report files will be saved. Set this to false if you want to disable XML reporting
+    output_folder: 'tests_output',
+
+    //The folder formatting to use while saving HTML report
+    folder_format: null
+  },
 
   // A string or array of folders (excluding subfolders) where the tests are located.
   src_folders: null,

--- a/lib/settings/settings.js
+++ b/lib/settings/settings.js
@@ -275,6 +275,7 @@ class Settings {
     this.setUnitTestsMode();
     this.setParallelMode();
     this.setTestRunner();
+    this.setReporterOptions();
 
     if (typeof this.settings.src_folders == 'string') {
       this.settings.src_folders = [this.settings.src_folders];
@@ -285,6 +286,10 @@ class Settings {
     }
 
     return this;
+  }
+
+  setReporterOptions() {
+    defaultsDeep(this.settings, this.settings.reporter_options);
   }
 
   setParallelMode() {

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,5 +1,6 @@
 var Nightwatch = require('./nightwatch.js');
 const fs = require('fs');
+const glob = require('glob');
 
 module.exports = {
 
@@ -41,14 +42,19 @@ module.exports = {
     return process.platform === 'win32' ? '\r\n' : '\n';
   },
 
-  readFilePromise(fileName) {
+  readFilePromise(pattern) {
     return new Promise(function(resolve, reject) {
-      fs.readFile(fileName, function(err, result) {
-        if (err) {
-          return reject(err);
+      glob(pattern, (error, matches)=> {
+        if (error) {
+          return reject(error);
         }
-
-        resolve(result);
+        fs.readFile(matches[0], function(err, result) {
+          if (err) {
+            return reject(err);
+          }
+          
+          return resolve(result);
+        });
       });
     });
   },

--- a/test/src/cli/testCliRunner.js
+++ b/test/src/cli/testCliRunner.js
@@ -56,6 +56,12 @@ describe('Test CLI Runner', function() {
       }
     });
 
+    mockery.registerMock('./reporter_options.json', {
+      reporter_options: {
+        output_folder: 'output'
+      }
+    });
+
     mockery.registerMock('./empty.json', {
       src_folders: 'tests'
     });
@@ -399,6 +405,35 @@ describe('Test CLI Runner', function() {
     assert.strictEqual(runner.settings.output_folder, false);
   });
 
+  it('testSetOutputFolder using reporterOptions', function(done) {
+    mockery.registerMock('fs', {
+      statSync: function(module) {
+        if (module === './settings.json' || module === './nightwatch.conf.js') {
+          throw new Error('Does not exist');
+        }
+
+        return {
+          isFile: function() {
+            return true;
+          }
+        };
+      },
+      constants,
+      rmdirSync
+    });
+
+    const CliRunner = common.require('runner/cli/cli.js');
+    const runner = new CliRunner({
+      config: './reporter_options.json',
+      env: 'default'
+    }).setup();
+
+    assert.strictEqual(runner.test_settings.output_folder, 'output');
+
+    done();
+  });
+  
+
   it('testReadSettingsDeprecated', function(done) {
     mockery.registerMock('fs', {
       statSync: function(module) {
@@ -435,6 +470,8 @@ describe('Test CLI Runner', function() {
 
     done();
   });
+
+ 
 
   it('testCustomSettingsFileAndEnvironment', function() {
     mockery.registerMock('fs', {

--- a/test/src/cli/testCliRunnerMocha.js
+++ b/test/src/cli/testCliRunnerMocha.js
@@ -180,6 +180,10 @@ describe('test CLI Runner Mocha', function() {
       reporter: 'mochawesome'
     };
 
+    if (isCi) {
+      mochaOptions.color = false;
+    }
+
     mockery.registerMock('mochawesome', {});
 
     mockery.registerMock('./withmochaReportOptions.json', {

--- a/test/src/cli/testCliRunnerMocha.js
+++ b/test/src/cli/testCliRunnerMocha.js
@@ -168,6 +168,55 @@ describe('test CLI Runner Mocha', function() {
       assert.deepStrictEqual(testFiles, ['test1.js', 'test2.js']);
     });
   });
+
+  it('testRunWithMochaReporterOptions', function() {
+    const testFiles = [];
+
+    const mochaOptions = {
+      timeout: 20000, 
+      reporterOptions: {
+        reportDir: 'html-dir'
+      },
+      reporter: 'mochawesome'
+    };
+
+    mockery.registerMock('mochawesome', {});
+
+    mockery.registerMock('./withmochaReportOptions.json', {
+      src_folders: ['tests'],
+      output_folder: false,
+      test_settings: {
+        'default': {
+          silent: true
+        }
+      },
+      reporter_options: {
+        reportDir: 'html-dir'
+      },
+      test_runner: {
+        type: 'mocha',
+        options: {
+          reporter: 'mochawesome'
+        }
+      }
+    });
+
+    createMockedMocha(function(options) {
+      assert.deepStrictEqual(options, mochaOptions);
+    }, testFiles);
+
+    const CliRunner = common.require('runner/cli/cli.js');
+    const runner = new CliRunner({
+      config: './withmochaReportOptions.json',
+      env: 'default',
+      reporter: 'junit'
+    }).setup();
+
+    return runner.runTests().then(function() {
+      assert.deepStrictEqual(testFiles, ['test1.js', 'test2.js']);
+    });
+  });
+
 });
 
 

--- a/test/src/runner/testRunnerHtmlOutput.js
+++ b/test/src/runner/testRunnerHtmlOutput.js
@@ -116,4 +116,44 @@ describe('testRunnerHTMLOutput', function() {
       });
      
   });
+  
+  it('test html report folder', function () {
+
+    const testsPath = [
+      path.join(__dirname, '../../sampletests/withfailures')
+    ];
+
+    MockServer.addMock({
+      url: '/wd/hub/session/1352110219202/screenshot',
+      method: 'GET',
+      response: JSON.stringify({
+        sessionId: '1352110219202',
+        status: 0,
+        value: '<faketag>fakedata'
+      })
+    }, true);
+
+
+    return runTests({source: testsPath, reporter: 'html'}, settings({
+      output_folder: outputPath,
+      globals: {
+        waitForConditionPollInterval: 20,
+        waitForConditionTimeout: 50,
+        retryAssertionTimeout: 50,
+        reporter: function () {
+        }
+      },
+      html_reporter: {
+        retain_report: true
+      }
+    }))
+      .then(_ => {
+        return readFilePromise(`${outputPath}${path.sep}*${path.sep}nightwatch-html-report${path.sep}index.html`);
+      }).
+      then(_ => {
+      });
+     
+  });
+
+
 });

--- a/test/src/runner/testRunnerHtmlOutput.js
+++ b/test/src/runner/testRunnerHtmlOutput.js
@@ -117,7 +117,7 @@ describe('testRunnerHTMLOutput', function() {
      
   });
   
-  it('test html report folder', function () {
+  it('test html report folder with a folder format function', function () {
 
     const testsPath = [
       path.join(__dirname, '../../sampletests/withfailures')
@@ -143,8 +143,10 @@ describe('testRunnerHTMLOutput', function() {
         reporter: function () {
         }
       },
-      html_reporter: {
-        retain_report: true
+      reporter_options: {
+        folder_format: function() {
+          return Date.now().toString();
+        }
       }
     }))
       .then(_ => {

--- a/test/src/runner/testRunnerHtmlOutput.js
+++ b/test/src/runner/testRunnerHtmlOutput.js
@@ -152,8 +152,5 @@ describe('testRunnerHTMLOutput', function() {
       }).
       then(_ => {
       });
-     
   });
-
-
 });


### PR DESCRIPTION
## Changes
- Add a flag to retain HTML report across test runs
- Default behaviour is not changed it generates different HTML reports if `retain_report` is set to true

## Impacts
- fixes #3307 