### PR TITLE
disable fail-fast for github workflows

### DIFF
--- a/.github/workflows/build-node.yaml
+++ b/.github/workflows/build-node.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [12.x, 14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
@@ -33,6 +34,7 @@ jobs:
     runs-on: windows-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [16.x, 18.x]
     steps:


### PR DESCRIPTION
## Changes
- update fail-fast strategy for github workflows
  - even if test process fails on a matrix version (example node v14 fails) avoid cancelling other workflow version