### PR TITLE
fix module names for parallel runs

### DIFF
--- a/lib/runner/concurrency/index.js
+++ b/lib/runner/concurrency/index.js
@@ -231,8 +231,8 @@ class Concurrency extends EventEmitter {
    * @param {function} fn
    */
   static buildProcessQueue(maxWorkers, modules, fn) {
-    const queue = modules;
-    
+    const queue = modules.slice(0);
+
     let workers = 0;
     let index = 0;
 


### PR DESCRIPTION
Without the fix module names look like this when there are few modules in a folder

 ```bash
 Running:  chrome: tests/duckDuckGo.js 
 Running:  chrome: ecosia.js 
 Running:  chrome: explore.js 
```

Should look like this:
```
 Running:  chrome: tests/duckDuckGo.js 
 Running:  chrome: tests/ecosia.js 
 Running:  chrome: tests/explore.js 
```