### PR TITLE
Add 'app' in REPL context.

### DIFF
--- a/lib/api/client-commands/debug.js
+++ b/lib/api/client-commands/debug.js
@@ -44,7 +44,8 @@ Debug.prototype.command = function(config, cb) {
 
   // Create context for vm
   const context = {
-    browser: this.api
+    browser: this.api,
+    app: this.api
   };
   repl.startServer(context);
 

--- a/test/src/api/commands/client/testNightwatchRepl.js
+++ b/test/src/api/commands/client/testNightwatchRepl.js
@@ -33,7 +33,7 @@ describe('startServer', function() {
     const NightwatchRepl = require('../../../../../lib/testsuite/repl.js');
     const repl = new NightwatchRepl();
 
-    const context = {browser: 'something'};
+    const context = {browser: 'something', app: 'other'};
     repl.startServer(context);
 
     assert.strictEqual(contextPassed, context);


### PR DESCRIPTION
`app` global is not available in the REPL interface started by `.debug()` command. This PR adds the same, so that users can run the commands using `app` as well instead of always using `browser` only.