### PR TITLE
Test fix: waitForElementNotPresent

### DIFF
--- a/test/src/cli/testServiceCreationFromCli.js
+++ b/test/src/cli/testServiceCreationFromCli.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const origPath = require('path');
 
 describe('Service creation from cli.js', function() {
-  this.timeout(15000);
+  this.timeout(30000);
 
   beforeEach(function() {
     mockery.enable({useCleanCache: true, warnOnUnregistered: false});

--- a/test/src/core/testPageObjectWaitForElementNotPresent.js
+++ b/test/src/core/testPageObjectWaitForElementNotPresent.js
@@ -18,7 +18,7 @@ describe('test PageObject WaitForElementNotPresent', function () {
     Nocks.deleteSession().disable();
   });
 
-  it('WaitForElementNotPresent with section', async function() {
+  it('WaitForElementNotPresent with section', function(done) {
     Nocks.elementFound().click().elementFound().childElementsFound('#badElement').elementFound().childElementsNotFound()
 
     const page = this.client.api.page.waitForElementNotPresentPageObj();
@@ -28,7 +28,18 @@ describe('test PageObject WaitForElementNotPresent', function () {
       res = result;
     })
   
-    await this.client.start();
-    assert.equal(res.status, 0);
+    this.client.start(function (err) {
+      if (err) {
+        done(err);
+        return;
+      }
+      
+      try {
+        assert.strictEqual(res.status, 0);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
   });
 });

--- a/test/src/core/testPageObjectWaitForElementNotPresent.js
+++ b/test/src/core/testPageObjectWaitForElementNotPresent.js
@@ -18,7 +18,7 @@ describe('test PageObject WaitForElementNotPresent', function () {
     Nocks.deleteSession().disable();
   });
 
-  it('WaitForElementNotPresent with section', function(done) {
+  it('WaitForElementNotPresent with section', async function() {
     Nocks.elementFound().click().elementFound().childElementsFound('#badElement').elementFound().childElementsNotFound()
 
     const page = this.client.api.page.waitForElementNotPresentPageObj();
@@ -28,18 +28,7 @@ describe('test PageObject WaitForElementNotPresent', function () {
       res = result;
     })
   
-    this.client.start(function (err) {
-      if (err) {
-        done(err);
-        return;
-      }
-      
-      try {
-        assert.strictEqual(res.status, 0);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    });
+    await this.client.start();
+    assert.equal(res.status, 0);
   });
 });

--- a/test/src/core/testPageObjectWaitForElementNotPresent.js
+++ b/test/src/core/testPageObjectWaitForElementNotPresent.js
@@ -18,16 +18,17 @@ describe('test PageObject WaitForElementNotPresent', function () {
     Nocks.deleteSession().disable();
   });
 
-  it('WaitForElementNotPresent with section', function(done) {
+  it('WaitForElementNotPresent with section', async function() {
     Nocks.elementFound().click().elementFound().childElementsFound('#badElement').elementFound().childElementsNotFound()
 
     const page = this.client.api.page.waitForElementNotPresentPageObj();
 
+    let res;
     page.waitForElementNotPresentDemo(function(result) {
-      assert.equal(result.status, 0);
-      done();
+      res = result;
     })
-
-    this.client.start()
+  
+    await this.client.start();
+    assert.equal(res.status, 0);
   });
 });


### PR DESCRIPTION
### Changes :
- Fixed a test of `waitForElementNotPresent`
- Removed the done() callback to end the test after an assertion. Because if the assertion fails, done() will never be called.

### Impact
- #3580 
