### PR TITLE
api-docs: update registerBasicAuth

### DIFF
--- a/lib/api/client-commands/registerBasicAuth.js
+++ b/lib/api/client-commands/registerBasicAuth.js
@@ -3,6 +3,7 @@ const {Logger} = require('../../utils');
 
 /**
  * Automate the input of basic auth credentials whenever they arise.
+ * This feature is currently implemented on top of Selenium 4’s CDP(Chrome DevTools Protocol) support, and so only works on those browser that support that protocol
  *
  * @example
  *  this.demoTest = function (browser) {


### PR DESCRIPTION
Based on this https://www.selenium.dev/blog/2021/a-tour-of-4-authentication/ This feature is currently implemented on top of Selenium 4’s CDP(Chrome DevTools Protocol) support, and so only works on those browser that support that protocol. That means it won't work in Safari.
And it's not going to solve the Safari basic auth issue in selenium. See https://www.browserstack.com/docs/automate/selenium/basic-http-authentication

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.

- [ ] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [ ] If you're fixing a bug also create an issue if one doesn't exist yet;
- [ ] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [ ] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [ ] Do not include changes that are not related to the issue at hand;
- [ ] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [ ] Always add unit tests - PRs without tests are most of the times ignored.
