### PR TITLE
Fix ESM imports on Windows

### DIFF
--- a/lib/utils/requireModule.js
+++ b/lib/utils/requireModule.js
@@ -1,4 +1,3 @@
-const {pathToFileURL} = require('node:url');
 const getNodeVersion = () => {
   const version = process.version.replace('v', '');
   
@@ -23,6 +22,8 @@ module.exports = function (fullpath) {
     }
 
     if (getNodeVersion() >= 14) {
+      const {pathToFileURL} = require('node:url');
+      
       return import(pathToFileURL(fullpath).href).then(result => (result.default || {}));
     }
 

--- a/lib/utils/requireModule.js
+++ b/lib/utils/requireModule.js
@@ -1,4 +1,9 @@
-const { pathToFileURL } = require('node:url');
+const {pathToFileURL} = require('node:url');
+const getNodeVersion = () => {
+  const version = process.version.replace('v', '');
+  
+  return parseInt(version, 10);
+}
 
 module.exports = function (fullpath) {
   let exported;
@@ -17,7 +22,11 @@ module.exports = function (fullpath) {
       throw err;
     }
 
-    return import(pathToFileURL(fullpath).href).then(result => (result.default || {}));
+    if (getNodeVersion() >= 14) {
+      return import(pathToFileURL(fullpath).href).then(result => (result.default || {}));
+    }
+
+    return import(fullpath).then(result => (result.default || {}));
   }
 
   if (exported && Object.prototype.hasOwnProperty.call(exported, 'default') && Object.keys(exported).length === 1) {

--- a/lib/utils/requireModule.js
+++ b/lib/utils/requireModule.js
@@ -1,3 +1,5 @@
+const { pathToFileURL } = require('node:url');
+
 module.exports = function (fullpath) {
   let exported;
   try {
@@ -15,7 +17,7 @@ module.exports = function (fullpath) {
       throw err;
     }
 
-    return import(fullpath).then(result => (result.default || {}));
+    return import(pathToFileURL(fullpath).href).then(result => (result.default || {}));
   }
 
   if (exported && Object.prototype.hasOwnProperty.call(exported, 'default') && Object.keys(exported).length === 1) {


### PR DESCRIPTION
* Fixes #3584.

When the [`requireModule()` utility function](https://github.com/nightwatchjs/nightwatch/blob/main/lib/utils/requireModule.js) determines that the given `fullpath` argument corresponds to an ECMAscript module, it tries to import the module as follows:

```js
import(fullpath)
```

Node.js' ESM loader requires that the given argument be a `file://` URL, but `fullpath` is instead an absolute path whose form varies by operating system:

| | *nix | Windows |
| --- | --- | --- |
| `fullpath` | `/foo/bar.js` | `c:/foo/bar.js` |
| Outcome | ✔️ Succeeds because the path can still be interpreted as a URL. | ❌ Fails because the path cannot be interpreted as a URL due to the leading drive letter. |

The error message on Windows:

```
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                                                                   │
│   There was an error while trying to load the file                                                                │
│   C:\foo\bar.js:                                                                                                  │
│   [ERR_UNSUPPORTED_ESM_URL_SCHEME] Only URLs with a scheme in: file, data are supported by the default ESM        │
│   loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:';                          │
│                                                                                    ^^^^                           │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

This change solves the problem in a cross-platform fashion by passing `fullpath` through `node:url`'s [`pathToFileURL()` function](https://nodejs.org/docs/latest-v18.x/api/url.html#urlpathtofileurlpath), which yields the proper `file://` URL that `import()` expects.

---

💡 **Missing test disclaimer:** `requireModule()` currently has no tests, and I don't see how one can be written without somehow mocking `require()` to fail with arbitrary error codes and messages. If you feel `requireModule()` should absolutely have tests and can provide any suggestions, I'm happy to oblige.