### PR TITLE
Move cookie-related commands to `.cookies` ns.

### DIFF
--- a/lib/api/client-commands/cookies/delete.js
+++ b/lib/api/client-commands/cookies/delete.js
@@ -22,6 +22,9 @@ const ClientCommand = require('../_base-command.js');
  * @param {string} cookieName The name of the cookie to delete.
  * @param {function} [callback] Optional callback function to be called when the command finishes.
  * @see cookies.deleteAll
+ * @see cookies.get
+ * @see cookies.getAll
+ * @see cookies.set
  * @api protocol.cookies
  */
 class DeleteCookie extends ClientCommand {

--- a/lib/api/client-commands/cookies/delete.js
+++ b/lib/api/client-commands/cookies/delete.js
@@ -1,23 +1,28 @@
-const ClientCommand = require('./_base-command.js');
+const ClientCommand = require('../_base-command.js');
 
 /**
  * Delete the cookie with the given name. This command is a no-op if there is no such cookie visible to the current page.
  *
  * @example
- * this.demoTest = function(browser) {
- *   browser.deleteCookie("test_cookie", function() {
- *     // do something more in here
- *   });
- * }
+ * module.exports = {
+ *   'delete a cookie': function (browser) {
+ *     browser
+ *       .cookies.delete('test_cookie', function () {
+ *         console.log('cookie deleted successfully');
+ *       });
+ *   },
  *
+ *   'delete a cookie with ES6 async/await': async function (browser) {
+ *     await browser.cookies.delete('test_cookie');
+ *   }
+ * };
  *
- * @method deleteCookie
- * @syntax .deleteCookie(cookieName, [callback])
+ * @syntax .cookies.delete(cookieName, [callback])
+ * @method cookies.delete
  * @param {string} cookieName The name of the cookie to delete.
  * @param {function} [callback] Optional callback function to be called when the command finishes.
+ * @see cookies.deleteAll
  * @api protocol.cookies
- * @see cookie
- * @deprecated In favour of `.cookies.delete()`.
  */
 class DeleteCookie extends ClientCommand {
   get returnsFullResultObject() {

--- a/lib/api/client-commands/cookies/delete.js
+++ b/lib/api/client-commands/cookies/delete.js
@@ -1,4 +1,5 @@
 const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Delete the cookie with the given name. This command is a no-op if there is no such cookie visible to the current page.
@@ -28,19 +29,26 @@ const ClientCommand = require('../_base-command.js');
  * @api protocol.cookies
  */
 class DeleteCookie extends ClientCommand {
-  get returnsFullResultObject() {
-    return true;
-  }
-
-  performAction(callback) {
-    this.api.cookie('DELETE', this.cookieName, callback);
-  }
-
   static get isTraceable() {
     return true;
   }
 
+  performAction(callback) {
+    const {cookieName} = this;
+
+    this.transportActions
+      .deleteCookie(cookieName, callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
+  }
+
   command(cookieName, callback) {
+    if (typeof cookieName !== 'string') {
+      throw new Error('First argument passed to .cookies.delete() must be a string.');
+    }
+
     this.cookieName = cookieName;
 
     return super.command(callback);

--- a/lib/api/client-commands/cookies/deleteAll.js
+++ b/lib/api/client-commands/cookies/deleteAll.js
@@ -1,0 +1,40 @@
+const ClientCommand = require('../_base-command.js');
+
+/**
+ * Delete all cookies visible to the current page.
+ *
+ * @example
+ * module.exports = {
+ *   'delete all cookies': function (browser) {
+ *     browser
+ *       .cookies.deleteAll(function() {
+ *         console.log('all cookies deleted successfully');
+ *       });
+ *   },
+ *
+ *   'delete all cookies with ES6 async/await': async function (browser) {
+ *     await browser.cookies.deleteAll();
+ *   }
+ * };
+ *
+ * @syntax .cookies.deleteAll([callback])
+ * @method cookies.deleteAll
+ * @param {function} [callback] Optional callback function to be called when the command finishes.
+ * @see cookies.delete
+ * @api protocol.cookies
+ */
+class DeleteCookie extends ClientCommand {
+  get returnsFullResultObject() {
+    return true;
+  }
+
+  static get isTraceable() {
+    return true;
+  }
+
+  performAction(callback) {
+    this.api.cookie('DELETE', callback);
+  }
+}
+
+module.exports = DeleteCookie;

--- a/lib/api/client-commands/cookies/deleteAll.js
+++ b/lib/api/client-commands/cookies/deleteAll.js
@@ -21,6 +21,9 @@ const ClientCommand = require('../_base-command.js');
  * @method cookies.deleteAll
  * @param {function} [callback] Optional callback function to be called when the command finishes.
  * @see cookies.delete
+ * @see cookies.get
+ * @see cookies.getAll
+ * @see cookies.set
  * @api protocol.cookies
  */
 class DeleteCookie extends ClientCommand {

--- a/lib/api/client-commands/cookies/deleteAll.js
+++ b/lib/api/client-commands/cookies/deleteAll.js
@@ -1,4 +1,5 @@
 const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Delete all cookies visible to the current page.
@@ -26,18 +27,19 @@ const ClientCommand = require('../_base-command.js');
  * @see cookies.set
  * @api protocol.cookies
  */
-class DeleteCookie extends ClientCommand {
-  get returnsFullResultObject() {
-    return true;
-  }
-
+class DeleteCookies extends ClientCommand {
   static get isTraceable() {
     return true;
   }
 
   performAction(callback) {
-    this.api.cookie('DELETE', callback);
+    this.transportActions
+      .deleteAllCookies(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
 }
 
-module.exports = DeleteCookie;
+module.exports = DeleteCookies;

--- a/lib/api/client-commands/cookies/get.js
+++ b/lib/api/client-commands/cookies/get.js
@@ -1,4 +1,5 @@
 const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Retrieve a single cookie visible to the current page.
@@ -10,8 +11,9 @@ const ClientCommand = require('../_base-command.js');
  *   'get a cookie': function (browser) {
  *     browser
  *       .cookies.get('test_cookie', function (result) {
- *         this.assert.equal(result.name, 'test_cookie');
- *         this.assert.equal(result.value, '123456');
+ *         const cookie = result.value;
+ *         this.assert.equal(cookie.name, 'test_cookie');
+ *         this.assert.equal(cookie.value, '123456');
  *       });
  *   },
  *
@@ -34,42 +36,22 @@ const ClientCommand = require('../_base-command.js');
  * @api protocol.cookies
  */
 class GetCookie extends ClientCommand {
-  get returnsFullResultObject() {
-    return false;
-  }
-
-  get resolvesWithFullResultObject() {
-    return false;
-  }
-
-  /**
-   * Perform the .cookie() protocol action and pass the result to the supplied callback
-   * with the original "this" context
-   *
-   * @param {function} actionCallback
-   */
-  performAction(actionCallback) {
+  performAction(callback) {
     const {cookieName} = this;
 
-    this.api.cookie('GET', function(result) {
-      let value = null;
-
-      if (Array.isArray(result.value) && result.value.length > 0) {
-        for (let i = 0; i < result.value.length; i++) {
-          if (result.value[i].name === cookieName) {
-            value = result.value[i];
-            break;
-          }
-        }
-      }
-
-      actionCallback.call(this, {
-        value
+    this.transportActions
+      .getCookie(cookieName, callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
       });
-    });
   }
 
   command(name, callback) {
+    if (typeof name !== 'string') {
+      throw new Error('First argument passed to .cookies.get() must be a string.');
+    }
+
     this.cookieName = name;
 
     return super.command(callback);

--- a/lib/api/client-commands/cookies/get.js
+++ b/lib/api/client-commands/cookies/get.js
@@ -28,6 +28,9 @@ const ClientCommand = require('../_base-command.js');
  * @param {function} [callback] Callback function which is called with the result value.
  * @returns {object|null} The cookie object with properties as defined [here](https://www.w3.org/TR/webdriver/#dfn-table-for-cookie-conversion), or `null` if the cookie wasn't found.
  * @see cookies.getAll
+ * @see cookies.set
+ * @see cookies.delete
+ * @see cookies.deleteAll
  * @api protocol.cookies
  */
 class GetCookie extends ClientCommand {

--- a/lib/api/client-commands/cookies/get.js
+++ b/lib/api/client-commands/cookies/get.js
@@ -1,0 +1,76 @@
+const ClientCommand = require('../_base-command.js');
+
+/**
+ * Retrieve a single cookie visible to the current page.
+ *
+ * The cookie is returned as a cookie JSON object, with properties as defined [here](https://www.w3.org/TR/webdriver/#dfn-table-for-cookie-conversion).
+ *
+ * @example
+ * module.exports = {
+ *   'get a cookie': function (browser) {
+ *     browser
+ *       .cookies.get('test_cookie', function (result) {
+ *         this.assert.equal(result.name, 'test_cookie');
+ *         this.assert.equal(result.value, '123456');
+ *       });
+ *   },
+ *
+ *   'get a cookie with ES6 async/await': async function (browser) {
+ *     const cookie = await browser.cookies.get('test_cookie');
+ *     browser.assert.equal(cookie.name, 'test_cookie');
+ *     browser.assert.equal(cookie.value, '123456');
+ *   }
+ * };
+ *
+ * @syntax .cookies.get(name, [callback])
+ * @method cookies.get
+ * @param {string} name The cookie name.
+ * @param {function} [callback] Callback function which is called with the result value.
+ * @returns {object|null} The cookie object with properties as defined [here](https://www.w3.org/TR/webdriver/#dfn-table-for-cookie-conversion), or `null` if the cookie wasn't found.
+ * @see cookies.getAll
+ * @api protocol.cookies
+ */
+class GetCookie extends ClientCommand {
+  get returnsFullResultObject() {
+    return false;
+  }
+
+  get resolvesWithFullResultObject() {
+    return false;
+  }
+
+  /**
+   * Perform the .cookie() protocol action and pass the result to the supplied callback
+   * with the original "this" context
+   *
+   * @param {function} actionCallback
+   */
+  performAction(actionCallback) {
+    const {cookieName} = this;
+
+    this.api.cookie('GET', function(result) {
+      let value = null;
+
+      if (Array.isArray(result.value) && result.value.length > 0) {
+        for (let i = 0; i < result.value.length; i++) {
+          if (result.value[i].name === cookieName) {
+            value = result.value[i];
+            break;
+          }
+        }
+      }
+
+      actionCallback.call(this, {
+        value
+      });
+    });
+  }
+
+  command(name, callback) {
+    this.cookieName = name;
+
+    return super.command(callback);
+  }
+}
+
+module.exports = GetCookie;

--- a/lib/api/client-commands/cookies/getAll.js
+++ b/lib/api/client-commands/cookies/getAll.js
@@ -27,6 +27,9 @@ const ClientCommand = require('../_base-command.js');
  * @param {function} [callback] Callback function which will receive the response as an argument.
  * @returns {Array.<object>} A list of cookie JSON objects, with properties as defined [here](https://www.w3.org/TR/webdriver/#dfn-table-for-cookie-conversion).
  * @see cookies.get
+ * @see cookies.set
+ * @see cookies.delete
+ * @see cookies.deleteAll
  * @api protocol.cookies
  */
 

--- a/lib/api/client-commands/cookies/getAll.js
+++ b/lib/api/client-commands/cookies/getAll.js
@@ -1,4 +1,5 @@
 const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Retrieve all cookies visible to the current page.
@@ -35,7 +36,12 @@ const ClientCommand = require('../_base-command.js');
 
 class GetCookies extends ClientCommand {
   performAction(callback) {
-    this.api.cookie('GET', callback);
+    this.transportActions
+      .getCookies(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
 }
 

--- a/lib/api/client-commands/cookies/getAll.js
+++ b/lib/api/client-commands/cookies/getAll.js
@@ -1,0 +1,39 @@
+const ClientCommand = require('../_base-command.js');
+
+/**
+ * Retrieve all cookies visible to the current page.
+ *
+ * The cookies are returned as an array of cookie JSON object, with properties as defined [here](https://www.w3.org/TR/webdriver/#dfn-table-for-cookie-conversion).
+ *
+ * @example
+ * module.exports = {
+ *   'get all cookies': function (browser) {
+ *     browser
+ *       .cookies.getAll(function (result) {
+ *         this.assert.equal(result.value.length, 1);
+ *         this.assert.equal(result.value[0].name, 'test_cookie');
+ *       });
+ *   },
+ *
+ *   'get all cookies with ES6 async/await': async function (browser) {
+ *     const cookies = await browser.cookies.getAll();
+ *     browser.assert.equal(cookies.length, 1);
+ *     browser.assert.equal(cookies[0].name, 'test_cookie');
+ *   }
+ * };
+ *
+ * @syntax .cookies.getAll([callback])
+ * @method cookies.getAll
+ * @param {function} [callback] Callback function which will receive the response as an argument.
+ * @returns {Array.<object>} A list of cookie JSON objects, with properties as defined [here](https://www.w3.org/TR/webdriver/#dfn-table-for-cookie-conversion).
+ * @see cookies.get
+ * @api protocol.cookies
+ */
+
+class GetCookies extends ClientCommand {
+  performAction(callback) {
+    this.api.cookie('GET', callback);
+  }
+}
+
+module.exports = GetCookies;

--- a/lib/api/client-commands/cookies/set.js
+++ b/lib/api/client-commands/cookies/set.js
@@ -32,8 +32,10 @@ const ClientCommand = require('../_base-command.js');
  * @method cookies.set
  * @param {object} cookie The cookie object.
  * @param {function} [callback] Optional callback function to be called when the command finishes.
- * @see cookie.get
- * @see cookie.delete
+ * @see cookies.get
+ * @see cookies.getAll
+ * @see cookies.delete
+ * @see cookies.deleteAll
  * @api protocol.cookies
  */
 class SetCookie extends ClientCommand {

--- a/lib/api/client-commands/cookies/set.js
+++ b/lib/api/client-commands/cookies/set.js
@@ -1,0 +1,55 @@
+const ClientCommand = require('../_base-command.js');
+
+/**
+ * Set a cookie, specified as a cookie JSON object, with properties as defined [here](https://www.w3.org/TR/webdriver/#dfn-table-for-cookie-conversion).
+ *
+ * @example
+ * module.exports = {
+ *   'set a cookie': function (browser) {
+ *     browser
+ *       .cookies.set({
+ *         name: "test_cookie",
+ *         value: "test_value",
+ *         path: "/", // (Optional)
+ *         domain: "example.org", // (Optional)
+ *         secure: false, // (Optional)
+ *         httpOnly: false, // (Optional)
+ *         expiry: 1395002765 // (Optional) time in seconds since midnight, January 1, 1970 UTC
+ *       });
+ *   },
+ *
+ *   'set a cookie with ES6 async/await': async function (browser) {
+ *     await browser.cookies.set({
+ *       name: 'test_cookie',
+ *       value: 'test_value',
+ *       domain: 'example.org', // (Optional)
+ *       sameSite: 'Lax' // (Optional)
+ *     });
+ *   }
+ * };
+ *
+ * @syntax .cookies.set(cookie, [callback])
+ * @method cookies.set
+ * @param {object} cookie The cookie object.
+ * @param {function} [callback] Optional callback function to be called when the command finishes.
+ * @see cookie.get
+ * @see cookie.delete
+ * @api protocol.cookies
+ */
+class SetCookie extends ClientCommand {
+  static get isTraceable() {
+    return true;
+  }
+
+  performAction(callback) {
+    this.api.cookie('POST', this.cookie, callback);
+  }
+
+  command(cookie, callback) {
+    this.cookie = cookie;
+
+    return super.command(callback);
+  }
+}
+
+module.exports = SetCookie;

--- a/lib/api/client-commands/cookies/set.js
+++ b/lib/api/client-commands/cookies/set.js
@@ -1,4 +1,6 @@
 const ClientCommand = require('../_base-command.js');
+const Utils = require('../../../utils/index.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Set a cookie, specified as a cookie JSON object, with properties as defined [here](https://www.w3.org/TR/webdriver/#dfn-table-for-cookie-conversion).
@@ -44,10 +46,21 @@ class SetCookie extends ClientCommand {
   }
 
   performAction(callback) {
-    this.api.cookie('POST', this.cookie, callback);
+    const {cookie} = this;
+
+    this.transportActions
+      .addCookie(cookie, callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
 
   command(cookie, callback) {
+    if (!Utils.isObject(cookie)) {
+      throw new Error(`First argument passed to .cookies.set() must be an object; received: ${typeof cookie} (${cookie}).`);
+    }
+
     this.cookie = cookie;
 
     return super.command(callback);

--- a/lib/api/client-commands/deleteCookies.js
+++ b/lib/api/client-commands/deleteCookies.js
@@ -16,6 +16,7 @@ const ClientCommand = require('./_base-command.js');
  * @param {function} [callback] Optional callback function to be called when the command finishes.
  * @api protocol.cookies
  * @see cookie
+ * @deprecated In favour of `.cookies.deleteAll()`.
  */
 class DeleteCookie extends ClientCommand {
   get returnsFullResultObject() {

--- a/lib/api/client-commands/getCookie.js
+++ b/lib/api/client-commands/getCookie.js
@@ -9,7 +9,7 @@ const ClientCommand = require('./_base-command.js');
  * this.demoTest = function(browser) {
  *   browser.getCookie(name, function callback(result) {
  *     this.assert.equal(result.value, '123456');
- *     this.assert.equals(result.name, 'test_cookie');
+ *     this.assert.equal(result.name, 'test_cookie');
  *   });
  * }
  *
@@ -21,6 +21,7 @@ const ClientCommand = require('./_base-command.js');
  * @syntax .getCookie(name, callback)
  * @see cookie
  * @returns {object|null} The cookie object as a selenium cookie JSON object or null if the cookie wasn't found.
+ * @deprecated In favour of `.cookies.get()`.
  */
 class GetCookie extends ClientCommand {
   get returnsFullResultObject() {

--- a/lib/api/client-commands/getCookies.js
+++ b/lib/api/client-commands/getCookies.js
@@ -9,7 +9,7 @@ const ClientCommand = require('./_base-command.js');
  * this.demoTest = function(browser) {
  *   browser.getCookies(function callback(result) {
  *     this.assert.equal(result.value.length, 1);
- *     this.assert.equals(result.value[0].name, 'test_cookie');
+ *     this.assert.equal(result.value[0].name, 'test_cookie');
  *   });
  * }
  *
@@ -20,6 +20,7 @@ const ClientCommand = require('./_base-command.js');
  * @api protocol.cookies
  * @see cookie
  * @returns {Array.<object>} A list of cookies.
+ * @deprecated In favour of `.cookies.getAll()`.
  */
 
 class GetCookies extends ClientCommand {

--- a/lib/api/client-commands/setCookie.js
+++ b/lib/api/client-commands/setCookie.js
@@ -25,6 +25,7 @@ const ClientCommand = require('./_base-command.js');
  * @param {function} [callback] Optional callback function to be called when the command finishes.
  * @api protocol.cookies
  * @see cookie
+ * @deprecated In favour of `.cookies.set()`.
  */
 class SetCookie extends ClientCommand {
   static get isTraceable() {

--- a/lib/api/expect/cookie.js
+++ b/lib/api/expect/cookie.js
@@ -56,7 +56,8 @@ class ExpectCookie extends BaseExpect {
           if (Array.isArray(result.value)) {
             this.resultValue = result.value.length > 0 ? result.value[0].value : null;
           } else {
-            this.resultValue = result.value;
+            // result.value represents the cookie object, so result.value.value would be the cookie value
+            this.resultValue = result.value.value;
           }
         } else {
           this.resultValue = {};

--- a/lib/api/protocol/cookie.js
+++ b/lib/api/protocol/cookie.js
@@ -12,6 +12,7 @@ const ProtocolAction = require('./_base-action.js');
  * @see deleteCookie
  * @see deleteCookies
  * @api protocol.cookies
+ * @deprecated
  */
 module.exports = class Session extends ProtocolAction {
   static get isTraceable() {

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -746,9 +746,19 @@ module.exports = class MethodMappings {
         },
 
         async getCookie(name) {
-          const result = await this.driver.manage().getCookie(name);
+          try {
+            const result = await this.driver.manage().getCookie(name);
 
-          return result;
+            return {
+              value: result
+            };
+          } catch (err) {
+            if (err.name === 'NoSuchCookieError') {
+              return null;
+            }
+
+            throw err;
+          }
         },
 
         ///////////////////////////////////////////////////////////

--- a/test/apidemos/cookies/cookieTests.js
+++ b/test/apidemos/cookies/cookieTests.js
@@ -48,4 +48,33 @@ describe('Cookie api demo tests', function() {
     ]);
   });
 
+  test('browser.cookies.get(<name>)', async (browser) => {
+    await browser.assert.strictEqual(browser.globals.calls, 1);
+    await browser.assert.urlContains('//localhost');
+
+    const test_cookie = await browser.cookies.get('test_cookie');
+    assert.deepStrictEqual(test_cookie, {
+      name: 'test_cookie',
+      value: '123456',
+      path: '/',
+      domain: 'example.org',
+      secure: false
+    });
+
+    const other_cookie = await browser.cookies.get('other_cookie');
+    assert.strictEqual(other_cookie, null);
+  });
+
+  test('browser.cookies.getAll()', async (browser) => {
+    const cookies = await browser.cookies.getAll();
+    assert.deepStrictEqual(cookies, [
+      {
+        name: 'test_cookie',
+        value: '123456',
+        path: '/',
+        domain: 'example.org',
+        secure: false
+      }
+    ]);
+  });
 });

--- a/test/apidemos/cookies/cookieTestsWithError.js
+++ b/test/apidemos/cookies/cookieTestsWithError.js
@@ -17,4 +17,16 @@ describe('Cookie api demo tests', function() {
     assert.strictEqual(cookies, null);
   });
 
+  test('browser.cookies.getAll() with network errors', async (browser) => {
+    const cookies = await browser.cookies.getAll(res => {
+      assert.ok(res.error instanceof Error);
+      assert.strictEqual(res.error.code, 'ECONNRESET');
+      assert.strictEqual(res.error.message, 'ECONNRESET socket hang up');
+      assert.strictEqual(res.status, -1);
+      assert.strictEqual(res.value, null);
+    });
+
+    assert.strictEqual(cookies, null);
+  });
+
 });

--- a/test/lib/command-mocks.js
+++ b/test/lib/command-mocks.js
@@ -25,6 +25,42 @@ module.exports = {
     return MockServer.initAsync(opts);
   },
 
+  cookieFound(name = 'test_cookie', value = '123456', {times = 0} = {}) {
+    MockServer.addMock({
+      url: `/wd/hub/session/1352110219202/cookie/${name}`,
+      method: 'GET',
+      response: {
+        sessionId: '1352110219202',
+        status: 0,
+        value: {
+          name: name,
+          value: value,
+          path: '/',
+          domain: 'example.org',
+          secure: false
+        }
+      },
+      times
+    }, times === 0);
+  },
+
+  cookieNotFound(name = 'other_cookie', {times = 0} = {}) {
+    MockServer.addMock({
+      url: `/wd/hub/session/1352110219202/cookie/${name}`,
+      method: 'GET',
+      response: JSON.stringify({
+        sessionId: '1352110219202',
+        value: {
+          error: 'no such cookie',
+          message: 'no such cookie',
+          stacktrace: ''
+        }
+      }),
+      statusCode: 404,
+      times
+    }, times === 0);
+  },
+
   cookiesFound({times = 0} = {}) {
     MockServer.addMock({
       url: '/wd/hub/session/1352110219202/cookie',

--- a/test/lib/command-mocks.js
+++ b/test/lib/command-mocks.js
@@ -25,7 +25,7 @@ module.exports = {
     return MockServer.initAsync(opts);
   },
 
-  cookiesFound() {
+  cookiesFound({times = 0} = {}) {
     MockServer.addMock({
       url: '/wd/hub/session/1352110219202/cookie',
       method: 'GET',
@@ -39,11 +39,12 @@ module.exports = {
           domain: 'example.org',
           secure: false
         }]
-      }
-    }, null, true);
+      },
+      times
+    }, times === 0);
   },
 
-  cookiesNotFound() {
+  cookiesNotFound({times = 0} = {}) {
     MockServer.addMock({
       url: '/wd/hub/session/1352110219202/cookie',
       method: 'GET',
@@ -51,17 +52,19 @@ module.exports = {
         sessionId: '1352110219202',
         status: 0,
         value: []
-      })
-    });
+      }),
+      times
+    }, times === 0);
   },
 
-  cookiesSocketDelay() {
+  cookiesSocketDelay({times = 0} = {}) {
     MockServer.addMock({
       url: '/wd/hub/session/1352110219202/cookie',
       method: 'GET',
       socketDelay: 200,
-      response: ''
-    }, true);
+      response: '',
+      times
+    }, times === 0);
   },
 
   deleteCookie() {
@@ -72,7 +75,19 @@ module.exports = {
         sessionId: '1352110219202',
         status: 0
       })
-    });
+    }, true);
+  },
+
+  deleteCookies() {
+    MockServer.addMock({
+      url: '/wd/hub/session/1352110219202/cookie',
+      method: 'DELETE',
+      response: JSON.stringify({
+        sessionId: '1352110219202',
+        status: 0,
+        value: null
+      })
+    }, true);
   },
 
   addCookie() {
@@ -92,7 +107,7 @@ module.exports = {
       response: JSON.stringify({
         value: null
       })
-    });
+    }, true);
   },
 
   elementSelected(elementId = '0') {

--- a/test/src/api/commands/cookies/testCookie.js
+++ b/test/src/api/commands/cookies/testCookie.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const Mocks  = require('../../../../lib/command-mocks.js');
 const CommandGlobals = require('../../../../lib/globals/commands.js');
 
-describe('getCookie', function() {
+describe('get, set and delete cookie', function() {
   describe('with backwards compat mode', function() {
     before(function(done) {
       CommandGlobals.beforeEach.call(this, done, {
@@ -15,7 +15,7 @@ describe('getCookie', function() {
     });
 
     it('client.getCookie(<name>)', function(done) {
-      Mocks.cookiesFound();
+      Mocks.cookiesFound({times: 2});
 
       const api = this.client.api;
       this.client.api.getCookie('test_cookie', function callback(result) {
@@ -25,6 +25,23 @@ describe('getCookie', function() {
       });
 
       this.client.api.getCookie('other_cookie', function callback(result) {
+        assert.strictEqual(result, null);
+      });
+
+      this.client.start(done);
+    });
+
+    it('client.cookies.get(<name>)', function(done) {
+      Mocks.cookiesFound({times: 2});
+
+      const api = this.client.api;
+      this.client.api.cookies.get('test_cookie', function callback(result) {
+        assert.strictEqual(this, api);
+        assert.strictEqual(result.name, 'test_cookie');
+        assert.strictEqual(result.value, '123456');
+      });
+
+      this.client.api.cookies.get('other_cookie', function callback(result) {
         assert.strictEqual(result, null);
       });
 
@@ -42,7 +59,7 @@ describe('getCookie', function() {
     });
 
     it('client.getCookie(<name>)', function(done) {
-      Mocks.cookiesFound();
+      Mocks.cookiesFound({times: 2});
 
       const api = this.client.api;
       this.client.api.getCookie('test_cookie', function callback(result) {
@@ -80,11 +97,55 @@ describe('getCookie', function() {
     it('client.setCookie(<name>)', function(done) {
       Mocks.addCookie();
 
-      this.client.api.setCookie({name: 'other_cookie', value: '123456'}, function callback(result){
+      this.client.api.setCookie({name: 'other_cookie', value: '123456'}, function callback(result) {
         assert.strictEqual(result.status, 0);
       });
       this.client.start(done);
+    });
 
+    it('client.cookies.get(<name>)', function(done) {
+      Mocks.cookiesFound({times: 2});
+
+      const api = this.client.api;
+      this.client.api.cookies.get('test_cookie', function callback(result) {
+        assert.strictEqual(this, api);
+        assert.strictEqual(result.name, 'test_cookie');
+        assert.strictEqual(result.value, '123456');
+      });
+
+      this.client.api.cookies.get('other_cookie', function callback(result) {
+        assert.strictEqual(result, null);
+      });
+
+      this.client.start(done);
+    });
+
+    it('client.cookies.get(<name>) - empty result', function(done) {
+      Mocks.cookiesNotFound();
+
+      this.client.api.cookies.get('other_cookie', function callback(result) {
+        assert.strictEqual(result, null);
+      });
+
+      this.client.start(done);
+    });
+
+    it('client.cookies.delete(<name>)', function(done){
+      Mocks.deleteCookie();
+
+      this.client.api.cookies.delete('other_cookie', function callback(result) {
+        assert.strictEqual(result.status, 0);
+      });
+      this.client.start(done);
+    });
+
+    it('client.cookies.set(<name>)', function(done) {
+      Mocks.addCookie();
+
+      this.client.api.cookies.set({name: 'other_cookie', value: '123456'}, function callback(result) {
+        assert.strictEqual(result.status, 0);
+      });
+      this.client.start(done);
     });
   });
 

--- a/test/src/api/commands/cookies/testCookie.js
+++ b/test/src/api/commands/cookies/testCookie.js
@@ -122,6 +122,20 @@ describe('get, set and delete cookie', function() {
       this.client.start(done);
     });
 
+    it('client.cookies.get() without any argument', function(done) {
+      this.client.api.cookies.get();
+
+      this.client.start(function(err) {
+        try {
+          assert.ok(err instanceof Error);
+          assert.strictEqual(err.message.includes('First argument passed to .cookies.get() must be a string.'), true);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+    });
+
     it('client.cookies.delete(<name>)', function(done){
       Mocks.deleteCookie();
 
@@ -129,6 +143,20 @@ describe('get, set and delete cookie', function() {
         assert.strictEqual(result.status, 0);
       });
       this.client.start(done);
+    });
+
+    it('client.cookies.get() without any argument', function(done) {
+      this.client.api.cookies.delete();
+
+      this.client.start(function(err) {
+        try {
+          assert.ok(err instanceof Error);
+          assert.strictEqual(err.message.includes('First argument passed to .cookies.delete() must be a string.'), true);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
     });
 
     it('client.cookies.set(<name>)', function(done) {
@@ -139,6 +167,19 @@ describe('get, set and delete cookie', function() {
       });
       this.client.start(done);
     });
-  });
 
+    it('client.cookies.set() without any argument', function(done) {
+      this.client.api.cookies.set();
+
+      this.client.start(function(err) {
+        try {
+          assert.ok(err instanceof Error);
+          assert.strictEqual(err.message.includes('First argument passed to .cookies.set() must be an object; received: undefined (undefined)'), true);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+    });
+  });
 });

--- a/test/src/api/commands/cookies/testCookie.js
+++ b/test/src/api/commands/cookies/testCookie.js
@@ -32,17 +32,18 @@ describe('get, set and delete cookie', function() {
     });
 
     it('client.cookies.get(<name>)', function(done) {
-      Mocks.cookiesFound({times: 2});
+      Mocks.cookieFound();
+      Mocks.cookieNotFound();
 
       const api = this.client.api;
       this.client.api.cookies.get('test_cookie', function callback(result) {
         assert.strictEqual(this, api);
-        assert.strictEqual(result.name, 'test_cookie');
-        assert.strictEqual(result.value, '123456');
+        assert.strictEqual(result.value.name, 'test_cookie');
+        assert.strictEqual(result.value.value, '123456');
       });
 
       this.client.api.cookies.get('other_cookie', function callback(result) {
-        assert.strictEqual(result, null);
+        assert.strictEqual(result.value, null);
       });
 
       this.client.start(done);
@@ -104,27 +105,18 @@ describe('get, set and delete cookie', function() {
     });
 
     it('client.cookies.get(<name>)', function(done) {
-      Mocks.cookiesFound({times: 2});
+      Mocks.cookieFound();
+      Mocks.cookieNotFound();
 
       const api = this.client.api;
       this.client.api.cookies.get('test_cookie', function callback(result) {
         assert.strictEqual(this, api);
-        assert.strictEqual(result.name, 'test_cookie');
-        assert.strictEqual(result.value, '123456');
+        assert.strictEqual(result.value.name, 'test_cookie');
+        assert.strictEqual(result.value.value, '123456');
       });
 
       this.client.api.cookies.get('other_cookie', function callback(result) {
-        assert.strictEqual(result, null);
-      });
-
-      this.client.start(done);
-    });
-
-    it('client.cookies.get(<name>) - empty result', function(done) {
-      Mocks.cookiesNotFound();
-
-      this.client.api.cookies.get('other_cookie', function callback(result) {
-        assert.strictEqual(result, null);
+        assert.strictEqual(result.value, null);
       });
 
       this.client.start(done);

--- a/test/src/api/commands/cookies/testCookies.js
+++ b/test/src/api/commands/cookies/testCookies.js
@@ -1,8 +1,8 @@
 const assert = require('assert');
-const MockServer  = require('../../../../lib/mockserver.js');
+const Mocks = require('../../../../lib/command-mocks.js');
 const CommandGlobals = require('../../../../lib/globals/commands.js');
 
-describe('.getCookies()', function() {
+describe('get and delete cookies', function() {
   describe('with backwards compat mode', function() {
     before(function(done) {
       CommandGlobals.beforeEach.call(this, done, {
@@ -15,21 +15,7 @@ describe('.getCookies()', function() {
     });
 
     it('client.getCookies()', function(done) {
-      MockServer.addMock({
-        url: '/wd/hub/session/1352110219202/cookie',
-        method: 'GET',
-        response: {
-          sessionId: '1352110219202',
-          status: 0,
-          value: [{
-            name: 'test_cookie',
-            value: '123456',
-            path: '/',
-            domain: 'example.org',
-            secure: false
-          }]
-        }
-      }, true);
+      Mocks.cookiesFound();
 
       const api = this.client.api;
       this.client.api.getCookies(function callback(result) {
@@ -52,21 +38,7 @@ describe('.getCookies()', function() {
     });
 
     it('client.getCookies()', function(done) {
-      MockServer.addMock({
-        url: '/wd/hub/session/1352110219202/cookie',
-        method: 'GET',
-        response: {
-          sessionId: '1352110219202',
-          status: 0,
-          value: [{
-            name: 'test_cookie',
-            value: '123456',
-            path: '/',
-            domain: 'example.org',
-            secure: false
-          }]
-        }
-      }, true);
+      Mocks.cookiesFound();
 
       const api = this.client.api;
       this.client.api.getCookies(function callback(result) {
@@ -79,21 +51,57 @@ describe('.getCookies()', function() {
     });
 
     it('client.getCookies() - empty result', function(done) {
-      MockServer.addMock({
-        url: '/wd/hub/session/1352110219202/cookie',
-        method: 'GET',
-        response: JSON.stringify({
-          sessionId: '1352110219202',
-          status: 0,
-          value: []
-        })
-      }, true);
+      Mocks.cookiesNotFound();
 
       this.client.api.getCookies(function callback(result) {
         assert.ok(Array.isArray(result.value));
         assert.strictEqual(result.value.length, 0);
       });
 
+      this.client.start(done);
+    });
+
+    it('client.deleteCookies(<name>)', function(done){
+      Mocks.deleteCookies();
+
+      this.client.api.deleteCookies(function callback(result) {
+        assert.strictEqual(result.value, null);
+        assert.strictEqual(result.status, 0);
+      });
+      this.client.start(done);
+    });
+
+    it('client.cookies.getAll()', function(done) {
+      Mocks.cookiesFound();
+
+      const api = this.client.api;
+      this.client.api.cookies.getAll(function callback(result) {
+        assert.strictEqual(this, api);
+        assert.strictEqual(result.value.length, 1);
+        assert.strictEqual(result.value[0].name, 'test_cookie');
+      });
+
+      this.client.start(done);
+    });
+
+    it('client.cookies.getAll() - empty result', function(done) {
+      Mocks.cookiesNotFound();
+
+      this.client.api.cookies.getAll(function callback(result) {
+        assert.ok(Array.isArray(result.value));
+        assert.strictEqual(result.value.length, 0);
+      });
+
+      this.client.start(done);
+    });
+
+    it('client.cookies.deleteAll(<name>)', function(done){
+      Mocks.deleteCookies();
+
+      this.client.api.cookies.deleteAll(function callback(result) {
+        assert.strictEqual(result.value, null);
+        assert.strictEqual(result.status, 0);
+      });
       this.client.start(done);
     });
   });

--- a/test/src/apidemos/cookies/testCookieCommands.js
+++ b/test/src/apidemos/cookies/testCookieCommands.js
@@ -21,7 +21,7 @@ describe('cookie demos', function() {
 
   it('run cookie api demo tests basic', function() {
     const testsPath = path.join(__dirname, '../../../apidemos/cookies/cookieTests.js');
-    Mocks.cookiesFound();
+    Mocks.cookiesFound({times: 6});
 
     const globals = {
       waitForConditionPollInterval: 50,
@@ -52,14 +52,14 @@ describe('cookie demos', function() {
 
   it('run cookie api demo tests with socket hang up error', function() {
     const testsPath = path.join(__dirname, '../../../apidemos/cookies/cookieTestsWithError.js');
-    Mocks.cookiesSocketDelay();
+    Mocks.cookiesSocketDelay({times: 2});
 
     const globals = {
       waitForConditionPollInterval: 50,
 
       reporter(results) {
         assert.ok(results.lastError instanceof Error);
-        assert.strictEqual(results.errors, 1);
+        assert.strictEqual(results.errors, 2);
       }
     };
 


### PR DESCRIPTION
This PR moves all the cookie-related commands to `.cookies` namespace and deprecates the older commands.

New commands added:
- `.cookies.get()`
- `.cookies.getAll()`
- `.cookies.set()`
- `.cookies.delete()`
- `.cookies.deleteAll()`

Old commands deprecated:
- `.cookie()`
- `.getCookie()`
- `.getCookies()`
- `.setCookie()`
- `.deleteCookie()`
- `.deleteCookies()`