### PR TITLE
Fixes/resolve command node in assert commands

### DIFF
--- a/lib/api/_loaders/assertion-scheduler.js
+++ b/lib/api/_loaders/assertion-scheduler.js
@@ -139,18 +139,16 @@ class AssertionScheduler {
           Utils.makePromise(this.instance.doneCallback, this, [resolveValue, this.instance]);
         })
         .then(_ => {
-          if (resolveValue.passed) {
-            this.deferred.resolve(resolveValue);
-          } else {
-            this.deferred.reject(resolveValue.err);
-          }
-
-          return resolveValue;
-        })
-        .then(_ => {
           if (testError && testError.name !== 'NoSuchElementError') {
             this.opts.reporter.registerTestError(testError);
           }
+          setTimeout(()=> {
+            if (resolveValue.passed) {
+              this.deferred.resolve(resolveValue);
+            } else {
+              this.deferred.reject(resolveValue.err);
+            }
+          });
         });
     }.bind(this), this.instance);
   }

--- a/lib/api/_loaders/static.js
+++ b/lib/api/_loaders/static.js
@@ -8,6 +8,8 @@ const chaiExpect = chai.expect;
 const {flag} = chai.util;
 const {AssertionRunner} = require('../../assertion');
 
+let __last_deferred__ = null;
+
 module.exports = class StaticAssert {
   static get assertOperators() {
     return {
@@ -25,6 +27,14 @@ module.exports = class StaticAssert {
       fail: 'fail',
       ifError: 'ifError'
     };
+  }
+
+  static get lastDeferred() {
+    return __last_deferred__;
+  }
+
+  static set lastDeferred(value) {
+    __last_deferred__ = value;
   }
 
   get api() {
@@ -55,13 +65,14 @@ module.exports = class StaticAssert {
       constructor({negate, args}) {
         super();
 
+        StaticAssert.lastDeferred = null;
         this.negate = negate;
         this.args = args;
         this.passed = null;
         this.expected = null;
         this.actual = null;
-        let lastArgument = args[args.length - 1];
-        let isLastArgString = Utils.isString(lastArgument);
+        const lastArgument = args[args.length - 1];
+        const isLastArgString = Utils.isString(lastArgument);
         this.message = isLastArgString && (args.length > 2 || Utils.isBoolean(args[0])) && lastArgument ||
           Utils.isFunction(args[0]) && '[Function]';
       }
@@ -146,8 +157,15 @@ module.exports = class StaticAssert {
         isES6Async
       });
 
-      if (isES6Async) {
+      if (isES6Async || node.isES6Async) {
+        StaticAssert.lastDeferred = deferred;
+
         Object.assign(node.deferred.promise, this.api);
+
+        //prevent unhandled rejection        
+        node.deferred.promise.catch(err => {
+          return StaticAssert.lastDeferred.reject(err);
+        });
 
         return node.deferred.promise;
       }

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -88,7 +88,7 @@ class AsyncTree extends EventEmitter{
   }
 
   shouldRejectNodePromise(err) {
-    if (err.isExpect && this.currentNode.isES6Async) {
+    if ((err.isExpect|| this.currentNode.namespace === 'assert') && this.currentNode.isES6Async) {
       return true;
     }
 
@@ -105,7 +105,7 @@ class AsyncTree extends EventEmitter{
       return false;
     }
 
-    return err.name === 'NightwatchAssertError' && !err.isExpect && !parent.isRootNode && parent.isES6Async;
+    return err.name !== 'NightwatchAssertError' && !err.isExpect && !parent.isRootNode && parent.isES6Async;
   }
 
   async runChildNode(node) {

--- a/test/apidemos/custom-commands/testUsingAsyncCustomAssert.js
+++ b/test/apidemos/custom-commands/testUsingAsyncCustomAssert.js
@@ -1,0 +1,5 @@
+describe('custom command using assert', function () {
+  it('element visible using custom command', async function() {
+    await browser.customVisible('#weblogin');
+  });
+});

--- a/test/extra/commands/es6async/customVisible.js
+++ b/test/extra/commands/es6async/customVisible.js
@@ -1,0 +1,5 @@
+module.exports = class customVisible {
+  async command(selector) {
+    await this.api.assert.visible(selector);
+  }
+};

--- a/test/lib/command-mocks.js
+++ b/test/lib/command-mocks.js
@@ -204,6 +204,16 @@ module.exports = {
     return this;
   },
 
+  w3cVisible(value = true) {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value
+      })
+    }, true);
+  }, 
+
   findElements({using = 'css selector', value = '#container', response = null, times = 0}) {
     const mockOpts = {
       url: '/session/13521-10219-202/elements',

--- a/test/sampletests/es6await/selenium/basicSampleTestSelenium.js
+++ b/test/sampletests/es6await/selenium/basicSampleTestSelenium.js
@@ -10,7 +10,7 @@ describe('basicSampleTest', function() {
       assert.deepStrictEqual(result, {value: [{ELEMENT: '0'}], status: 0, returned: 1, passed: true});
     });
 
-    assert.deepStrictEqual(assertResult, {value: [{ELEMENT: '0'}], status: 0, returned: 1, passed: true});
+    assert.deepStrictEqual(assertResult, [{ELEMENT: '0'}]);
 
     await browser.end();
   });

--- a/test/sampletests/suiteretries/locate-strategy/suiteRetriesLocateStrategy.js
+++ b/test/sampletests/suiteretries/locate-strategy/suiteRetriesLocateStrategy.js
@@ -20,7 +20,8 @@ module.exports = {
       .perform(function() {
         if (failFirstTime) {
           failFirstTime = false;
-          client.assert.ok(false);
+
+          return client.assert.ok(false);
         }
       });
   }

--- a/test/src/apidemos/custom-commands/testCustomCommandsAsync.js
+++ b/test/src/apidemos/custom-commands/testCustomCommandsAsync.js
@@ -38,12 +38,42 @@ describe('custom commands with findElements es6 async', function() {
     };
 
     return NightwatchClient.runTests(testsPath, settings({
-      output: false,
+      output: true,
+      silent: false,
       selenium_host: null,
       custom_commands_path: [path.join(__dirname, '../../../extra/commands/es6async')],
       globals
     }));
   });
 
+  it('custom assert visible es6 async', function() {
+    const testsPath = path.join(__dirname, '../../../apidemos/custom-commands/testUsingAsyncCustomAssert.js');
+    
+    Mocks.createNewW3CSession({
+      testName: 'custom command using assert'
+    });
+
+    Mocks.w3cVisible(true);
+
+    const globals = {
+      waitForConditionPollInterval: 50,
+      waitForConditionTimeout: 120,
+      retryAssertionTimeout: 1000,
+
+      reporter(results) {
+        if (results.lastError) {
+          throw results.lastError;
+        }
+      }
+    };
+
+    return NightwatchClient.runTests(testsPath, settings({
+      output: true,
+      silent: false,
+      selenium_host: null,
+      custom_commands_path: [path.join(__dirname, '../../../extra/commands/es6async')],
+      globals
+    }));
+  });
 
 });

--- a/test/src/apidemos/custom-commands/testCustomCommandsAsync.js
+++ b/test/src/apidemos/custom-commands/testCustomCommandsAsync.js
@@ -38,8 +38,8 @@ describe('custom commands with findElements es6 async', function() {
     };
 
     return NightwatchClient.runTests(testsPath, settings({
-      output: true,
-      silent: false,
+      output: false,
+      silent: true,
       selenium_host: null,
       custom_commands_path: [path.join(__dirname, '../../../extra/commands/es6async')],
       globals
@@ -68,8 +68,8 @@ describe('custom commands with findElements es6 async', function() {
     };
 
     return NightwatchClient.runTests(testsPath, settings({
-      output: true,
-      silent: false,
+      output: false,
+      silent: true,
       selenium_host: null,
       custom_commands_path: [path.join(__dirname, '../../../extra/commands/es6async')],
       globals


### PR DESCRIPTION
### Changes
- Delay the resolution of assert node so that command node (child node of assert resolves first).
- Added test to check if async/await custom commands using asserts works fine.
- fix static assertions (`assert.ok`) to return a promise in case of async `node`.
- reject assert node if error is assertion assertion error.
- fix a test to drop `status` params from promise result.

### Impacts
- fixes #3301 