### PR TITLE
Fixes/3612 add session name to browserstack transport

### DIFF
--- a/lib/transport/selenium-webdriver/browserstack/browserstack.js
+++ b/lib/transport/selenium-webdriver/browserstack/browserstack.js
@@ -51,7 +51,8 @@ class Browserstack extends AppiumBaseServer {
       userName: desiredCapabilities['browserstack.user'], 
       accessKey: desiredCapabilities['browserstack.key'], 
       buildName: desiredCapabilities.build || desiredCapabilities.buildName,
-      local: desiredCapabilities['browserstack.local']
+      local: desiredCapabilities['browserstack.local'],
+      sessionName: desiredCapabilities['name']
     });
 
     if (!this.accessKey && process.env.BROWSERSTACK_KEY) {

--- a/test/src/core/testCreateSession.js
+++ b/test/src/core/testCreateSession.js
@@ -487,6 +487,7 @@ describe('test Request With Credentials', function () {
               browserName: 'chrome',
               'bstack:options': {
                 local: 'false',
+                sessionName: 'Try 1',
                 userName: 'test_user',
                 accessKey: 'test_key',
                 os: 'OS X',
@@ -570,6 +571,7 @@ describe('test Request With Credentials', function () {
           browserName: 'chrome',
           'bstack:options': {
             local: 'false',
+            sessionName: 'Try 1',
             userName: 'test_user',
             accessKey: 'test_key',
             os: 'OS X',
@@ -598,6 +600,7 @@ describe('test Request With Credentials', function () {
               'appium:app': 'bs://878bdf21505f0004ce',
               'bstack:options': {
                 local: 'false',
+                sessionName: 'Try 1',
                 userName: 'test_user',
                 accessKey: 'test_key',
                 osVersion: '14',
@@ -715,6 +718,7 @@ describe('test Request With Credentials', function () {
               'browserName': '',
               'bstack:options': {
                 local: 'false',
+                sessionName: 'Try 1',
                 userName: 'test_user',
                 accessKey: 'test_key',
                 realMobile: true,
@@ -937,6 +941,7 @@ describe('test Request With Credentials', function () {
               browserName: 'chrome',
               'bstack:options': {
                 local: 'false',
+                sessionName: 'Try 1',
                 userName: 'test_user',
                 accessKey: 'test_key',
                 os: 'OS X',
@@ -1018,6 +1023,7 @@ describe('test Request With Credentials', function () {
           browserName: 'chrome',
           'bstack:options': {
             local: 'false',
+            sessionName: 'Try 1',
             userName: 'test_user',
             accessKey: 'test_key',
             os: 'OS X',

--- a/test/src/runner/testRunBrowserstackTransport.js
+++ b/test/src/runner/testRunBrowserstackTransport.js
@@ -17,12 +17,16 @@ describe('testRunBrowserstackTransport', function() {
 
     nock('https://hub-cloud.browserstack.com')
       .post('/wd/hub/session')
-      .reply(201, {
-        status: 0,
-        sessionId: '1352110219202',
-        value: {
-          browserName: 'chrome'
-        }
+      .reply(201, (uri, requestBody) => {
+        assert.ok(requestBody.capabilities.alwaysMatch['bstack:options'].sessionName, 'session request should contain session Name');
+        
+        return {
+          status: 0,
+          sessionId: '1352110219202',
+          value: {
+            browserName: 'chrome'
+          }
+        };
       });
 
     nock('https://api.browserstack.com')
@@ -68,7 +72,7 @@ describe('testRunBrowserstackTransport', function() {
   });
 
   it('run with error', function() {
-    let testsPath = path.join(__dirname, '../../sampletests/withfailures/');
+    const testsPath = path.join(__dirname, '../../sampletests/withfailures/');
 
     return runTests(testsPath, settings({
       output: false,
@@ -79,8 +83,10 @@ describe('testRunBrowserstackTransport', function() {
         start_process: true
       },
       desiredCapabilities: {
-        'browserstack.user': 'test-access-user',
-        'browserstack.key': 'test-access-key',
+        'bstack:options': {
+          'userName': 'test-access-user',
+          'accessKey': 'test-access-key'
+        },
         browserName: 'chrome'
       },
       globals: {


### PR DESCRIPTION
## Changes 
- add session name to BrowserStack capabilities before creating the session

## Impact
- fixes #3612 