### PR TITLE
avoid pushing autoInvoked command nodes to command queue

### DIFF
--- a/lib/core/queue.js
+++ b/lib/core/queue.js
@@ -29,7 +29,7 @@ class CommandQueue extends EventEmitter {
     return this.currentNode.started && allChildNodesDone;
   }
 
-  add({commandName, commandFn, context, args, stackTrace, namespace, options = {}, deferred, isES6Async, rejectPromise}) {
+  add({commandName, commandFn, context = {}, args, stackTrace, namespace, options = {}, deferred, isES6Async, rejectPromise}) {
     const {compatMode} = this;
     const parentContext = this.currentNode.context;
 
@@ -53,7 +53,7 @@ class CommandQueue extends EventEmitter {
 
     const initialChildNode = this.shouldStartQueue();
 
-    if (context.module.autoInvoke) {
+    if (context.module && context.module.autoInvoke) {
       return node;
     }
     

--- a/lib/core/queue.js
+++ b/lib/core/queue.js
@@ -53,6 +53,10 @@ class CommandQueue extends EventEmitter {
 
     const initialChildNode = this.shouldStartQueue();
 
+    if (context.module.autoInvoke) {
+      return node;
+    }
+    
     this.tree.addNode(node);
 
     if (this.currentNode.done || !this.currentNode.started || initialChildNode) {

--- a/test/apidemos/custom-commands/testUsingAutoInvokeCommand.js
+++ b/test/apidemos/custom-commands/testUsingAutoInvokeCommand.js
@@ -1,0 +1,11 @@
+describe('Test Using ES6 Async Custom Commands', function() {
+  before(browser => {
+    browser
+      .url('http://localhost');
+  });
+
+  it('sampleTest', browser => {
+    browser.customCommandInvoke();
+    browser.end();
+  });
+});

--- a/test/extra/commands/autoInvoke/customCommandInvoke.js
+++ b/test/extra/commands/autoInvoke/customCommandInvoke.js
@@ -1,0 +1,9 @@
+module.exports = class CustomCommandInvoke {
+  command() {
+    return this.api.perform(function() {
+      this.globals.count++;
+    });
+  }
+};
+
+module.exports.autoInvoke = true;

--- a/test/src/apidemos/custom-commands/testCustomCommandAutoInvoke.js
+++ b/test/src/apidemos/custom-commands/testCustomCommandAutoInvoke.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const assert = require('assert');
+const MockServer = require('../../../lib/mockserver.js');
+const Mocks = require('../../../lib/command-mocks.js');
+const common = require('../../../common.js');
+const {settings} = common;
+const NightwatchClient = common.require('index.js');
+
+describe('custom commands with auto invoke', function() {
+  beforeEach(function(done) {
+    this.server = MockServer.init();
+    this.server.on('listening', () => {
+      done();
+    });
+  });
+
+  afterEach(function(done) {
+    this.server.close(function() {
+      done();
+    });
+  });
+
+  it('custom find elements es6 async', function() {
+    const testsPath = path.join(__dirname, '../../../apidemos/custom-commands/testUsingAutoInvokeCommand.js');
+    Mocks.createNewW3CSession({
+      testName: 'Test Using ES6 Async Custom Commands'
+    });
+
+    const globals = {
+      waitForConditionPollInterval: 50,
+      waitForConditionTimeout: 120,
+      retryAssertionTimeout: 1000,
+      count: 0,
+
+      reporter(results) {
+        
+        if (results.lastError) {
+          throw results.lastError;
+        }
+        assert.strictEqual(this.count, 1);
+      }
+    };
+
+    return NightwatchClient.runTests(testsPath, settings({
+      output: true,
+      silent: false,
+      selenium_host: null,
+      custom_commands_path: [path.join(__dirname, '../../../extra/commands/autoInvoke')],
+      globals
+    }));
+  });
+
+});


### PR DESCRIPTION
## changes
- avoid push command node marked with `autoInvoke` to command Queue

## Impact
- fixes #3652 