### PR TITLE
Fixes/3540 undhandled promises for wait commands

### DIFF
--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -87,8 +87,8 @@ class AsyncTree extends EventEmitter{
     return parentNode.childNodes.filter(item => item !== node && !item.done).length > 0;
   }
 
-  shouldRejectNodePromise(err) {
-    if ((err.isExpect|| this.currentNode.namespace === 'assert') && this.currentNode.isES6Async) {
+  shouldRejectNodePromise(err, node = this.currentNode) {
+    if ((err.isExpect|| node.namespace === 'assert') && this.currentNode.isES6Async) {
       return true;
     }
 
@@ -96,11 +96,11 @@ class AsyncTree extends EventEmitter{
       return err.waitFor;
     }
 
-    return this.currentNode.rejectPromise || err.rejectPromise;
+    return node.rejectPromise || err.rejectPromise;
   }
 
-  shouldRejectParentNodePromise(err) {
-    const {parent} = this.currentNode;
+  shouldRejectParentNodePromise(err, node = this.currentNode) {
+    const {parent} = node;
     if (!parent || this.mochaRunner) {
       return false;
     }
@@ -129,18 +129,18 @@ class AsyncTree extends EventEmitter{
         err.stack = err.stack.split('\n').slice(1).join('\n');
       }
 
-      if (this.shouldRejectNodePromise(err)) {
-        this.currentNode.reject(err);
+      if (this.shouldRejectNodePromise(err, node)) {
+        node.reject(err);
       } else {
-        this.currentNode.resolve(err);
+        node.resolve(err);
       }
 
-      if (this.shouldRejectParentNodePromise(err)) {
+      if (this.shouldRejectParentNodePromise(err, node)) {
         parent.reject(err);
       }
     } else {
       node.resolveValue = result;
-      this.resolveNode(this.currentNode, result);
+      this.resolveNode(node, result);
     }
 
     Logger.log(` ${Logger.colors.green('→')} Completed command: ${Logger.colors.light_green(node.fullName)}` +
@@ -157,7 +157,7 @@ class AsyncTree extends EventEmitter{
       return err;
     }
 
-    if (Debuggability.stepOverAndPause && node.parent.isRootNode && this.currentNode.fullName !== 'pause') {
+    if (Debuggability.stepOverAndPause && node.parent.isRootNode && node.fullName !== 'pause') {
       this.currentNode.context.api.pause();
       // Whether to stop after performing next step will be decided
       // in the next "paused" prompt.

--- a/test/cucumber-integration-tests/sample_cucumber_tests/customCommands/testCucumberWithCustomWait.js
+++ b/test/cucumber-integration-tests/sample_cucumber_tests/customCommands/testCucumberWithCustomWait.js
@@ -1,0 +1,12 @@
+const {Given, Then} = require('@cucumber/cucumber');
+
+Given('I navigate to localhost', function() {
+
+  return browser.url('http://localhost');
+});
+
+Then('I check if badElement is present', async function() {
+
+  await browser.customWaitForPresent('#badElement');
+  await browser.click('#webdriver');
+});

--- a/test/extra/commands/customWaitForPresent.js
+++ b/test/extra/commands/customWaitForPresent.js
@@ -1,0 +1,5 @@
+module.exports = class CustomWaitForPresent {
+  async command(selector) {
+    await this.api.waitForElementPresent(selector);
+  }
+};

--- a/test/extra/cucumber-config.js
+++ b/test/extra/cucumber-config.js
@@ -11,8 +11,10 @@ module.exports = {
 
   webdriver: {
     start_process: false
-  },
+  }, 
 
+  custom_commands_path: [path.join(__dirname, './commands')],
+  
   globals: {
     test_calls: 0,
     waitForConditionTimeout: 20,

--- a/test/src/apidemos/expect-global/testExpect.js
+++ b/test/src/apidemos/expect-global/testExpect.js
@@ -48,7 +48,7 @@ describe('expect(element.<command>) - passed', function() {
     const testsPath = path.join(__dirname, '../../../apidemos/expect-global/expect.js');
     
     Mocks.elementNotSelected();
-    Mocks.elementProperty('0', 'className', {value: ['div-container']});
+    Mocks.elementProperty('0', 'className', {value: ['container']});
 
     const globals = {
       waitForConditionPollInterval: 50,

--- a/test/src/runner/cucumber-integration/testCucumberSampleTests.js
+++ b/test/src/runner/cucumber-integration/testCucumberSampleTests.js
@@ -54,4 +54,18 @@ describe('Cucumber integration', function() {
     });
   });
 
+
+  it('testCucumberSampleTests - use custom commands failure', function() {
+    const source = [path.join(__dirname, '../../../cucumber-integration-tests/sample_cucumber_tests/customCommands/testCucumberWithCustomWait.js')];
+
+    return runTests({
+      source,
+      tags: ['@fail'],
+      verbose: false,
+      config: path.join(__dirname, '../../../extra/cucumber-config.js')
+    }, {})
+      .then(failures => {
+        assert.strictEqual(failures, true, 'Cucumber has test failures. Run with verbose to investigate.');
+      });
+  });
 });


### PR DESCRIPTION
## Changes
- refactors `runChildNode` in asynctree.js
- fixed a test

## Impacts
- fixes #3540 