### PR TITLE
avoid closing of session according to end_session_on_fail

### DIFF
--- a/lib/runner/test-runners/default.js
+++ b/lib/runner/test-runners/default.js
@@ -48,7 +48,9 @@ class DefaultRunner {
     if (this.client && this.client.sessionId && this.client.startSessionEnabled) {
       Logger.info(`Attempting to close session ${this.client.sessionId}...`);
 
-      return this.currentSuite.terminate(null, null, true);
+      const failures = !this.currentSuite.reporter.allTestsPassed;
+
+      return this.currentSuite.terminate(failures ? 'FAILED' : '', null, true);
     }
 
     return Promise.resolve();

--- a/lib/testsuite/index.js
+++ b/lib/testsuite/index.js
@@ -1,11 +1,13 @@
 const AssertionError = require('assertion-error');
 const {By, Key, locateWith, withTagName} = require('selenium-webdriver');
 
+
 const Reporter = require('../reporter');
 const Context = require('./context.js');
 const TestHooks = require('./hooks.js');
 const TestCase = require('./testcase.js');
 const Runnable = require('./runnable.js');
+const Transport = require('../transport/selenium-webdriver');
 const NightwatchAssertError = require('../assertion').AssertionError;
 const SuiteRetries = require('./retries.js');
 const NightwatchClient = require('../core/client.js');
@@ -662,6 +664,11 @@ class TestSuite {
     }
 
     if (!this.endSessionOnFail && reason === 'FAILED') {
+
+      // Keep the session open; avoid reusing of same session
+      Transport.driver = null;
+      Transport.driverService = null;
+
       return potentialError;
     }
 

--- a/test/src/runner/testRunnerEndSessionOnFail.js
+++ b/test/src/runner/testRunnerEndSessionOnFail.js
@@ -1,0 +1,56 @@
+const path = require('path');
+const assert = require('assert');
+const nock = require('nock');
+const nocks = require('../../lib/nocks');
+const common = require('../../common.js');
+const CommandGlobals = require('../../lib/globals/commands.js');
+const {settings} = common;
+const {runTests} = common.require('index.js');
+
+describe('test runner with end_session_on_fail flag', function() {
+
+  before(function(done) {
+    nocks.enable().cleanAll();
+    CommandGlobals.beforeEach.call(this, done);
+    
+  });
+
+  after(function(done) {
+    nocks.disable();
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+
+  it('session is not ended with end_on_sessiion_fail: false', function() {
+    let endSessionCalled = false;
+    const testFile = path.join(__dirname, '../../sampletests/withfailures/sample.js');
+
+    nocks.createSession()
+      .url()
+      .elementNotFound('#weblogin');
+   
+
+    nock('http://localhost:10195')
+      .delete('/wd/hub/session/1352110219202')
+      .reply(204, ()=> {
+        endSessionCalled = true;
+      
+        return '';
+      });
+
+    return runTests(testFile, settings({
+      enable_fail_fast: true,
+      end_session_on_fail: false,
+      globals: {
+        waitForConditionPollInterval: 5,
+        waitForConditionTimeout: 5,
+        retryAssertionTimeout: 1
+      }
+    })).catch(_ => {
+      assert.strictEqual(endSessionCalled, false);
+    });
+
+
+  });
+
+});


### PR DESCRIPTION
## Changes
- avoid closing the session when `end_on_session_fail` is set to false
- added logic to avoid reusing sessions in case of failure when `end_on_session_fail` is enabled
    - It would spawn a new session and reuse that if a failure is detected in the preceding test and will keep that session open.
## Impact
- fixes #3574 