### PR TITLE
set path prefix to empty string by default

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -14,7 +14,8 @@ const __defaultSettings__ = {
   use_ssl: false,
   proxy: null,
   timeout: 60000,
-  retry_attempts: 0
+  retry_attempts: 0,
+  default_path: ''
 };
 
 let __globalSettings__ = null;


### PR DESCRIPTION
fix #3304 