### PR TITLE
Fix cli failure on Windows due to pause() tests.

### DIFF
--- a/test/sampletests/withuncaughterrors/demoTestWithError.js
+++ b/test/sampletests/withuncaughterrors/demoTestWithError.js
@@ -13,7 +13,7 @@ describe('test with uncaught error', function () {
 
     setTimeout(function () {
       throw new Error('Test Error Uncaught');
-    }, 25);
+    }, 100);
   });
 
 });

--- a/test/src/api/commands/client/testPause.js
+++ b/test/src/api/commands/client/testPause.js
@@ -10,23 +10,21 @@ describe('.pause()', function() {
     CommandGlobals.afterEach.call(this, done);
   });
 
-  it('browser.pause(10)', function(done) {
+  it('browser.pause(10) pauses atleast 10ms and not more than 2000ms', function(done) {
     const startTime = new Date();
     this.client.api.pause(10, function() {
       const timeElapsed = new Date() - startTime;
       assert.ok(timeElapsed >= 10);
-      assert.ok(timeElapsed <= 20);
     });
 
     this.client.start(done);
   });
 
-  it('browser.pause(200)', function(done) {
+  it('browser.pause(200) pauses for atleast 200ms and not more than 2000ms', function(done) {
     const startTime = new Date();
     this.client.api.pause(200, function() {
       const timeElapsed = new Date() - startTime;
       assert.ok(timeElapsed >= 200);
-      assert.ok(timeElapsed <= 210);
     });
 
     this.client.start(done);
@@ -37,7 +35,6 @@ describe('.pause()', function() {
     this.client.api.pause(undefined, function() {
       const timeElapsed = new Date() - startTime;
       assert.ok(timeElapsed >= 200);
-      assert.ok(timeElapsed <= 220);
     });
 
     setTimeout(() => {
@@ -52,7 +49,6 @@ describe('.pause()', function() {
     this.client.api.pause(undefined, function() {
       const timeElapsed = new Date() - startTime;
       assert.ok(timeElapsed >= 1000);
-      assert.ok(timeElapsed <= 1020);
     });
 
     setTimeout(() => {
@@ -71,7 +67,6 @@ describe('.pause()', function() {
     this.client.api.pause(undefined, function() {
       const timeElapsed = new Date() - startTime;
       assert.ok(timeElapsed >= 200);
-      assert.ok(timeElapsed <= 220);
       assert.strictEqual(Debuggability.stepOverAndPause, true);
     });
 
@@ -91,7 +86,6 @@ describe('.pause()', function() {
     this.client.api.pause(undefined, function() {
       const timeElapsed = new Date() - startTime;
       assert.ok(timeElapsed >= 200);
-      assert.ok(timeElapsed <= 220);
       assert.strictEqual(Debuggability.stepOverAndPause, true);
     });
 
@@ -120,7 +114,6 @@ describe('.pause()', function() {
     this.client.api.pause(undefined, function() {
       const timeElapsed = new Date() - startTime;
       assert.ok(timeElapsed >= 200);
-      assert.ok(timeElapsed <= 220);
       assert.strictEqual(apiEndCalledWithCallback, true);
       assert.strictEqual(callbackCalled.toString().includes('process.exit(0)'), true);
 

--- a/test/src/runner/testRunnerUncaughtErrors.js
+++ b/test/src/runner/testRunnerUncaughtErrors.js
@@ -75,6 +75,6 @@ describe('testRunWithUncaughtErrors', function() {
       } catch (e) {
         done(e);
       }
-    }, 500);
+    }, 1500);
   });
 });


### PR DESCRIPTION
~Increased the time in assertions to give a good margin to the `pause()` command to complete.~
Removed the upper limit of time for pause command.

Tested on Windows machine by running the tests multiple times.