### PR TITLE
Fix mobile app testing with `test_workers` enabled.

### DIFF
--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -10,6 +10,7 @@ const Transport = require('../transport');
 const Element = require('../element');
 const ApiLoader = require('../api');
 const ElementGlobal = require('../api/_loaders/element-global.js');
+const {isAndroid, isIos} = require('../utils/mobile');
 
 const {LocateStrategy, Locator} = Element;
 const {Logger, isUndefined, isDefined, isObject, isFunction} = Utils;
@@ -37,7 +38,7 @@ class NightwatchAPI {
     }
 
     if (this.desiredCapabilities instanceof Capabilities) {
-      return this.desiredCapabilities.getplatformName();
+      return this.desiredCapabilities.getPlatform();
     }
 
     return this.desiredCapabilities.platformName;
@@ -79,11 +80,11 @@ class NightwatchAPI {
   }
 
   isIOS() {
-    return this.__isPlatformName('iOS');
+    return isIos(this.desiredCapabilities);
   }
 
   isAndroid() {
-    return this.__isPlatformName('Android');
+    return isAndroid(this.desiredCapabilities);
   }
 
   isMobile() {

--- a/lib/utils/mobile.js
+++ b/lib/utils/mobile.js
@@ -29,7 +29,13 @@ function requireMobileHelper() {
  * @param {Object} desiredCapabilities 
  * @returns {Boolean}
  */
-function isAndroid(desiredCapabilities){
+function isAndroid(desiredCapabilities = {}){
+  const {platformName} = desiredCapabilities;
+
+  if (platformName && platformName.toLowerCase() === 'android') {
+    return true;
+  }
+
   const options = desiredCapabilities['goog:chromeOptions'] || desiredCapabilities['moz:firefoxOptions'];
 
   if (options && options.androidPackage) {
@@ -44,10 +50,10 @@ function isAndroid(desiredCapabilities){
  * @param {Object} desiredCapabilities 
  * @returns {Boolean}
  */
-function isIos(desiredCapabilities) {
-  const {browserName = '', platformName = ''} = desiredCapabilities;
+function isIos(desiredCapabilities = {}) {
+  const {platformName} = desiredCapabilities;
 
-  if (browserName.toLowerCase() === 'safari' && platformName.toLowerCase() === 'ios') {
+  if (platformName && platformName.toLowerCase() === 'ios') {
     return true;
   }
 

--- a/test/src/index/transport/testMobileOptions.js
+++ b/test/src/index/transport/testMobileOptions.js
@@ -36,9 +36,9 @@ describe('Test mobile options in Nightwatch/Appium client', function () {
       desiredCapabilities: {
         browserName: 'Chrome',
         javascriptEnabled: true,
-        platformName: 'Android',
-        platformVersion: '13.0',
-        deviceName: 'Google Pixel'
+        'goog:chromeOptions': {
+          androidPackage: 'com.android.chrome'
+        }
       }
     });
 
@@ -94,7 +94,7 @@ describe('Test mobile options in Nightwatch/Appium client', function () {
         use_appium: true
       },
       desiredCapabilities: {
-        browserName: '',
+        browserName: null,
         platformName: 'Android'
       }
     });


### PR DESCRIPTION
This PR fixes the failing mobile app testing when `test_workers` config is enabled.