### PR TITLE
Features/update end command to handle reuse browser session

### DIFF
--- a/lib/api/_loaders/command.js
+++ b/lib/api/_loaders/command.js
@@ -84,6 +84,10 @@ class CommandLoader extends BaseCommandLoader {
         return nightwatchInstance.api;
       }
 
+      get reuseBrowser() {
+        return nightwatchInstance.argv['reuse-browser'] || (nightwatchInstance.settings.globals && nightwatchInstance.settings.globals.reuseBrowserSession);
+      }      
+      
       get isES6AsyncCommand() {
         return Utils.isES6AsyncFn(
           CommandLoader.isDeprecatedCommandStyle(CommandModule) ? CommandModule.command: this.command

--- a/lib/api/client-commands/end.js
+++ b/lib/api/client-commands/end.js
@@ -15,10 +15,16 @@ const EventEmitter = require('events');
  * @api protocol.sessions
  */
 class End extends EventEmitter {
-  command(callback) {
+  command(forceEnd = !this.reuseBrowser, callback) {
+
+    if (arguments.length === 1 && typeof arguments[0] === 'function') {
+      callback = forceEnd;
+      forceEnd = !this.reuseBrowser;
+    }
+
     const client = this.client;
 
-    if (this.api.sessionId) {
+    if (this.api.sessionId && forceEnd) {
       this.api.session('delete', result => {
         client.sessionId = null;
         client.setApiProperty('sessionId', null);

--- a/lib/testsuite/index.js
+++ b/lib/testsuite/index.js
@@ -636,7 +636,7 @@ class TestSuite {
     if (endSession) {
       const runnable = new Runnable('terminate', _ => {
         if (this.api && isFunction(this.api.end)) {
-          this.api.end();
+          this.api.end(endSession);
         }
       }, {
         isES6Async: this.isES6Async

--- a/test/sampletests/reusebrowser/firstTest.js
+++ b/test/sampletests/reusebrowser/firstTest.js
@@ -17,6 +17,7 @@ module.exports = {
   after(client, callback) {
     setTimeout(function() {
       client.globals.calls++;
+      client.end();
       callback();
     }, 10);
   }

--- a/test/sampletests/reusebrowser/secondTest.js
+++ b/test/sampletests/reusebrowser/secondTest.js
@@ -17,6 +17,7 @@ module.exports = {
   after(client, callback) {
     setTimeout(function() {
       client.globals.calls++;
+      client.end();
       callback();
     }, 10);
   }

--- a/test/src/api/commands/client/testEnd.js
+++ b/test/src/api/commands/client/testEnd.js
@@ -24,6 +24,22 @@ describe('.end()', function() {
       this.client.start(done);
     });
 
+    it('browser.end(true) - forceEnd by default true', function (done) { 
+      this.client.api.end(true, result => {
+        assert.strictEqual(result.status, 0);
+        assert.strictEqual(this.client.sessionId, null);
+      });
+      this.client.start(done);
+    });
+
+    it('browser.end(false) - do not end sesion', function(done) {
+      this.client.api.end(false, result=> {
+        assert.strictEqual(result, null);
+        assert.strictEqual(this.client.sessionId, '1352110219202');
+      });
+      this.client.start(done);
+    });
+
     it('browser.end() - no session id', function (done) {
       this.client.api.end();
       this.client.api.end(function callback(result) {
@@ -86,6 +102,21 @@ describe('.end()', function() {
         client.start(done);
       }).catch(err => done(err));
     });
+
+
+    it('browser.end() - reuse browser session', function (done) {
+
+      Nightwatch.initClient({globals: {reuseBrowserSession: true}})
+        .then(client => {
+          client.api.end(function callback(result) {
+            assert.strictEqual(result, null);
+            assert.strictEqual(client.sessionId, '1352110219202');
+          });
+
+          client.start(done);
+        }).catch(err => done(err));
+    });
+
 
     it('browser.end() - failures and screenshots disabled', function (done) {
       MockServer.addMock({

--- a/test/src/runner/testRunnerSessionCreate.js
+++ b/test/src/runner/testRunnerSessionCreate.js
@@ -349,6 +349,16 @@ describe('testRunnerSessionCreate', function() {
       })
     }, true);
 
+    MockServer.addMock({
+      url: '/session/1352110219202',
+      method: 'DELETE',
+      statusCode: 200,
+      response: JSON.stringify({
+        status: 0
+      })
+    }, true);
+
+
    
 
     const globals = {
@@ -391,6 +401,16 @@ describe('testRunnerSessionCreate', function() {
         sessionId: '1352110219202'
       })
     }, true);
+
+    MockServer.addMock({
+      url: '/session/1352110219202',
+      method: 'DELETE',
+      statusCode: 200,
+      response: JSON.stringify({
+        status: 0
+      })
+    }, true);
+
 
    
 


### PR DESCRIPTION
## Changes
- added `forceEnd` for `end` command
- handled `.end` command while resuing browser sessions

## Impacts
- `.end` command will not end sessions while reusing browser session unless forced.