### PR TITLE
Fix #3361 expect.cookie always returning undefined value

### DIFF
--- a/lib/api/expect/cookie.js
+++ b/lib/api/expect/cookie.js
@@ -51,15 +51,7 @@ class ExpectCookie extends BaseExpect {
         if (!result.value) {
           return this.reject(new NotFoundError(`no cookie "${this.cookieName}"${domainStr} was found`));
         }
-        if (result && result.value) {
-          if (Array.isArray(result.value)) {
-            this.resultValue = result.value.length > 0 ? result.value[0].value : null;
-          } else {
-            this.resultValue = result.value.value;
-          }
-        } else {
-          this.resultValue = {};
-        }
+        this.resultValue = result ? result.value : {};
 
         return this.resolve(this.resultValue);
       })

--- a/test/lib/nocks.js
+++ b/test/lib/nocks.js
@@ -474,13 +474,9 @@ module.exports = {
       .reply(200, {
         status: 0,
         state: 'success',
-        value: [
-          {
-            domain: 'cookie-domain',
-            name: name,
-            value: value
-          }
-        ]
+        domain: 'cookie-domain',
+        name: name,
+        value: value
       });
 
     return this;

--- a/test/lib/nocks.js
+++ b/test/lib/nocks.js
@@ -474,9 +474,11 @@ module.exports = {
       .reply(200, {
         status: 0,
         state: 'success',
-        domain: 'cookie-domain',
-        name: name,
-        value: value
+        value : {
+          domain: 'cookie-domain',
+          name: name,
+          value: value
+        }
       });
 
     return this;


### PR DESCRIPTION
### Impacts 

- #3361 

### Changes

- Array check was removed since the [getCookie function](https://github.com/SeleniumHQ/selenium/blob/trunk/javascript/node/selenium-webdriver/lib/webdriver.js#L1831-L1853) in Selenium always returns the result as an object rather than an array (**Note** : _I also tested it on subdomains and paths to see if it produces an array value or not, but I always got an object instead of an array._ )
- Fixed `result.value.value` to `result.value` because `result.value.value` is returning `undefined` value
- Modified Nock's cookie response to fix the test-cases

