### PR TITLE
Fix test for Browserstack Transport

### DIFF
--- a/test/src/index/transport/testBrowserstackTransport.js
+++ b/test/src/index/transport/testBrowserstackTransport.js
@@ -5,7 +5,7 @@ const NightwatchClient = common.require('index.js');
 const SeleniumRemote = common.require('transport/selenium-webdriver/selenium.js');
 const Browserstack = common.require('transport/selenium-webdriver/browserstack.js');
 
-xdescribe('BrowserstackTransport', function () {
+describe('BrowserstackTransport', function () {
   beforeEach(function() {
     try {
       nock.activate();
@@ -228,25 +228,26 @@ xdescribe('BrowserstackTransport', function () {
     result.sessionId = '1234567';
     client.emit('nightwatch:session.create', result);
 
-    setTimeout(async function() {
+    return new Promise((resolve, reject) => {
+      setTimeout(async function() {
 
-      nock('https://api.browserstack.com')
-        .put('/automate/sessions/1234567.json', {
-          status: 'failed',
-          reason: 'NightwatchAssertError: Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected "visible" but got: "not found" (5400ms)'
-        })
-        .reply(200, {});
-
-      const error = new Error('Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected "visible" but got: "not found" (5400ms)');
-      error.name = 'NightwatchAssertError';
-
-      result = await transport.testSuiteFinished(error);
-
-      assert.strictEqual(result, true);
-      assert.strictEqual(transport.sessionId, null);
-
-    }, 100);
-
+        nock('https://api.browserstack.com')
+          .put('/automate/sessions/1234567.json', {
+            status: 'failed',
+            reason: 'NightwatchAssertError: Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected "visible" but got: "not found" (5400ms)'
+          })
+          .reply(200, {});
+  
+        const error = new Error('Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected "visible" but got: "not found" (5400ms)');
+        error.name = 'NightwatchAssertError';
+  
+        result = await transport.testSuiteFinished(error);
+  
+        assert.strictEqual(result, true);
+        assert.strictEqual(transport.sessionId, null);
+        resolve();
+      }, 100);
+    });
   });
 
   it('test create Transport for Browserstack - App automate', async function() {

--- a/test/src/index/transport/testBrowserstackTransport.js
+++ b/test/src/index/transport/testBrowserstackTransport.js
@@ -230,22 +230,25 @@ describe('BrowserstackTransport', function () {
 
     return new Promise((resolve, reject) => {
       setTimeout(async function() {
-
-        nock('https://api.browserstack.com')
-          .put('/automate/sessions/1234567.json', {
-            status: 'failed',
-            reason: 'NightwatchAssertError: Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected "visible" but got: "not found" (5400ms)'
-          })
-          .reply(200, {});
-  
-        const error = new Error('Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected "visible" but got: "not found" (5400ms)');
-        error.name = 'NightwatchAssertError';
-  
-        result = await transport.testSuiteFinished(error);
-  
-        assert.strictEqual(result, true);
-        assert.strictEqual(transport.sessionId, null);
-        resolve();
+        try {
+          nock('https://api.browserstack.com')
+            .put('/automate/sessions/1234567.json', {
+              status: 'failed',
+              reason: 'NightwatchAssertError: Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected "visible" but got: "not found" (5400ms)'
+            })
+            .reply(200, {});
+    
+          const error = new Error('Timed out while waiting for element <#james> to be present for 5000 milliseconds. - expected "visible" but got: "not found" (5400ms)');
+          error.name = 'NightwatchAssertError';
+    
+          result = await transport.testSuiteFinished(error);
+    
+          assert.strictEqual(result, true);
+          assert.strictEqual(transport.sessionId, null);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
       }, 100);
     });
   });


### PR DESCRIPTION
**The problem:** following error occurs after test execution completes, and assertions are not executed.

```
PUT https://api.browserstack.com:9999 /automate/sessions/1234567.json - ETIMEDOUT
Error: connect ETIMEDOUT 52.1.181.200:9999
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1157:16)
```

