### PR TITLE
Allow to use any browser with BrowserStack and Appium.

### DIFF
--- a/lib/transport/factory.js
+++ b/lib/transport/factory.js
@@ -90,12 +90,6 @@ module.exports = class TransportFactory {
       browserName = Browser.EDGE;
     } else if (BrowsersLowerCase[browserName && browserName.toLowerCase()]) {
       browserName = BrowsersLowerCase[browserName.toLowerCase()];
-    } else {
-      const didYouMean = require('didyoumean');
-      const browsersList = Object.values(Browser);
-      const resultMeant = didYouMean(browserName, browsersList);
-  
-      throw new Error(`Unknown browser: "${browserName}"${resultMeant ? ('; did you mean "' + resultMeant + '"?') : ''}`);
     }
 
     return browserName;
@@ -154,8 +148,13 @@ module.exports = class TransportFactory {
         Driver = require('./selenium-webdriver/safari.js');
         break;
 
-      default:
-        throw new Error(`Unrecognized browser: ${browserName}.`);
+      default: {
+        const didYouMean = require('didyoumean');
+        const browsersList = Object.values(Browser);
+        const resultMeant = didYouMean(browserName, browsersList);
+    
+        throw new Error(`Unknown browser: "${browserName}"${resultMeant ? ('; did you mean "' + resultMeant + '"?') : ''}`);
+      }
     }
 
     return new Driver(nightwatchInstance);

--- a/lib/transport/factory.js
+++ b/lib/transport/factory.js
@@ -61,10 +61,15 @@ module.exports = class TransportFactory {
 
     let {browserName} = settings.desiredCapabilities;
 
-    // Better support for app-testing, if the browserName is not present we can skip all further checks
+    // Allow to use any browserName with Appium and BrowserStack.
+    // Not supporting '--browserName' cli flag for both of these.
     const usingAppium = TransportFactory.usingSeleniumServer(settings) && settings.selenium.use_appium;
     const usingBrowserStack = TransportFactory.usingBrowserstack(settings);
-    if ((usingAppium || usingBrowserStack) && !browserName) {
+    if ((usingAppium || usingBrowserStack)) {
+      if (BrowsersLowerCase[browserName && browserName.toLowerCase()]) {
+        browserName = BrowsersLowerCase[browserName.toLowerCase()];
+      }
+
       return browserName;
     }
 
@@ -90,6 +95,12 @@ module.exports = class TransportFactory {
       browserName = Browser.EDGE;
     } else if (BrowsersLowerCase[browserName && browserName.toLowerCase()]) {
       browserName = BrowsersLowerCase[browserName.toLowerCase()];
+    } else {
+      const didYouMean = require('didyoumean');
+      const browsersList = Object.values(Browser);
+      const resultMeant = didYouMean(browserName, browsersList);
+
+      throw new Error(`Unknown browser: "${browserName}"${resultMeant ? ('; did you mean "' + resultMeant + '"?') : ''}`);
     }
 
     return browserName;
@@ -148,13 +159,8 @@ module.exports = class TransportFactory {
         Driver = require('./selenium-webdriver/safari.js');
         break;
 
-      default: {
-        const didYouMean = require('didyoumean');
-        const browsersList = Object.values(Browser);
-        const resultMeant = didYouMean(browserName, browsersList);
-    
-        throw new Error(`Unknown browser: "${browserName}"${resultMeant ? ('; did you mean "' + resultMeant + '"?') : ''}`);
-      }
+      default:
+        throw new Error(`Unrecognized browser: ${browserName}.`);
     }
 
     return new Driver(nightwatchInstance);

--- a/lib/transport/factory.js
+++ b/lib/transport/factory.js
@@ -65,7 +65,7 @@ module.exports = class TransportFactory {
     // Not supporting '--browserName' cli flag for both of these.
     const usingAppium = TransportFactory.usingSeleniumServer(settings) && settings.selenium.use_appium;
     const usingBrowserStack = TransportFactory.usingBrowserstack(settings);
-    if ((usingAppium || usingBrowserStack)) {
+    if (usingAppium || usingBrowserStack) {
       if (BrowsersLowerCase[browserName && browserName.toLowerCase()]) {
         browserName = BrowsersLowerCase[browserName.toLowerCase()];
       }

--- a/lib/transport/selenium-webdriver/selenium.js
+++ b/lib/transport/selenium-webdriver/selenium.js
@@ -1,5 +1,8 @@
+const {Capabilities} = require('selenium-webdriver');
+
 const DefaultSeleniumDriver = require('./');
 const SeleniumServiceBuilder = require('./service-builders/selenium.js');
+
 
 module.exports = class SeleniumServer extends DefaultSeleniumDriver {
   /**
@@ -66,6 +69,11 @@ module.exports = class SeleniumServer extends DefaultSeleniumDriver {
   }
 
   setBuilderOptions({builder, options}) {
+    if (!(options instanceof Capabilities)) {
+      const browserName = this.initialCapabilities.getBrowserName();
+      throw new Error(`Unknown browser: '${browserName}'`);
+    }
+
     const serverUrl = this.getServerUrl();
 
     builder
@@ -74,8 +82,6 @@ module.exports = class SeleniumServer extends DefaultSeleniumDriver {
 
     return super.setBuilderOptions({builder, options});
   }
-
-
 };
 
 

--- a/lib/transport/selenium-webdriver/selenium.js
+++ b/lib/transport/selenium-webdriver/selenium.js
@@ -1,8 +1,5 @@
-const {Capabilities} = require('selenium-webdriver');
-
 const DefaultSeleniumDriver = require('./');
 const SeleniumServiceBuilder = require('./service-builders/selenium.js');
-
 
 module.exports = class SeleniumServer extends DefaultSeleniumDriver {
   /**
@@ -69,11 +66,6 @@ module.exports = class SeleniumServer extends DefaultSeleniumDriver {
   }
 
   setBuilderOptions({builder, options}) {
-    if (!(options instanceof Capabilities)) {
-      const browserName = this.initialCapabilities.getBrowserName();
-      throw new Error(`Unknown browser: '${browserName}'`);
-    }
-
     const serverUrl = this.getServerUrl();
 
     builder

--- a/test/src/core/testCreateSession.js
+++ b/test/src/core/testCreateSession.js
@@ -376,7 +376,7 @@ describe('test Request With Credentials', function () {
   });
 
   it('Test blank browserName', async function () {
-    try {
+    assert.throws(function() {
       const client = Nightwatch.createClient({
         selenium_port: 10195,
         silent: false,
@@ -386,13 +386,7 @@ describe('test Request With Credentials', function () {
           alwaysMatch: {}
         }
       });
-
-      await client.createSession();
-      
-      assert.fail('Error expected.');
-    } catch (err) {
-      assert.strictEqual(err.message.includes('[Error] Unknown browser: \'undefined\''), true);
-    }
+    }, /Error: Unknown browser:/);
   });
 
   it('Test create session with browsername null - Appium support', async function () {

--- a/test/src/core/testCreateSession.js
+++ b/test/src/core/testCreateSession.js
@@ -447,7 +447,7 @@ describe('test Request With Credentials', function () {
           capabilities: {
             firstMatch: [{}],
             alwaysMatch: {
-              browserName: 'random',
+              browserName: 'acmeBrowser',
               platformName: 'android',
               'appium:platformVersion': '12.0'
             }
@@ -457,7 +457,7 @@ describe('test Request With Credentials', function () {
         return {
           value: {
             capabilities: {
-              browserName: 'random',
+              browserName: 'acmeBrowser',
               platformName: 'android',
               platformVersion: '12.0',
               name: 'sample test goes here'
@@ -478,7 +478,7 @@ describe('test Request With Credentials', function () {
         port: 9999
       },
       desiredCapabilities: {
-        browserName: 'random',
+        browserName: 'acmeBrowser',
         platformName: 'android',
         'appium:platformVersion': '12.0'
       }
@@ -487,7 +487,7 @@ describe('test Request With Credentials', function () {
     const result = await client.createSession();
     assert.deepStrictEqual(result, {
       capabilities: {
-        browserName: 'random',
+        browserName: 'acmeBrowser',
         platformName: 'android',
         platformVersion: '12.0',
         name: 'sample test goes here'
@@ -954,7 +954,7 @@ describe('test Request With Credentials', function () {
           capabilities: {
             firstMatch: [{}],
             alwaysMatch: {
-              browserName: 'random',
+              browserName: 'acmeBrowser',
               'bstack:options': {
                 local: 'false',
                 userName: 'test_user',
@@ -1014,7 +1014,7 @@ describe('test Request With Credentials', function () {
           os: 'OS X',
           osVersion: 'Monterey'
         },
-        browserName: 'random'
+        browserName: 'acmeBrowser'
       },
       parallel: false
     });
@@ -1030,7 +1030,7 @@ describe('test Request With Credentials', function () {
       capabilities: {
         firstMatch: [{}],
         alwaysMatch: {
-          browserName: 'random',
+          browserName: 'acmeBrowser',
           'bstack:options': {
             local: 'false',
             userName: 'test_user',


### PR DESCRIPTION
This PR allows users to use any browser with BrowserStack, as well as while creating a session with Appium server.

This is because with BrowserStack, we can send any browser name and instead of returning an error it creates a session with Chrome browser as default. And with Appium server, accepted values of `browserName` depends on the driver being used and hence cannot be pre-defined.

With selenium server, because we use Selenium's `Builder` class which supports only a few browsers, it will throw an appropriate error for other unsupported browsers instead of just some random error.