### PR TITLE
Fix#3387 Remove event listeners on command completion

### DIFF
--- a/lib/core/treenode.js
+++ b/lib/core/treenode.js
@@ -191,14 +191,19 @@ class TreeNode {
       return;
     }
 
-    commandResult
-      .once('complete', result => {
-        resolveFn(result);
-      })
-      .once('error', (err, abortOnFailure) => {
-        err.abortOnFailure = abortOnFailure || abortOnFailure === undefined;
-        rejectFn(err);
-      });
+    const completeHandler =  result => {
+      commandResult.removeListener('error', errorHandler);
+      resolveFn(result);
+    };
+
+    const errorHandler = (err, abortOnFailure) => {
+      err.abortOnFailure = abortOnFailure || abortOnFailure === undefined;
+      commandResult.removeListener('complete', completeHandler);
+      rejectFn(err);
+    };
+
+    commandResult.once('complete', completeHandler);
+    commandResult.once('error', errorHandler);
   }
 }
 

--- a/test/src/core/testTreeNode.js
+++ b/test/src/core/testTreeNode.js
@@ -4,7 +4,7 @@ const TreeNode = require('../../../lib/core/treenode');
 
 describe('test Queue', function () {
   it('Test commands treeNode - clear error events in handleCommandResult', function () {
-    const treeNode =this.__rootNode__ = new TreeNode({
+    const treeNode = new TreeNode({
       name: '__root__',
       parent: null
     });

--- a/test/src/core/testTreeNode.js
+++ b/test/src/core/testTreeNode.js
@@ -1,0 +1,48 @@
+const assert = require('assert');
+const EventEmitter = require('events');
+const TreeNode = require('../../../lib/core/treenode');
+
+describe.only('test Queue', function () {
+  it('Test commands treeNode - clear error events in handleCommandResult', function () {
+    const treeNode =this.__rootNode__ = new TreeNode({
+      name: '__root__',
+      parent: null
+    });
+
+    class MockCommandLoader extends EventEmitter {
+      constructor() {
+        super();
+        this.__commandName = 'testCommand';
+      }
+    }
+
+    const mockCommandLoader = new MockCommandLoader();
+
+    treeNode.setCommand(()=>{}, mockCommandLoader, {}, {});
+
+    treeNode.execute();
+    treeNode.execute();
+    treeNode.execute();
+
+    assert.equal(mockCommandLoader.listenerCount('error'), 3);
+    assert.equal(mockCommandLoader.listenerCount('complete'), 3);
+    
+    mockCommandLoader.emit('complete');
+
+    assert.equal(mockCommandLoader.listenerCount('error'), 0);
+    assert.equal(mockCommandLoader.listenerCount('complete'), 0);   
+    
+    
+    treeNode.execute();
+    treeNode.execute();
+    treeNode.execute();
+
+    assert.equal(mockCommandLoader.listenerCount('error'), 3);
+    assert.equal(mockCommandLoader.listenerCount('complete'), 3);
+
+    mockCommandLoader.emit('error', new Error(), false);
+
+    assert.equal(mockCommandLoader.listenerCount('error'), 0);
+    assert.equal(mockCommandLoader.listenerCount('complete'), 0);  
+  });
+});

--- a/test/src/core/testTreeNode.js
+++ b/test/src/core/testTreeNode.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const EventEmitter = require('events');
 const TreeNode = require('../../../lib/core/treenode');
 
-describe.only('test Queue', function () {
+describe('test Queue', function () {
   it('Test commands treeNode - clear error events in handleCommandResult', function () {
     const treeNode =this.__rootNode__ = new TreeNode({
       name: '__root__',


### PR DESCRIPTION
Removes complete listener if error event occurs, and vice versa for complete event.