### PR TITLE
Fixes/consider test suite settings in cucumber runner

### DIFF
--- a/cucumber-js/_setup_cucumber_runner.js
+++ b/cucumber-js/_setup_cucumber_runner.js
@@ -40,6 +40,7 @@ Before(function({pickle}) {
     webdriver,
     persist_globals,
     config: this.parameters.config,
+    test_settings: this.parameters.settings,
     globals
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 const {By, Key, Capabilities} = require('selenium-webdriver');
+const lodashMerge = require('lodash.merge');
 const Utils = require('./utils');
 const Settings = require('./settings/settings.js');
 const ElementGlobal = require('./api/_loaders/element-global.js');
@@ -40,7 +41,8 @@ module.exports.createClient = function({
   devtools = false,
   debug = false,
   enable_global_apis = false,
-  config = './nightwatch.json'
+  config = './nightwatch.json',
+  test_settings
 } = {}) {
   if (browserName && !env) {
     switch (browserName) {
@@ -102,6 +104,10 @@ module.exports.createClient = function({
   });
 
   cliRunner.test_settings.disable_global_apis = cliRunner.test_settings.disable_global_apis || !enable_global_apis;
+  
+  //merge settings recieved from testsuite to cli runner settings (this might have changed in hooks) 
+  lodashMerge(cliRunner.test_settings, test_settings);
+  
   const client = Nightwatch.client(cliRunner.test_settings, reporter, cliRunner.argv, true);
 
   Object.defineProperty(Nightwatch, 'element', {

--- a/lib/runner/test-runners/cucumber.js
+++ b/lib/runner/test-runners/cucumber.js
@@ -98,7 +98,7 @@ class CucumberSuite extends TestSuite {
     const {feature_path = ''} = options;
     const parallelArgs = this.usingCucumberWorkers ? ['--parallel', this.usingCucumberWorkers]: [];
     const additionalOptions = this.buildArgvValue(['tags', 'retry-tag-filter', 'profile', 'format', 'format-options', 'dry-run', 'fail-fast', ['retry', 'retries'], 'no-strict', 'name']);
-    const extraParams = ['--world-parameters', JSON.stringify(this.argv)];
+    const extraParams = ['--world-parameters', JSON.stringify({...this.argv, settings: this.settings})];
 
     return [
       process.execPath,

--- a/test/cucumber-integration-tests/sample_cucumber_tests/with-modified-settings/plugin/nightwatch/globals.js
+++ b/test/cucumber-integration-tests/sample_cucumber_tests/with-modified-settings/plugin/nightwatch/globals.js
@@ -1,0 +1,5 @@
+module.exports = {
+  before(settings) {
+    settings.desiredCapabilities.browserName = 'chrome';
+  }
+};

--- a/test/cucumber-integration-tests/sample_cucumber_tests/with-modified-settings/testSample.js
+++ b/test/cucumber-integration-tests/sample_cucumber_tests/with-modified-settings/testSample.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const {Given, Then, After} = require('@cucumber/cucumber');
+
+Given('I navigate to localhost', function() {
+  browser.globals.test_calls = 0;
+  browser.globals.test_calls++;
+
+  return browser.navigateTo('http://localhost');
+});
+
+Then('I check if webdriver is present', function() {
+  browser.globals.test_calls++;
+
+  return browser.assert.elementPresent('#webdriver');
+});
+
+Then('I check if webdriver is present and contains text', async function() {
+  browser.globals.test_calls++;
+
+  await browser.expect.element('#webdriver').text.to.contain('xx')
+});
+
+Then('I check if badElement is present', function() {
+  browser.globals.test_calls++;
+
+  return browser.assert.elementPresent('#badElement');
+});
+
+After(function() {
+  assert.strictEqual(browser.globals.test_calls, 2);
+});

--- a/test/cucumber-integration-tests/testCucumberTestsWithModifiedSettings.js
+++ b/test/cucumber-integration-tests/testCucumberTestsWithModifiedSettings.js
@@ -47,7 +47,7 @@ describe('Cucumber integration - with modified settings in plugin', function() {
       verbose: false, 
       config: path.join(__dirname, '../extra/cucumber-config.js')
     }, {
-      plugins: pluginPath,
+      plugins: pluginPath
     })
       .then(failures => {
         assert.strictEqual(failures, false);

--- a/test/cucumber-integration-tests/testCucumberTestsWithModifiedSettings.js
+++ b/test/cucumber-integration-tests/testCucumberTestsWithModifiedSettings.js
@@ -1,0 +1,57 @@
+const path = require('path');
+const assert = require('assert');
+const Globals = require('../lib/globals/commands.js');
+const common = require('../common.js');
+const MockServer = require('../lib/mockserver.js');
+const {runTests} = common.require('index.js');
+
+describe('Cucumber integration - with modified settings in plugin', function() {
+  beforeEach(function(done) {
+    this.server = MockServer.init(null, {port: 10195});
+    this.server.on('listening', () => done());
+  });
+
+  afterEach(function(done) {
+    Globals.afterEach.call(this, done);
+  });
+
+  it('testCucumberSampleTests with browsername modified (chrome) in plugin global hook', function() {
+    const source = [path.join(__dirname, './sample_cucumber_tests/with-modified-settings/testSample.js')];
+
+
+    const pluginPath = [path.join(__dirname, './sample_cucumber_tests/with-modified-settings/plugin')];
+
+    MockServer.addMock({
+      url: '/wd/hub/session',
+      method: 'POST',
+      statusCode: 201,
+      postdata: {
+        capabilities: {
+          firstMatch: [{}],
+          alwaysMatch: {browserName: 'chrome', 'goog:chromeOptions': {}}
+        }
+      },
+      response: {
+        status: 0,
+        sessionId: '1352110219202',
+        value: {browserName: 'chrome', browserVersion: 'TEST_chrome'},
+        state: null
+      }
+    }, true);
+
+
+    // modify browserName to chrome in plugin global hook
+    return runTests({
+      source,
+      tags: ['@pass'],
+      verbose: false, 
+      config: path.join(__dirname, '../extra/cucumber-config.js')
+    }, {
+      plugins: pluginPath,
+    })
+      .then(failures => {
+        assert.strictEqual(failures, false);
+      });
+  });
+
+});


### PR DESCRIPTION
## Overview
- when settings is updated in global plugin it should be considered while creating sessions using cucumber as a test-runner

## Changes
- merge `test_settings` from cucumber-testsuite to `CliRunner.test_settings`.
- added test.

## Impact
- with this change browserstack-local plugin will work with cucumber runner as well