### PR TITLE
Added a fix for assert.hasAttribute

### DIFF
--- a/lib/api/assertions/hasAttribute.js
+++ b/lib/api/assertions/hasAttribute.js
@@ -53,14 +53,22 @@ exports.assertion = function(definition, expectedAttribute, msg) {
       return '';
     }
 
-    this.attributeList = result.value.map(attribute =>  attribute.name);
+    this.attributeList = result.value;
 
     return this.attributeList;
   };
 
   this.command = function(callback) {
-    this.api.getAttribute(setElementSelectorProps(definition, {
+    const element = this.api.findElement(setElementSelectorProps(definition, {
       suppressNotFoundErrors: true
-    }), 'attributes', callback);
+    }));
+
+    this.api.executeScript(function(element){
+      if (element) {
+        return element.getAttributeNames();
+      }
+
+      return null;
+    }, [element], callback);
   };
 };

--- a/lib/api/assertions/hasAttribute.js
+++ b/lib/api/assertions/hasAttribute.js
@@ -19,7 +19,7 @@
  * @api assertions
  */
 
-const {setElementSelectorProps, containsMultiple} = require('../../utils');
+const {setElementSelectorProps} = require('../../utils');
 
 exports.assertion = function(definition, expectedAttribute, msg) {
   this.options = {
@@ -36,39 +36,23 @@ exports.assertion = function(definition, expectedAttribute, msg) {
  
     return {
       message,
-      args: [this.elementSelector, `'${Array.isArray(expectedAttribute) ? expectedAttribute.join(' ') : expectedAttribute}'`]
+      args: [this.elementSelector, `'${expectedAttribute}'`]
     };
   };
 
   this.evaluate = function() {
-    if (!this.attributeList) {
+    const {result} = this;
+
+    if (!result || !result.value) {
       return false;
     }
  
-    return containsMultiple(this.attributeList, expectedAttribute, ' ');
-  };
-
-  this.value = function(result) {
-    if (!result || !result.value) {
-      return '';
-    }
-
-    this.attributeList = result.value;
-
-    return this.attributeList;
+    return true;
   };
 
   this.command = function(callback) {
-    const element = this.api.findElement(setElementSelectorProps(definition, {
+    this.api.getAttribute(setElementSelectorProps(definition, {
       suppressNotFoundErrors: true
-    }));
-
-    this.api.executeScript(function(element){
-      if (element) {
-        return element.getAttributeNames();
-      }
-
-      return null;
-    }, [element], callback);
+    }), expectedAttribute, callback);
   };
 };

--- a/lib/api/assertions/hasAttribute.js
+++ b/lib/api/assertions/hasAttribute.js
@@ -19,6 +19,7 @@
  * @api assertions
  */
 
+const Utils = require('../../utils');
 const {setElementSelectorProps} = require('../../utils');
 
 exports.assertion = function(definition, expectedAttribute, msg) {
@@ -32,6 +33,10 @@ exports.assertion = function(definition, expectedAttribute, msg) {
  
 
   this.formatMessage = function() {
+    if (!Utils.isString(expectedAttribute)) {
+      throw new Error('Expected attribute must be a string');
+    }
+
     let message = msg || `Testing if element %s ${this.negate ? 'doesn\'t have attribute %s' : 'has attribute %s'}`;
  
     return {

--- a/lib/api/assertions/hasAttribute.js
+++ b/lib/api/assertions/hasAttribute.js
@@ -19,8 +19,7 @@
  * @api assertions
  */
 
-const Utils = require('../../utils');
-const {setElementSelectorProps} = require('../../utils');
+const {setElementSelectorProps, isString} = require('../../utils');
 
 exports.assertion = function(definition, expectedAttribute, msg) {
   this.options = {
@@ -33,7 +32,7 @@ exports.assertion = function(definition, expectedAttribute, msg) {
  
 
   this.formatMessage = function() {
-    if (!Utils.isString(expectedAttribute)) {
+    if (!isString(expectedAttribute)) {
       throw new Error('Expected attribute must be a string');
     }
 

--- a/test/src/api/assertions/testHasAttribute.js
+++ b/test/src/api/assertions/testHasAttribute.js
@@ -112,4 +112,17 @@ describe('assert.hasAttribute', function () {
       }
     });
   });
+
+  it('hasAttribute assertion failed for wrong parameters', function () {
+    return assertionTest({
+      args: ['.test_element', ['data-test', 'dummy'], 'Test message'],
+      commandResult: {
+        value: 'data-track'
+      },
+      assertMessage: true
+    }).catch((err) => {
+      assert.ok(err instanceof Error);
+      assert.strictEqual(err.message, 'Error while running "assert.hasAttribute" command: Expected attribute must be a string');
+    });
+  });
 });

--- a/test/src/api/assertions/testHasAttribute.js
+++ b/test/src/api/assertions/testHasAttribute.js
@@ -13,7 +13,7 @@ describe('assert.hasAttribute', function () {
     return assertionTest({
       args: ['.test_element', 'data-test', 'Test message'],
       commandResult: {
-        value: [{name: 'data-track'}, {name: 'data-test'}]
+        value: 'data-track'
       },
       assertMessage: true,
       assertion({instance, failure}) {
@@ -28,7 +28,7 @@ describe('assert.hasAttribute', function () {
     return assertionTest({
       args: ['.test_element', 'data-test'],
       commandResult: {
-        value: [{name: 'data-track'}]
+        value: 'data-track'
       },
       negate: true,
       assertion({instance, queueOpts, message}) {
@@ -36,8 +36,8 @@ describe('assert.hasAttribute', function () {
         assert.strictEqual(queueOpts.negate, true);
 
         assert.strictEqual(instance.hasFailure(), false);
-        assert.deepStrictEqual(instance.getValue(), ['data-track']);
-        assert.deepStrictEqual(instance.getActual(), ['data-track']);
+        assert.deepStrictEqual(instance.getValue(), 'data-track');
+        assert.deepStrictEqual(instance.getActual(), 'data-track');
         assert.strictEqual(instance.message, 'Testing if element <.test_element> doesn\'t have attribute \'data-test\'');
         assert.ok(message.startsWith('Testing if element <.test_element> doesn\'t have attribute \'data-test\''), message);
       }
@@ -48,15 +48,15 @@ describe('assert.hasAttribute', function () {
     return assertionTest({
       args: ['.test_element', 'data-test'],
       commandResult: {
-        value: [{name: 'data-test'}]
+        value: 'data-test'
       },
       negate: true,
       assertError: true,
       assertion({instance, queueOpts, err}) {
         assert.strictEqual(queueOpts.negate, true);
         assert.strictEqual(instance.hasFailure(), false);
-        assert.deepStrictEqual(instance.getValue(), ['data-test']);
-        assert.deepStrictEqual(instance.getActual(), ['data-test']);
+        assert.deepStrictEqual(instance.getValue(), 'data-test');
+        assert.deepStrictEqual(instance.getActual(), 'data-test');
         assert.strictEqual(err.message, `Testing if element <.test_element> doesn't have attribute 'data-test' in 5ms - expected "has not data-test" but got: "data-test" (${instance.elapsedTime}ms)`);
       }
     });
@@ -66,13 +66,13 @@ describe('assert.hasAttribute', function () {
     return assertionTest({
       args: [{selector: '.test_element'}, 'data-test'],
       commandResult: {
-        value: [{name: 'data-test'}]
+        value: 'data-test'
       },
       assertResult: true,
       assertion({instance, failure, message, err}) {
         assert.strictEqual(err, undefined);
         assert.deepStrictEqual(instance.options, {elementSelector: true});
-        assert.deepStrictEqual(instance.getActual(), ['data-test']);
+        assert.deepStrictEqual(instance.getActual(), 'data-test');
         assert.strictEqual(instance.hasFailure(), false);
         assert.ok(message.startsWith('Testing if element <.test_element> has attribute \'data-test\''), message);
         assert.strictEqual(failure, false);
@@ -84,33 +84,13 @@ describe('assert.hasAttribute', function () {
     return assertionTest({
       args: ['.test_element', 'data-test', 'Test message'],
       commandResult: {
-        value: [{name: 'not_expected'}]
+        value: null
       },
       assertError: true,
       assertResult: true,
       assertion({instance, failure}) {
-        assert.deepStrictEqual(instance.getActual(), ['not_expected']);
-        assert.strictEqual(failure, 'Expected "has data-test" but got: "not_expected"');
-      }
-    });
-  });
-
-  it('hasAttribute assertion - element not found', function() {
-    return assertionTest({
-      args: ['.test_element', 'data-test', 'Test attribute %s from element "%s" == %s'],
-      commandResult: {
-        status: -1,
-        value: []
-      },
-      assertError: true,
-      assertFailure: true,
-      assertResult: true,
-      assertion({instance, failure, err}) {
-        assert.strictEqual(instance.getActual(), 'element could not be located');
-        assert.strictEqual(instance.expected(), 'has data-test');
-        assert.strictEqual(instance.getValue(), null);
-        assert.strictEqual(failure, 'Expected "has data-test" but got: "element could not be located"');
-        assert.strictEqual(err.message, `Test attribute <.test_element> from element "'data-test'" == %s in 5ms - expected "has data-test" but got: "element could not be located" (${instance.elapsedTime}ms)`);
+        assert.deepStrictEqual(instance.getActual(), null);
+        assert.strictEqual(failure, 'Expected "has data-test" but got: "null"');
       }
     });
   });


### PR DESCRIPTION
- #3608 

As discussed with @AutomatedTester, removing the uses for multiple attributes as the webdriver's [get element attribute API](https://www.w3.org/TR/webdriver/#get-element-attribute) returns only one attribute value.