### PR TITLE
removed boxen from concurrent test runs

### DIFF
--- a/lib/runner/concurrency/child-process.js
+++ b/lib/runner/concurrency/child-process.js
@@ -1,6 +1,5 @@
 const child_process = require('child_process');
 const EventEmitter = require('events');
-const boxen = require('boxen');
 const {Logger, isObject, symbols} = require('../../utils');
 const ProcessListener = require('../../runner/process-listener.js');
 
@@ -171,7 +170,7 @@ class ChildProcess extends EventEmitter {
 
           let status = code > 0 ? symbols.fail : symbols.ok;
           // eslint-disable-next-line no-console
-          console.log(boxen(this.env_output.join('\n'), {title: `────────────────── ${status} ${this.env_label}`, padding: 1, borderColor: 'cyan'}));
+          console.log(`\n${status} ${this.env_label}`, this.env_output.join('\n'), '\n');
 
           code = code || this.processListener.exitCode;
           resolve(code);


### PR DESCRIPTION
Remake of https://github.com/nightwatchjs/nightwatch/pull/3614 because the CLA Agreement gave me some trouble with my enterprise account.  Re-doing the work away from my enterprise account. 

## Information from Original PR:
After a discussion on the Discord Channel, it appears that it may be beneficial to the community to remove the Boxen Library from the Concurrent Test Output.

Discord Thread: https://discord.com/channels/618399631038218240/1073406595725275267/1073406595725275267