### PR TITLE
Add support for namespaced aliases.

### DIFF
--- a/lib/api/_loaders/_base-loader.js
+++ b/lib/api/_loaders/_base-loader.js
@@ -242,7 +242,7 @@ class BaseLoader extends EventEmitter {
     const commandFn = this.commandFn.bind(this);
 
     let stringifiedNamespace;
-    if (this.namespace && typeof this.namespace === 'string') {
+    if (this.namespace && Utils.isString(this.namespace)) {
       stringifiedNamespace = this.namespace;
     } else if (Array.isArray(this.namespace) && this.namespace.length > 0) {
       stringifiedNamespace = this.namespace.join('.');

--- a/lib/api/_loaders/_base-loader.js
+++ b/lib/api/_loaders/_base-loader.js
@@ -267,13 +267,13 @@ class BaseLoader extends EventEmitter {
   getNamespacedAliases() {
     const nsAliases = this.module.namespacedAliases;
 
-    if (typeof nsAliases === 'string') {
+    if (nsAliases && Utils.isString(nsAliases)) {
       return [nsAliases.split('.')];
     }
 
     if (Array.isArray(nsAliases)) {
       return nsAliases
-        .filter((nsAlias) => nsAlias && typeof nsAlias === 'string')
+        .filter((nsAlias) => nsAlias && Utils.isString(nsAlias))
         .map((nsAlias) => nsAlias.split('.'));
     }
 

--- a/lib/api/_loaders/_base-loader.js
+++ b/lib/api/_loaders/_base-loader.js
@@ -240,9 +240,18 @@ class BaseLoader extends EventEmitter {
   defineArgs(parent) {
     const {commandName} = this;
     const commandFn = this.commandFn.bind(this);
+
+    let stringifiedNamespace;
+    if (this.namespace && typeof this.namespace === 'string') {
+      stringifiedNamespace = this.namespace;
+    } else if (Array.isArray(this.namespace) && this.namespace.length > 0) {
+      stringifiedNamespace = this.namespace.join('.');
+    }
+
     const args = [this.createQueuedCommandFn({
       parent,
       commandName,
+      namespace: stringifiedNamespace,
       commandFn,
       context: this
     })];
@@ -255,20 +264,52 @@ class BaseLoader extends EventEmitter {
     return args;
   }
 
+  getNamespacedAliases() {
+    const nsAliases = this.module.namespacedAliases;
+
+    if (typeof nsAliases === 'string') {
+      return [nsAliases.split('.')];
+    }
+
+    if (Array.isArray(nsAliases)) {
+      return nsAliases
+        .filter((nsAlias) => nsAlias && typeof nsAlias === 'string')
+        .map((nsAlias) => nsAlias.split('.'));
+    }
+
+    return [];
+  }
+
   define(parent = null) {
     if (!this.commandFn) {
       return this;
     }
 
-    this.validateMethod(parent);
-
     const {commandName, nightwatchInstance} = this;
+
+    this.validateMethod(parent);
     const args = this.defineArgs(parent);
 
     nightwatchInstance.setApiMethod(commandName, ...args);
     if (this.module && this.module.AliasName) {
       nightwatchInstance.setApiMethod(this.module.AliasName, ...args);
     }
+
+    // check for namespaced aliases
+    const nsAliases = this.getNamespacedAliases();
+
+    const origNamespace = this.namespace;    
+    nsAliases.forEach((ns) => {
+      const commandName = ns.pop();
+      this.setNamespace(ns);
+
+      this.validateMethod(parent);
+      const args = this.defineArgs(parent, ns);
+
+      nightwatchInstance.setApiMethod(commandName, ...args);
+    });
+
+    this.setNamespace(origNamespace);
 
     return this;
   }

--- a/lib/api/_loaders/_base-loader.js
+++ b/lib/api/_loaders/_base-loader.js
@@ -300,15 +300,16 @@ class BaseLoader extends EventEmitter {
 
     const origNamespace = this.namespace;    
     nsAliases.forEach((ns) => {
-      const commandName = ns.pop();
+      this.commandName = ns.pop();
       this.setNamespace(ns);
 
       this.validateMethod(parent);
       const args = this.defineArgs(parent);
 
-      nightwatchInstance.setApiMethod(commandName, ...args);
+      nightwatchInstance.setApiMethod(this.commandName, ...args);
     });
 
+    this.commandName = commandName;
     this.setNamespace(origNamespace);
 
     return this;

--- a/lib/api/_loaders/_base-loader.js
+++ b/lib/api/_loaders/_base-loader.js
@@ -304,7 +304,7 @@ class BaseLoader extends EventEmitter {
       this.setNamespace(ns);
 
       this.validateMethod(parent);
-      const args = this.defineArgs(parent, ns);
+      const args = this.defineArgs(parent);
 
       nightwatchInstance.setApiMethod(commandName, ...args);
     });

--- a/test/apidemos/custom-commands/testNamespacedAliases.js
+++ b/test/apidemos/custom-commands/testNamespacedAliases.js
@@ -3,11 +3,12 @@ const assert = require('assert');
 describe('custom command using namespaced aliases', function () {
   it('test aliases are available on requested namespace', async function() {
     assert.strictEqual(typeof browser.customPauseWithNamespacedAlias, 'function');
-    assert.strictEqual(typeof browser.sampleNamespace.customPause, 'function');
+    assert.strictEqual(typeof browser.newPause, 'function');
+    assert.strictEqual(typeof browser.sampleNamespace.amazingPause, 'function');
     assert.strictEqual(typeof browser.fantasticNamespace.subNamespace.fantasticPause, 'function');
   });
 
   it('test custom command with a failure', async function() {
-    browser.sampleNamespace.customPause('200');
+    browser.sampleNamespace.amazingPause('200');
   });
 });

--- a/test/apidemos/custom-commands/testNamespacedAliases.js
+++ b/test/apidemos/custom-commands/testNamespacedAliases.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+
+describe('custom command using namespaced aliases', function () {
+  it('test aliases are available on requested namespace', async function() {
+    assert.strictEqual(typeof browser.customPauseWithNamespacedAlias, 'function');
+    assert.strictEqual(typeof browser.sampleNamespace.customPause, 'function');
+    assert.strictEqual(typeof browser.fantasticNamespace.subNamespace.fantasticPause, 'function');
+  });
+
+  it('test custom command with a failure', async function() {
+    browser.sampleNamespace.customPause('200');
+  });
+});

--- a/test/extra/commands/customPauseWithNamespacedAlias.js
+++ b/test/extra/commands/customPauseWithNamespacedAlias.js
@@ -1,6 +1,6 @@
 module.exports = class CustomPause {
   static get namespacedAliases() {
-    return ['sampleNamespace.customPause', 'fantasticNamespace.subNamespace.fantasticPause'];
+    return ['newPause', 'sampleNamespace.amazingPause', 'fantasticNamespace.subNamespace.fantasticPause'];
   }
 
   command(timeout) {

--- a/test/extra/commands/customPauseWithNamespacedAlias.js
+++ b/test/extra/commands/customPauseWithNamespacedAlias.js
@@ -1,0 +1,13 @@
+module.exports = class CustomPause {
+  static get namespacedAliases() {
+    return ['sampleNamespace.customPause', 'fantasticNamespace.subNamespace.fantasticPause'];
+  }
+
+  command(timeout) {
+    if (typeof timeout !== 'number') {
+      throw new Error('First argument should be a number.');
+    }
+
+    this.pause(200);
+  }
+};

--- a/test/src/api/protocol/testOrientation.js
+++ b/test/src/api/protocol/testOrientation.js
@@ -38,7 +38,7 @@ describe('orientation commands', function() {
       commandName: 'setOrientation',
       args: ['TEST']
     }).catch(err => {
-      strictEqual(err.message, 'Error while running "appium.setOrientation" command: Invalid screen orientation value specified. Accepted values are: LANDSCAPE, PORTRAIT');
+      strictEqual(err.message, 'Error while running "setOrientation" command: Invalid screen orientation value specified. Accepted values are: LANDSCAPE, PORTRAIT');
 
       return true;
     }).then(result => assert.strictEqual(result, true));
@@ -75,7 +75,7 @@ describe('orientation commands', function() {
       commandName: 'appium.setOrientation',
       args: ['TEST']
     }).catch(err => {
-      strictEqual(err.message, 'Error while running "setOrientation" command: Invalid screen orientation value specified. Accepted values are: LANDSCAPE, PORTRAIT');
+      strictEqual(err.message, 'Error while running "appium.setOrientation" command: Invalid screen orientation value specified. Accepted values are: LANDSCAPE, PORTRAIT');
 
       return true;
     }).then(result => assert.strictEqual(result, true));

--- a/test/src/api/protocol/testOrientation.js
+++ b/test/src/api/protocol/testOrientation.js
@@ -38,7 +38,7 @@ describe('orientation commands', function() {
       commandName: 'setOrientation',
       args: ['TEST']
     }).catch(err => {
-      strictEqual(err.message, 'Error while running "setOrientation" command: Invalid screen orientation value specified. Accepted values are: LANDSCAPE, PORTRAIT');
+      strictEqual(err.message, 'Error while running "appium.setOrientation" command: Invalid screen orientation value specified. Accepted values are: LANDSCAPE, PORTRAIT');
 
       return true;
     }).then(result => assert.strictEqual(result, true));

--- a/test/src/apidemos/custom-commands/testCustomPauseWithNamespacedAlias.js
+++ b/test/src/apidemos/custom-commands/testCustomPauseWithNamespacedAlias.js
@@ -37,7 +37,7 @@ describe('custom command with namespaced alias', function () {
         assert.ok(results.lastError instanceof Error);
         assert.strictEqual(
           results.lastError.message,
-          'Error while running "sampleNamespace.customPauseWithNamespacedAlias" command: First argument should be a number.'
+          'Error while running "sampleNamespace.amazingPause" command: First argument should be a number.'
         );
       }
     };

--- a/test/src/apidemos/custom-commands/testCustomPauseWithNamespacedAlias.js
+++ b/test/src/apidemos/custom-commands/testCustomPauseWithNamespacedAlias.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+const path = require('path');
+const common = require('../../../common.js');
+const {settings} = common;
+const MockServer = require('../../../lib/mockserver.js');
+const Mocks = require('../../../lib/command-mocks.js');
+const NightwatchClient = common.require('index.js');
+
+describe('custom command with namespaced alias', function () {
+  beforeEach(function (done) {
+    this.server = MockServer.init();
+    this.server.on('listening', () => {
+      done();
+    });
+  });
+
+  afterEach(function (done) {
+    this.server.close(function () {
+      done();
+    });
+  });
+
+  it('test namespaced aliases by running a custom-command', function () {
+    const testsPath = path.join(__dirname, '../../../apidemos/custom-commands/testNamespacedAliases.js');
+    Mocks.createNewW3CSession({
+      testName: 'Test Using Namespaced Aliases'
+    });
+
+    const globals = {
+      waitForConditionPollInterval: 50,
+
+      reporter(results) {
+        if (results.lastError && !results.lastError.message.includes('First argument should be a number')) {
+          throw results.lastError;
+        }
+
+        assert.ok(results.lastError instanceof Error);
+        assert.strictEqual(
+          results.lastError.message,
+          'Error while running "sampleNamespace.customPauseWithNamespacedAlias" command: First argument should be a number.'
+        );
+      }
+    };
+
+    return NightwatchClient.runTests(testsPath, settings({
+      output: false,
+      silent: true,
+      selenium_host: null,
+      custom_commands_path: [path.join(__dirname, '../../../extra/commands')],
+      globals
+    }));
+  });
+});


### PR DESCRIPTION
This PR adds support for adding namespaced aliases to Nightwatch commands. This would allow us to make a particular command available on multiple namespaces without the need to duplicate the file at multiple places.

This can be achieved by adding a `namespacedAliases` static get method to any command file. The aliases returned by the method should be absolute (how it will be used on the main `browser` object) and should end with the command name).

Having the aliases as absolute is necessary so that we can make a command having a namespace already, be available on the main `browser` object. For example, making `browser.appium.hideKeyboard()` command available as `browser.hideAppiumKeyboard()` as well, instead of the other way around.

### Example Usage

Inside `lib/api/protocol/navigateTo.js` command, add the following method:
```js
static get namespacedAliases() {
  return 'client.navigateTo'; // or return ['client.navigateTo']
}
```
Now, the `browser.navigateTo()` command can also be used as `browser.client.navigateTo()`.

Similarly, inside `lib/api/protocol/appium/hideKeyboard.js` command, add the following method:
```js
static get namespacedAliases() {
  return 'hideAppiumKeyboard'; // or return ['hideAppiumKeyboard']
}
```
Now, the `browser.appium.hideKeyboard()` command can also be used as `browser.hideAppiumKeyboard()`.