### PR TITLE
Fixes/new headless mode in chrome

### DIFF
--- a/lib/transport/selenium-webdriver/options.js
+++ b/lib/transport/selenium-webdriver/options.js
@@ -328,7 +328,7 @@ module.exports = class SeleniumCapabilities {
 
   addHeadlessOption({options}) {
     if (this.argv.headless && (options instanceof Capabilities) && (this.isChrome || options.headless)) {
-      this.isChrome ? options.addArguments('headless=chrome') : options.headless();
+      this.isChrome ? options.addArguments('headless=new') : options.headless();
     }
 
     return this;

--- a/test/lib/command-mocks.js
+++ b/test/lib/command-mocks.js
@@ -385,7 +385,7 @@ module.exports = {
     url = '/wd/hub/session'
   }) {
     const browserName = 'chrome';
-    const headlessOpt = headless ? 'headless=chrome' : '';
+    const headlessOpt = headless ? 'headless=new' : '';
     const options = {
       ['goog:chromeOptions']: {}
     };

--- a/test/src/core/testCreateSession.js
+++ b/test/src/core/testCreateSession.js
@@ -198,7 +198,7 @@ describe('test Request With Credentials', function () {
       sessionId: '1352110219202',
       capabilities: {browserName: 'chrome', version: 'TEST', platform: 'TEST'}
     });
-    assert.deepStrictEqual(sessionOptions.get('goog:chromeOptions'), {args: ['headless=chrome']});
+    assert.deepStrictEqual(sessionOptions.get('goog:chromeOptions'), {args: ['headless=new']});
   });
 
   it('Test create session with headless mode in Edge', async function () {
@@ -287,7 +287,7 @@ describe('test Request With Credentials', function () {
     assert.deepStrictEqual(sessionOptions.get('goog:chromeOptions'), {
       args: [
         '--no-sandbox',
-        'headless=chrome'
+        'headless=new'
       ]
     });
   });

--- a/test/src/index/transport/testChromeOptions.js
+++ b/test/src/index/transport/testChromeOptions.js
@@ -108,7 +108,7 @@ describe('Test chrome options', function () {
     const options = client.transport.createSessionOptions({headless: true});
 
     assert.strictEqual(options instanceof ChromeOptions, true);
-    assert.deepStrictEqual(options.options_.args, ['headless=chrome']);
+    assert.deepStrictEqual(options.options_.args, ['headless=new']);
   });
 
   it('devtools cli arg', function(){


### PR DESCRIPTION
## Changes
- changed headless argument for chrome to `--headless=new` from `--headless=chrome` according to the recent change in chrome. For more details refer this [issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1380881)