### PR TITLE
Add some tests for new element api.

### DIFF
--- a/test/lib/mocks/mocks-w3c.yaml
+++ b/test/lib/mocks/mocks-w3c.yaml
@@ -174,3 +174,45 @@ mocks:
     value: 
     - element-6066-11e4-a52e-4f735466cecf: 5cc459b8-36a8-3042-8b4a-258883ea642b
     - element-6066-11e4-a52e-4f735466cecf: 3783b042-7001-0740-a2c0-afdaac732e9f
+
+- url: '/session/13521-10219-202/elements'
+  postdata:
+    using: 'css selector'
+    value: 'html'
+  response:
+    value:
+    - element-6066-11e4-a52e-4f735466cecf: '00'
+
+- url: '/session/13521-10219-202/element/00/elements'
+  postdata:
+    using: 'css selector'
+    value: '#signupSection'
+  response:
+    value:
+    - element-6066-11e4-a52e-4f735466cecf: '0'
+
+- url: '/session/13521-10219-202/elements'
+  postdata:
+    using: 'css selector'
+    value: '#signupSection'
+  response:
+    value:
+    - element-6066-11e4-a52e-4f735466cecf: '0'
+
+- url: '/session/13521-10219-202/element/0/elements'
+  postdata:
+    using: 'css selector'
+    value: '#helpBtn'
+  response:
+    value:
+    - element-6066-11e4-a52e-4f735466cecf: '1'
+
+- url: '/session/13521-10219-202/element/0/elements'
+  postdata:
+    using: 'css selector'
+    value: '.btn'
+  response:
+    value:
+    - element-6066-11e4-a52e-4f735466cecf: '1'
+    - element-6066-11e4-a52e-4f735466cecf: '2'
+    - element-6066-11e4-a52e-4f735466cecf: '3'

--- a/test/src/api/commands/web-element/commands/testClear.js
+++ b/test/src/api/commands/web-element/commands/testClear.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().clear() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().clear()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/clear',
+      method: 'POST',
+      response: JSON.stringify({
+        value: null
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').clear();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+  });
+
+  it('test .element().find().clear()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/1/clear',
+      method: 'POST',
+      response: JSON.stringify({
+        value: null
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').clear();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '1');
+  });
+
+  it('test .element.find().clear()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/clear',
+      method: 'POST',
+      response: JSON.stringify({
+        value: null
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').clear();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testClick.js
+++ b/test/src/api/commands/web-element/commands/testClick.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().click() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().click()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/click',
+      method: 'POST',
+      response: JSON.stringify({
+        value: null
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').click();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+  });
+
+  it('test .element().find().click()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/1/click',
+      method: 'POST',
+      response: JSON.stringify({
+        value: null
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').click();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '1');
+  });
+
+  it('test .element.find().click()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/click',
+      method: 'POST',
+      response: JSON.stringify({
+        value: null
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').click();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testClickAndHold.js
+++ b/test/src/api/commands/web-element/commands/testClickAndHold.js
@@ -1,0 +1,89 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().clickAndHold() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().clickAndHold()', async function() {
+    let pressAndHoldArgs;
+    this.client.transport.Actions.session.pressAndHold = function(args) {
+      pressAndHoldArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element('#signupSection').clickAndHold();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+
+    const webElementArg = await pressAndHoldArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '0');
+  });
+
+  it('test .element().find().clickAndHold()', async function() {
+    let pressAndHoldArgs;
+    this.client.transport.Actions.session.pressAndHold = function(args) {
+      pressAndHoldArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').clickAndHold();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '1');
+
+    const webElementArg = await pressAndHoldArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '1');
+  });
+
+  it('test .element.find().clickAndHold()', async function() {
+    let pressAndHoldArgs;
+    this.client.transport.Actions.session.pressAndHold = function(args) {
+      pressAndHoldArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element.find('#signupSection').clickAndHold();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+
+    const webElementArg = await pressAndHoldArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '0');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testDoubleClick.js
+++ b/test/src/api/commands/web-element/commands/testDoubleClick.js
@@ -1,0 +1,89 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().doubleClick() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().doubleClick()', async function() {
+    let doubleClickArgs;
+    this.client.transport.Actions.session.doubleClick = function(args) {
+      doubleClickArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element('#signupSection').doubleClick();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+
+    const webElementArg = await doubleClickArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '0');
+  });
+
+  it('test .element().find().doubleClick()', async function() {
+    let doubleClickArgs;
+    this.client.transport.Actions.session.doubleClick = function(args) {
+      doubleClickArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').doubleClick();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '1');
+
+    const webElementArg = await doubleClickArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '1');
+  });
+
+  it('test .element.find().doubleClick()', async function() {
+    let doubleClickArgs;
+    this.client.transport.Actions.session.doubleClick = function(args) {
+      doubleClickArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element.find('#signupSection').doubleClick();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+
+    const webElementArg = await doubleClickArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '0');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testDragAndDrop.js
+++ b/test/src/api/commands/web-element/commands/testDragAndDrop.js
@@ -1,0 +1,148 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().dragAndDrop(WebElement) command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().dragAndDrop()', async function() {
+    let dragElementArgs;
+    this.client.transport.Actions.session.dragElement = function(args) {
+      dragElementArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const webLoginWebElement = await this.client.api.element('#weblogin');
+    const resultPromise = this.client.api.element('#signupSection').dragAndDrop(webLoginWebElement);
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+
+    const webElementArg = await dragElementArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '0');
+    assert.strictEqual(dragElementArgs.args[1], webLoginWebElement);
+  });
+
+  it('test .element().dragAndDrop(elementId)', async function() {
+    let dragElementArgs;
+    this.client.transport.Actions.session.dragElement = function(args) {
+      dragElementArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const webLoginElementId = await this.client.api.element('#weblogin').getId();
+    const resultPromise = this.client.api.element('#signupSection').dragAndDrop(webLoginElementId);
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+
+    const webElementArg = await dragElementArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '0');
+    assert.strictEqual(dragElementArgs.args[1], webLoginElementId);
+  });
+
+  it('test .element().dragAndDrop({x, y})', async function() {
+    let dragElementArgs;
+    this.client.transport.Actions.session.dragElement = function(args) {
+      dragElementArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element('#signupSection').dragAndDrop({x: 100, y: 200});
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+
+    const webElementArg = await dragElementArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '0');
+    assert.deepStrictEqual(dragElementArgs.args[1], {x: 100, y: 200});
+  });
+
+  it('test .element().find().dragAndDrop(WebElement)', async function() {
+    let dragElementArgs;
+    this.client.transport.Actions.session.dragElement = function(args) {
+      dragElementArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const webLoginWebElement = await this.client.api.element('#weblogin');
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').dragAndDrop(webLoginWebElement);
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '1');
+
+    const webElementArg = await dragElementArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '1');
+    assert.strictEqual(dragElementArgs.args[1], webLoginWebElement);
+  });
+
+  it('test .element.find().dragAndDrop()', async function() {
+    let dragElementArgs;
+    this.client.transport.Actions.session.dragElement = function(args) {
+      dragElementArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const webLoginWebElement = await this.client.api.element('#weblogin');
+    const resultPromise = this.client.api.element.find('#signupSection').dragAndDrop(webLoginWebElement);
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+
+    const webElementArg = await dragElementArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '0');
+    assert.strictEqual(dragElementArgs.args[1], webLoginWebElement);
+  });
+});

--- a/test/src/api/commands/web-element/commands/testElement.js
+++ b/test/src/api/commands/web-element/commands/testElement.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('.element() commands', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element()', async function() {
+    const signupElement = this.client.api.element('#signupSection');
+    assert.strictEqual(signupElement instanceof Element, true);
+    assert.strictEqual(await signupElement.getId(), '0');
+    assert.strictEqual(typeof signupElement.find, 'function');
+    assert.strictEqual(typeof signupElement.findByRole, 'function');
+    assert.strictEqual(typeof signupElement.assert, 'object');
+
+    const signupWebElement = await signupElement;
+    assert.strictEqual(signupWebElement instanceof WebElement, true);
+    assert.strictEqual(await signupWebElement.getId(), '0');
+    assert.strictEqual(typeof signupWebElement.find, 'undefined');
+    assert.strictEqual(typeof signupWebElement.assert, 'undefined');
+    assert.strictEqual(typeof signupWebElement.click, 'function');
+    assert.strictEqual(typeof signupWebElement.sendKeys, 'function');
+    assert.strictEqual(typeof signupWebElement.getDriver, 'function');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testElement.js
+++ b/test/src/api/commands/web-element/commands/testElement.js
@@ -18,7 +18,7 @@ describe('.element() commands', function () {
     assert.strictEqual(await signupElement.getId(), '0');
     assert.strictEqual(typeof signupElement.find, 'function');
     assert.strictEqual(typeof signupElement.findByRole, 'function');
-    // assert.strictEqual(typeof signupElement.assert, 'object');
+    assert.strictEqual(typeof signupElement.assert, 'object');
 
     const signupWebElement = await signupElement;
     assert.strictEqual(signupWebElement instanceof WebElement, true);

--- a/test/src/api/commands/web-element/commands/testElement.js
+++ b/test/src/api/commands/web-element/commands/testElement.js
@@ -18,7 +18,7 @@ describe('.element() commands', function () {
     assert.strictEqual(await signupElement.getId(), '0');
     assert.strictEqual(typeof signupElement.find, 'function');
     assert.strictEqual(typeof signupElement.findByRole, 'function');
-    assert.strictEqual(typeof signupElement.assert, 'object');
+    // assert.strictEqual(typeof signupElement.assert, 'object');
 
     const signupWebElement = await signupElement;
     assert.strictEqual(signupWebElement instanceof WebElement, true);

--- a/test/src/api/commands/web-element/commands/testFind.js
+++ b/test/src/api/commands/web-element/commands/testFind.js
@@ -4,7 +4,7 @@ const MockServer  = require('../../../../../lib/mockserver.js');
 const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
 const Element = require('../../../../../../lib/element/index.js');
 
-describe('.findByText() commands', function () {
+describe('element().find() commands', function () {
   before(function (done) {
     CommandGlobals.beforeEach.call(this, done);
   });

--- a/test/src/api/commands/web-element/commands/testFind.js
+++ b/test/src/api/commands/web-element/commands/testFind.js
@@ -21,8 +21,6 @@ describe('.findByText() commands', function () {
     const helpBtnWebElement = await helpBtnElement;
     assert.strictEqual(helpBtnWebElement instanceof WebElement, true);
     assert.strictEqual(await helpBtnWebElement.getId(), '1');
-
-    await this.client.start();
   });
 
   it('test .element().get()', async function() {
@@ -33,8 +31,6 @@ describe('.findByText() commands', function () {
     const helpBtnWebElement = await helpBtnElement;
     assert.strictEqual(helpBtnWebElement instanceof WebElement, true);
     assert.strictEqual(await helpBtnWebElement.getId(), '1');
-
-    await this.client.start();
   });
 
   it('test .element().findElement()', async function() {
@@ -45,8 +41,6 @@ describe('.findByText() commands', function () {
     const helpBtnWebElement = await helpBtnElement;
     assert.strictEqual(helpBtnWebElement instanceof WebElement, true);
     assert.strictEqual(await helpBtnWebElement.getId(), '1');
-
-    await this.client.start();
   });
 
   it('test .element().find(selectorObject)', async function() {
@@ -70,7 +64,15 @@ describe('.findByText() commands', function () {
     const helpBtnWebElement = await helpBtnElement;
     assert.strictEqual(helpBtnWebElement instanceof WebElement, true);
     assert.strictEqual(await helpBtnWebElement.getId(), '2');
+  });
 
-    await this.client.start();
+  it('test .element.find()', async function() {
+    const signupElement = this.client.api.element.find('#signupSection');
+    assert.strictEqual(signupElement instanceof Element, true);
+    assert.strictEqual(await signupElement.getId(), '0');
+
+    const signupWebElement = await signupElement;
+    assert.strictEqual(signupWebElement instanceof WebElement, true);
+    assert.strictEqual(await signupWebElement.getId(), '0');
   });
 });

--- a/test/src/api/commands/web-element/commands/testFind.js
+++ b/test/src/api/commands/web-element/commands/testFind.js
@@ -1,0 +1,76 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('.findByText() commands', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().find()', async function() {
+    const helpBtnElement = this.client.api.element('#signupSection').find('#helpBtn');
+    assert.strictEqual(helpBtnElement instanceof Element, true);
+    assert.strictEqual(await helpBtnElement.getId(), '1');
+
+    const helpBtnWebElement = await helpBtnElement;
+    assert.strictEqual(helpBtnWebElement instanceof WebElement, true);
+    assert.strictEqual(await helpBtnWebElement.getId(), '1');
+
+    await this.client.start();
+  });
+
+  it('test .element().get()', async function() {
+    const helpBtnElement = this.client.api.element('#signupSection').get('#helpBtn');
+    assert.strictEqual(helpBtnElement instanceof Element, true);
+    assert.strictEqual(await helpBtnElement.getId(), '1');
+
+    const helpBtnWebElement = await helpBtnElement;
+    assert.strictEqual(helpBtnWebElement instanceof WebElement, true);
+    assert.strictEqual(await helpBtnWebElement.getId(), '1');
+
+    await this.client.start();
+  });
+
+  it('test .element().findElement()', async function() {
+    const helpBtnElement = this.client.api.element('#signupSection').findElement('#helpBtn');
+    assert.strictEqual(helpBtnElement instanceof Element, true);
+    assert.strictEqual(await helpBtnElement.getId(), '1');
+
+    const helpBtnWebElement = await helpBtnElement;
+    assert.strictEqual(helpBtnWebElement instanceof WebElement, true);
+    assert.strictEqual(await helpBtnWebElement.getId(), '1');
+
+    await this.client.start();
+  });
+
+  it('test .element().find(selectorObject)', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'xpath',
+        value: '//*[id="helpBtn"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [{'element-6066-11e4-a52e-4f735466cecf': '2'}]
+      })
+    }, true);
+
+    const helpBtnElement = this.client.api.element('#signupSection').find({
+      locateStrategy: 'xpath', selector: '//*[id="helpBtn"]'});
+    assert.strictEqual(helpBtnElement instanceof Element, true);
+    assert.strictEqual(await helpBtnElement.getId(), '2');
+
+    const helpBtnWebElement = await helpBtnElement;
+    assert.strictEqual(helpBtnWebElement instanceof WebElement, true);
+    assert.strictEqual(await helpBtnWebElement.getId(), '2');
+
+    await this.client.start();
+  });
+});

--- a/test/src/api/commands/web-element/commands/testFindAll.js
+++ b/test/src/api/commands/web-element/commands/testFindAll.js
@@ -1,0 +1,175 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().findAll() commands', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().findAll()', async function() {
+    const btnElements = this.client.api.element('#signupSection').findAll('.btn');
+    assert.strictEqual(btnElements instanceof Element, false);
+    assert.strictEqual(typeof btnElements.find, 'undefined');
+    assert.strictEqual(typeof btnElements.click, 'undefined');
+
+    assert.strictEqual(btnElements instanceof Promise, false);
+    assert.strictEqual(typeof btnElements.then, 'function');
+    assert.strictEqual(typeof btnElements.nth, 'function');
+    assert.strictEqual(typeof btnElements.count, 'function');
+
+    const btnWEbElements = await btnElements;
+    assert.strictEqual(btnWEbElements.length, 3);
+    assert.strictEqual(btnWEbElements[0] instanceof WebElement, true);
+    assert.strictEqual(await btnWEbElements[0].getId(), '1');
+  });
+
+  it('test .element().getAll()', async function() {
+    const btnElements = this.client.api.element('#signupSection').getAll('.btn');
+    assert.strictEqual(btnElements instanceof Element, false);
+    assert.strictEqual(typeof btnElements.find, 'undefined');
+    assert.strictEqual(typeof btnElements.click, 'undefined');
+
+    assert.strictEqual(btnElements instanceof Promise, false);
+    assert.strictEqual(typeof btnElements.then, 'function');
+    assert.strictEqual(typeof btnElements.nth, 'function');
+    assert.strictEqual(typeof btnElements.count, 'function');
+
+    const btnWEbElements = await btnElements;
+    assert.strictEqual(btnWEbElements.length, 3);
+    assert.strictEqual(btnWEbElements[0] instanceof WebElement, true);
+    assert.strictEqual(await btnWEbElements[0].getId(), '1');
+  });
+
+  it('test .element().findElements()', async function() {
+    const btnElements = this.client.api.element('#signupSection').findElements('.btn');
+    assert.strictEqual(btnElements instanceof Element, false);
+    assert.strictEqual(typeof btnElements.find, 'undefined');
+    assert.strictEqual(typeof btnElements.click, 'undefined');
+
+    assert.strictEqual(btnElements instanceof Promise, false);
+    assert.strictEqual(typeof btnElements.then, 'function');
+    assert.strictEqual(typeof btnElements.nth, 'function');
+    assert.strictEqual(typeof btnElements.count, 'function');
+
+    const btnWEbElements = await btnElements;
+    assert.strictEqual(btnWEbElements.length, 3);
+    assert.strictEqual(btnWEbElements[0] instanceof WebElement, true);
+    assert.strictEqual(await btnWEbElements[0].getId(), '1');
+  });
+
+  it('test .element().findAll(selectorObject)', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'xpath',
+        value: '//*[id="helpBtn"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '2'},
+          {'element-6066-11e4-a52e-4f735466cecf': '3'}
+        ]
+      })
+    }, true);
+
+    const helpBtnElements = this.client.api.element('#signupSection').findAll({
+      locateStrategy: 'xpath', selector: '//*[id="helpBtn"]'});
+    assert.strictEqual(helpBtnElements instanceof Element, false);
+    assert.strictEqual(typeof helpBtnElements.find, 'undefined');
+    assert.strictEqual(typeof helpBtnElements.click, 'undefined');
+
+    assert.strictEqual(helpBtnElements instanceof Promise, false);
+    assert.strictEqual(typeof helpBtnElements.then, 'function');
+    assert.strictEqual(typeof helpBtnElements.nth, 'function');
+    assert.strictEqual(typeof helpBtnElements.count, 'function');
+
+    const btnWEbElements = await helpBtnElements;
+    assert.strictEqual(btnWEbElements.length, 2);
+    assert.strictEqual(btnWEbElements[0] instanceof WebElement, true);
+    assert.strictEqual(await btnWEbElements[0].getId(), '2');
+  });
+
+  it('test .element.findAll()', async function() {
+    const webLoginElements = this.client.api.element.findAll('#weblogin');
+    assert.strictEqual(webLoginElements instanceof Element, false);
+    assert.strictEqual(typeof webLoginElements.find, 'undefined');
+    assert.strictEqual(typeof webLoginElements.click, 'undefined');
+
+    assert.strictEqual(webLoginElements instanceof Promise, false);
+    assert.strictEqual(typeof webLoginElements.then, 'function');
+    assert.strictEqual(typeof webLoginElements.nth, 'function');
+    assert.strictEqual(typeof webLoginElements.count, 'function');
+
+    const btnWEbElements = await webLoginElements;
+    assert.strictEqual(btnWEbElements.length, 2);
+    assert.strictEqual(btnWEbElements[0] instanceof WebElement, true);
+    assert.strictEqual(await btnWEbElements[0].getId(), '5cc459b8-36a8-3042-8b4a-258883ea642b');
+  });
+
+  it('test .element().findAll().count()', async function() {
+    const resultPromise = this.client.api.element('#signupSection').findAll('.btn').count();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.value, 'object');
+    assert.strictEqual(typeof resultPromise.assert, 'object');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 3);
+
+    assert.strictEqual(await resultPromise.value, 3);
+    assert.strictEqual(await resultPromise.assert.equals(3), 3);
+    assert.strictEqual(await resultPromise.assert.not.equals(4), 3);
+  });
+
+  it('test .element().findAll().nth()', async function() {
+    MockServer
+      .addMock({
+        url: '/session/13521-10219-202/element/2/elements',
+        postdata: {
+          using: 'css selector',
+          value: 'span'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [
+            {'element-6066-11e4-a52e-4f735466cecf': '9'}
+          ]
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/2/property/role',
+        method: 'GET',
+        response: JSON.stringify({
+          value: 'button'
+        })
+      }, true);
+
+    const btnElement = this.client.api.element('#signupSection').findAll('.btn').nth(1);
+    assert.strictEqual(btnElement instanceof Element, false);
+    assert.strictEqual(btnElement instanceof Promise, true);
+    assert.strictEqual(typeof btnElement.find, 'function');
+    assert.strictEqual(typeof btnElement.getValue, 'function');
+
+    const btnWebElement = await btnElement;
+    assert.strictEqual(btnWebElement instanceof WebElement, true);
+    assert.strictEqual(await btnWebElement.getId(), '2');
+
+    const btnSpanElement = btnElement.find('span');
+    assert.strictEqual(await btnSpanElement.getId(), '9');
+
+    const btnElementProperty = await btnElement.getProperty('role');
+    assert.strictEqual(btnElementProperty, 'button');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testFindAllByAltText.js
+++ b/test/src/api/commands/web-element/commands/testFindAllByAltText.js
@@ -1,0 +1,127 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().findAllByAltText() commands', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().findAllByAltText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'css selector',
+        value: '[alt="Email"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '8'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'},
+          {'element-6066-11e4-a52e-4f735466cecf': '3'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').findAllByAltText('Email');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(typeof resultPromise.click, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.nth, 'function');
+    assert.strictEqual(typeof resultPromise.count, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0] instanceof WebElement, true);
+    assert.strictEqual(await result[0].getId(), '8');
+
+    const resultCount = await resultPromise.count();
+    assert.strictEqual(resultCount, 3);
+
+    const secondResultPromise = resultPromise.nth(1);
+    assert.strictEqual(secondResultPromise instanceof Element, false);
+    assert.strictEqual(secondResultPromise instanceof Promise, true);
+    assert.strictEqual(typeof secondResultPromise.find, 'function');
+    assert.strictEqual(typeof secondResultPromise.getValue, 'function');
+
+    const secondResult = await secondResultPromise;
+    assert.strictEqual(secondResult instanceof WebElement, true);
+    assert.strictEqual(await secondResult.getId(), '2');
+  });
+
+  it('test .element().getAllByAltText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'css selector',
+        value: '[alt*="Email"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '8'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'},
+          {'element-6066-11e4-a52e-4f735466cecf': '3'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getAllByAltText('Email', {exact: false});
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(typeof resultPromise.click, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.nth, 'function');
+    assert.strictEqual(typeof resultPromise.count, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0] instanceof WebElement, true);
+    assert.strictEqual(await result[0].getId(), '8');
+  });
+
+  it('test .element.findAllByAltText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/elements',
+      postdata: {
+        using: 'css selector',
+        value: '[alt="Email"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '8'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'},
+          {'element-6066-11e4-a52e-4f735466cecf': '3'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.findAllByAltText('Email');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(typeof resultPromise.click, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.nth, 'function');
+    assert.strictEqual(typeof resultPromise.count, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0] instanceof WebElement, true);
+    assert.strictEqual(await result[0].getId(), '8');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testFindAllByPlaceholderText.js
+++ b/test/src/api/commands/web-element/commands/testFindAllByPlaceholderText.js
@@ -1,0 +1,127 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().findAllByPlaceholderText() commands', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().findAllByPlaceholderText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'css selector',
+        value: '[placeholder="Email"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '8'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'},
+          {'element-6066-11e4-a52e-4f735466cecf': '3'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').findAllByPlaceholderText('Email');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(typeof resultPromise.click, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.nth, 'function');
+    assert.strictEqual(typeof resultPromise.count, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0] instanceof WebElement, true);
+    assert.strictEqual(await result[0].getId(), '8');
+
+    const resultCount = await resultPromise.count();
+    assert.strictEqual(resultCount, 3);
+
+    const secondResultPromise = resultPromise.nth(1);
+    assert.strictEqual(secondResultPromise instanceof Element, false);
+    assert.strictEqual(secondResultPromise instanceof Promise, true);
+    assert.strictEqual(typeof secondResultPromise.find, 'function');
+    assert.strictEqual(typeof secondResultPromise.getValue, 'function');
+
+    const secondResult = await secondResultPromise;
+    assert.strictEqual(secondResult instanceof WebElement, true);
+    assert.strictEqual(await secondResult.getId(), '2');
+  });
+
+  it('test .element().getAllByPlaceholderText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'css selector',
+        value: '[placeholder*="Email"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '8'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'},
+          {'element-6066-11e4-a52e-4f735466cecf': '3'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getAllByPlaceholderText('Email', {exact: false});
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(typeof resultPromise.click, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.nth, 'function');
+    assert.strictEqual(typeof resultPromise.count, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0] instanceof WebElement, true);
+    assert.strictEqual(await result[0].getId(), '8');
+  });
+
+  it('test .element.findAllByPlaceholderText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/elements',
+      postdata: {
+        using: 'css selector',
+        value: '[placeholder="Email"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '8'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'},
+          {'element-6066-11e4-a52e-4f735466cecf': '3'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.findAllByPlaceholderText('Email');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(typeof resultPromise.click, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.nth, 'function');
+    assert.strictEqual(typeof resultPromise.count, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0] instanceof WebElement, true);
+    assert.strictEqual(await result[0].getId(), '8');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testFindAllByRole.js
+++ b/test/src/api/commands/web-element/commands/testFindAllByRole.js
@@ -1,0 +1,127 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().findAllByRole() commands', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().findAllByRole()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'css selector',
+        value: '*[role~="button"],input,summary,button'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '8'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'},
+          {'element-6066-11e4-a52e-4f735466cecf': '3'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').findAllByRole('button');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(typeof resultPromise.click, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.nth, 'function');
+    assert.strictEqual(typeof resultPromise.count, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0] instanceof WebElement, true);
+    assert.strictEqual(await result[0].getId(), '8');
+
+    const resultCount = await resultPromise.count();
+    assert.strictEqual(resultCount, 3);
+
+    const secondResultPromise = resultPromise.nth(1);
+    assert.strictEqual(secondResultPromise instanceof Element, false);
+    assert.strictEqual(secondResultPromise instanceof Promise, true);
+    assert.strictEqual(typeof secondResultPromise.find, 'function');
+    assert.strictEqual(typeof secondResultPromise.getValue, 'function');
+
+    const secondResult = await secondResultPromise;
+    assert.strictEqual(secondResult instanceof WebElement, true);
+    assert.strictEqual(await secondResult.getId(), '2');
+  });
+
+  it('test .element().getAllByRole()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'css selector',
+        value: '*[role~="button"],input,summary,button'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '8'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'},
+          {'element-6066-11e4-a52e-4f735466cecf': '3'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getAllByRole('button');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(typeof resultPromise.click, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.nth, 'function');
+    assert.strictEqual(typeof resultPromise.count, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0] instanceof WebElement, true);
+    assert.strictEqual(await result[0].getId(), '8');
+  });
+
+  it('test .element.findAllByRole()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/elements',
+      postdata: {
+        using: 'css selector',
+        value: '*[role~="button"],input,summary,button'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '8'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'},
+          {'element-6066-11e4-a52e-4f735466cecf': '3'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.findAllByRole('button');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(typeof resultPromise.click, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.nth, 'function');
+    assert.strictEqual(typeof resultPromise.count, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0] instanceof WebElement, true);
+    assert.strictEqual(await result[0].getId(), '8');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testFindAllByText.js
+++ b/test/src/api/commands/web-element/commands/testFindAllByText.js
@@ -1,0 +1,127 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().findAllByText() commands', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().findAllByText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'xpath',
+        value: '//*[text()="Email"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '8'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'},
+          {'element-6066-11e4-a52e-4f735466cecf': '3'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').findAllByText('Email');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(typeof resultPromise.click, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.nth, 'function');
+    assert.strictEqual(typeof resultPromise.count, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0] instanceof WebElement, true);
+    assert.strictEqual(await result[0].getId(), '8');
+
+    const resultCount = await resultPromise.count();
+    assert.strictEqual(resultCount, 3);
+
+    const secondResultPromise = resultPromise.nth(1);
+    assert.strictEqual(secondResultPromise instanceof Element, false);
+    assert.strictEqual(secondResultPromise instanceof Promise, true);
+    assert.strictEqual(typeof secondResultPromise.find, 'function');
+    assert.strictEqual(typeof secondResultPromise.getValue, 'function');
+
+    const secondResult = await secondResultPromise;
+    assert.strictEqual(secondResult instanceof WebElement, true);
+    assert.strictEqual(await secondResult.getId(), '2');
+  });
+
+  it('test .element().getAllByText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'xpath',
+        value: '//*[contains(text(),"Email")]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '8'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'},
+          {'element-6066-11e4-a52e-4f735466cecf': '3'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getAllByText('Email', {exact: false});
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(typeof resultPromise.click, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.nth, 'function');
+    assert.strictEqual(typeof resultPromise.count, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0] instanceof WebElement, true);
+    assert.strictEqual(await result[0].getId(), '8');
+  });
+
+  it('test .element.findAllByText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/elements',
+      postdata: {
+        using: 'xpath',
+        value: '//*[text()="Email"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '8'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'},
+          {'element-6066-11e4-a52e-4f735466cecf': '3'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.findAllByText('Email');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(typeof resultPromise.click, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.nth, 'function');
+    assert.strictEqual(typeof resultPromise.count, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result[0] instanceof WebElement, true);
+    assert.strictEqual(await result[0].getId(), '8');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testFindByAltText.js
+++ b/test/src/api/commands/web-element/commands/testFindByAltText.js
@@ -57,7 +57,6 @@ describe('.findByAltText() commands', function () {
     }, true, true);
 
     const submitBtnElement = this.client.api.element('#signupSection').findByAltText('Email', {exact: false});
-    console.log(submitBtnElement);
     assert.strictEqual(submitBtnElement instanceof Element, true);
     assert.strictEqual(await submitBtnElement.getId(), '8');
     const submitBtnWebElement = await submitBtnElement;

--- a/test/src/api/commands/web-element/commands/testFindByAltText.js
+++ b/test/src/api/commands/web-element/commands/testFindByAltText.js
@@ -1,0 +1,76 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('.findByAltText() commands', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().findByAltText(exact)/getByAltText(exact)', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'css selector',
+        value: '[alt="Email"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [{'element-6066-11e4-a52e-4f735466cecf': '7'}]
+      })
+    }, true, true);
+
+    const submitBtnElement = this.client.api.element('#signupSection').findByAltText('Email');
+    assert.strictEqual(submitBtnElement instanceof Element, true);
+    assert.strictEqual(await submitBtnElement.getId(), '7');
+    const submitBtnWebElement = await submitBtnElement;
+    assert.strictEqual(submitBtnWebElement instanceof WebElement, true);
+    assert.strictEqual(await submitBtnWebElement.getId(), '7');
+
+    const submitBtnElement2 = this.client.api.element('#signupSection').getByAltText('Email');
+    assert.strictEqual(submitBtnElement2 instanceof Element, true);
+    assert.strictEqual(await submitBtnElement2.getId(), '7');
+    const submitBtnWebElement2 = await submitBtnElement2;
+    assert.strictEqual(submitBtnWebElement2 instanceof WebElement, true);
+    assert.strictEqual(await submitBtnWebElement2.getId(), '7');
+
+    await this.client.start();
+  });
+
+  it('test .element().findByAltText()/getByAltText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'css selector',
+        value: '[alt*="Email"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [{'element-6066-11e4-a52e-4f735466cecf': '8'}]
+      })
+    }, true, true);
+
+    const submitBtnElement = this.client.api.element('#signupSection').findByAltText('Email', {exact: false});
+    console.log(submitBtnElement);
+    assert.strictEqual(submitBtnElement instanceof Element, true);
+    assert.strictEqual(await submitBtnElement.getId(), '8');
+    const submitBtnWebElement = await submitBtnElement;
+    assert.strictEqual(submitBtnWebElement instanceof WebElement, true);
+    assert.strictEqual(await submitBtnWebElement.getId(), '8');
+
+    const submitBtnElement2 = this.client.api.element('#signupSection').getByAltText('Email', {exact: false});
+    assert.strictEqual(submitBtnElement2 instanceof Element, true);
+    assert.strictEqual(await submitBtnElement2.getId(), '8');
+    const submitBtnWebElement2 = await submitBtnElement2;
+    assert.strictEqual(submitBtnWebElement2 instanceof WebElement, true);
+    assert.strictEqual(await submitBtnWebElement2.getId(), '8');
+
+    await this.client.start();
+  });
+});

--- a/test/src/api/commands/web-element/commands/testFindByLabelText.js
+++ b/test/src/api/commands/web-element/commands/testFindByLabelText.js
@@ -1,0 +1,304 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('.findByLabelText() commands', function () {
+  this.timeout(10000000);
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .findByLabelText() (findByForId)', async function() {
+    MockServer
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'xpath',
+          value: '//label[text()="Email"]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '1'}]
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/execute/sync',
+        method: 'POST',
+        response: JSON.stringify({
+          value: 'email'
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'css selector',
+          value: 'input[id="email"]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '2'}]
+        })
+      }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').findByLabelText('Email');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+    assert.strictEqual(typeof resultPromise.assert, 'object');
+    assert.strictEqual(await resultPromise.getId(), '2');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '2');
+  });
+
+  it('test .getByLabelText(exact=false) (findByForId)', async function() {
+    MockServer
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'xpath',
+          value: '//label[contains(text(),"Email")]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '1'}]
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/execute/sync',
+        method: 'POST',
+        response: JSON.stringify({
+          value: 'email'
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'css selector',
+          value: 'input[id="email"]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '2'}]
+        })
+      }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getByLabelText('Email', {exact: false});
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+    assert.strictEqual(typeof resultPromise.assert, 'object');
+    assert.strictEqual(await resultPromise.getId(), '2');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '2');
+  });
+
+  it('test .findByLabelText() (findByAriaLabelled)', async function() {
+    MockServer
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'xpath',
+          value: '//label[text()="Email"]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '1'}]
+        })
+      }, true, true)
+      .addMock({
+        url: '/session/13521-10219-202/execute/sync',
+        method: 'POST',
+        response: JSON.stringify({
+          value: null
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/execute/sync',
+        method: 'POST',
+        response: JSON.stringify({
+          value: 'email-label'
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'css selector',
+          value: 'input[aria-labelledby="email-label"]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '2'}]
+        })
+      }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').findByLabelText('Email');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+    assert.strictEqual(typeof resultPromise.assert, 'object');
+    assert.strictEqual(await resultPromise.getId(), '2');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '2');
+  });
+  
+  it('test .findByLabelText() (findByDirectNesting)', async function() {
+    MockServer
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'xpath',
+          value: '//label[text()="Email"]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '1'}]
+        }),
+        times: 3
+      })
+      .addMock({
+        url: '/session/13521-10219-202/execute/sync',
+        method: 'POST',
+        response: JSON.stringify({
+          value: null
+        })
+      }, true, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/1/elements',
+        postdata: {
+          using: 'css selector',
+          value: 'input'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '2'}]
+        })
+      }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').findByLabelText('Email');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+    assert.strictEqual(typeof resultPromise.assert, 'object');
+    assert.strictEqual(await resultPromise.getId(), '2');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '2');
+  });
+
+  it('test .findByLabelText() (findByDeepNesting)', async function() {
+    MockServer
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'xpath',
+          value: '//label[text()="Email"]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: []
+        }),
+        times: 3
+      })
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'xpath',
+          value: '//label[*[text() = "Email"]]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '1'}]
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/1/elements',
+        postdata: {
+          using: 'css selector',
+          value: 'input'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '2'}]
+        })
+      }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').findByLabelText('Email');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+    assert.strictEqual(typeof resultPromise.assert, 'object');
+    assert.strictEqual(await resultPromise.getId(), '2');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '2');
+  });
+
+  it('test .findByLabelText() (aria-label)', async function() {
+    MockServer
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'xpath',
+          value: '//label[text()="Email"]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: []
+        }),
+        times: 3
+      })
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'xpath',
+          value: '//label[*[text() = "Email"]]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: []
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'css selector',
+          value: 'input[aria-label="Email"]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '2'}]
+        })
+      }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').findByLabelText('Email');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+    assert.strictEqual(typeof resultPromise.assert, 'object');
+    assert.strictEqual(await resultPromise.getId(), '2');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '2');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testFindByPlaceholderText.js
+++ b/test/src/api/commands/web-element/commands/testFindByPlaceholderText.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('.findByPlaceholderText() commands', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().findByPlaceholderText(exact)/getByPlaceholderText(exact)', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'css selector',
+        value: '[placeholder="Email"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [{'element-6066-11e4-a52e-4f735466cecf': '3'}]
+      })
+    }, true, true);
+
+    const submitBtnElement = this.client.api.element('#signupSection').findByPlaceholderText('Email');
+    assert.strictEqual(submitBtnElement instanceof Element, true);
+    assert.strictEqual(await submitBtnElement.getId(), '3');
+    const submitBtnWebElement = await submitBtnElement;
+    assert.strictEqual(submitBtnWebElement instanceof WebElement, true);
+    assert.strictEqual(await submitBtnWebElement.getId(), '3');
+
+    const submitBtnElement2 = this.client.api.element('#signupSection').getByPlaceholderText('Email');
+    assert.strictEqual(submitBtnElement2 instanceof Element, true);
+    assert.strictEqual(await submitBtnElement2.getId(), '3');
+    const submitBtnWebElement2 = await submitBtnElement2;
+    assert.strictEqual(submitBtnWebElement2 instanceof WebElement, true);
+    assert.strictEqual(await submitBtnWebElement2.getId(), '3');
+
+    await this.client.start();
+  });
+
+  it('test .element().findByPlaceholderText()/getByPlaceholderText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'css selector',
+        value: '[placeholder*="Email"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [{'element-6066-11e4-a52e-4f735466cecf': '4'}]
+      })
+    }, true, true);
+
+    const submitBtnElement = this.client.api.element('#signupSection').findByPlaceholderText('Email', {exact: false});
+    assert.strictEqual(submitBtnElement instanceof Element, true);
+    assert.strictEqual(await submitBtnElement.getId(), '4');
+    const submitBtnWebElement = await submitBtnElement;
+    assert.strictEqual(submitBtnWebElement instanceof WebElement, true);
+    assert.strictEqual(await submitBtnWebElement.getId(), '4');
+
+    const submitBtnElement2 = this.client.api.element('#signupSection').getByPlaceholderText('Email', {exact: false});
+    assert.strictEqual(submitBtnElement2 instanceof Element, true);
+    assert.strictEqual(await submitBtnElement2.getId(), '4');
+    const submitBtnWebElement2 = await submitBtnElement2;
+    assert.strictEqual(submitBtnWebElement2 instanceof WebElement, true);
+    assert.strictEqual(await submitBtnWebElement2.getId(), '4');
+
+    await this.client.start();
+  });
+});

--- a/test/src/api/commands/web-element/commands/testFindByRole.js
+++ b/test/src/api/commands/web-element/commands/testFindByRole.js
@@ -1,0 +1,99 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().findByRole() commands', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().findByRole()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'css selector',
+        value: '*[role~="button"],input,summary,button'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '9'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').findByRole('button');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+    assert.strictEqual(typeof resultPromise.assert, 'object');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
+  });
+  
+  it('test .element().getByRole()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'css selector',
+        value: '*[role~="button"],input,summary,button'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '9'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getByRole('button');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+    assert.strictEqual(typeof resultPromise.assert, 'object');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
+  });
+
+  it('test .element.findByRole()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/elements',
+      postdata: {
+        using: 'css selector',
+        value: '*[role~="button"],input,summary,button'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [
+          {'element-6066-11e4-a52e-4f735466cecf': '9'},
+          {'element-6066-11e4-a52e-4f735466cecf': '2'}
+        ]
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.findByRole('button');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+    assert.strictEqual(typeof resultPromise.assert, 'object');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testFindByText.js
+++ b/test/src/api/commands/web-element/commands/testFindByText.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('.findByText() commands', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().findByText(exact)/getByText(exact)', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'xpath',
+        value: '//*[text()="Submit"]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [{'element-6066-11e4-a52e-4f735466cecf': '5'}]
+      })
+    }, true, true);
+
+    const submitBtnElement = this.client.api.element('#signupSection').findByText('Submit');
+    assert.strictEqual(submitBtnElement instanceof Element, true);
+    assert.strictEqual(await submitBtnElement.getId(), '5');
+    const submitBtnWebElement = await submitBtnElement;
+    assert.strictEqual(submitBtnWebElement instanceof WebElement, true);
+    assert.strictEqual(await submitBtnWebElement.getId(), '5');
+
+    const submitBtnElement2 = this.client.api.element('#signupSection').getByText('Submit');
+    assert.strictEqual(submitBtnElement2 instanceof Element, true);
+    assert.strictEqual(await submitBtnElement2.getId(), '5');
+    const submitBtnWebElement2 = await submitBtnElement2;
+    assert.strictEqual(submitBtnWebElement2 instanceof WebElement, true);
+    assert.strictEqual(await submitBtnWebElement2.getId(), '5');
+
+    await this.client.start();
+  });
+
+  it('test .element().findByText()/getByText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/elements',
+      postdata: {
+        using: 'xpath',
+        value: '//*[contains(text(),"Submit")]'
+      },
+      method: 'POST',
+      response: JSON.stringify({
+        value: [{'element-6066-11e4-a52e-4f735466cecf': '6'}]
+      })
+    }, true, true);
+
+    const submitBtnElement = this.client.api.element('#signupSection').findByText('Submit', {exact: false});
+    assert.strictEqual(submitBtnElement instanceof Element, true);
+    assert.strictEqual(await submitBtnElement.getId(), '6');
+    const submitBtnWebElement = await submitBtnElement;
+    assert.strictEqual(submitBtnWebElement instanceof WebElement, true);
+    assert.strictEqual(await submitBtnWebElement.getId(), '6');
+
+    const submitBtnElement2 = this.client.api.element('#signupSection').getByText('Submit', {exact: false});
+    assert.strictEqual(submitBtnElement2 instanceof Element, true);
+    assert.strictEqual(await submitBtnElement2.getId(), '6');
+    const submitBtnWebElement2 = await submitBtnElement2;
+    assert.strictEqual(submitBtnWebElement2 instanceof WebElement, true);
+    assert.strictEqual(await submitBtnWebElement2.getId(), '6');
+
+    await this.client.start();
+  });
+});

--- a/test/src/api/commands/web-element/commands/testGetAccessibleName.js
+++ b/test/src/api/commands/web-element/commands/testGetAccessibleName.js
@@ -25,11 +25,16 @@ describe('element().getAccessibleName() command', function () {
     const resultPromise = this.client.api.element('#signupSection').getAccessibleName();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'Signup');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'Signup');
   });
 
   it('test .element().find().getAccessibleName()', async function() {
@@ -44,11 +49,16 @@ describe('element().getAccessibleName() command', function () {
     const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getAccessibleName();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'Help');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'Help');
   });
 
   it('test .element.find().getAccessibleName()', async function() {
@@ -63,10 +73,15 @@ describe('element().getAccessibleName() command', function () {
     const resultPromise = this.client.api.element.find('#signupSection').getAccessibleName();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'Signup');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'Signup');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetAccessibleName.js
+++ b/test/src/api/commands/web-element/commands/testGetAccessibleName.js
@@ -5,6 +5,7 @@ const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
 const Element = require('../../../../../../lib/element/index.js');
 
 describe('element().getAccessibleName() command', function () {
+  this.timeout(10000000);
   before(function (done) {
     CommandGlobals.beforeEach.call(this, done);
   });
@@ -28,6 +29,7 @@ describe('element().getAccessibleName() command', function () {
 
     assert.strictEqual(resultPromise instanceof Promise, false);
     assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.value, 'object');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
@@ -52,6 +54,7 @@ describe('element().getAccessibleName() command', function () {
 
     assert.strictEqual(resultPromise instanceof Promise, false);
     assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.value, 'object');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
@@ -76,6 +79,7 @@ describe('element().getAccessibleName() command', function () {
 
     assert.strictEqual(resultPromise instanceof Promise, false);
     assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.value, 'object');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
@@ -83,5 +87,31 @@ describe('element().getAccessibleName() command', function () {
 
     const resultValue = await resultPromise.value;
     assert.strictEqual(resultValue, 'Signup');
+  });
+
+  it('test .element().getAccessibleName() assert', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/computedlabel',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'Signup'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getAccessibleName();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.assert, 'object');
+
+    assert.strictEqual(await resultPromise.assert.equals('Signup'), 'Signup');
+    assert.strictEqual(await resultPromise.assert.contains('Sign'), 'Signup');
+    assert.strictEqual(await resultPromise.assert.matches(/Si[a-z]{2}up/), 'Signup');
+
+    assert.strictEqual(await resultPromise.assert.not.equals('Signupx'), 'Signup');
+    assert.strictEqual(await resultPromise.assert.not.contains('Signupx'), 'Signup');
+    assert.strictEqual(await resultPromise.assert.not.matches(/Si[a-z]{2}upx/), 'Signup');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetAccessibleName.js
+++ b/test/src/api/commands/web-element/commands/testGetAccessibleName.js
@@ -1,0 +1,69 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().getAccessibleName() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().getAccessibleName()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/computedlabel',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'Signup'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getAccessibleName();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'Signup');
+  });
+
+  it('test .element().find().getAccessibleName()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/1/computedlabel',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'Help'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getAccessibleName('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'Help');
+  });
+
+  it('test .element.find().getAccessibleName()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/computedlabel',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'Signup'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').getAccessibleName('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'Signup');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testGetAriaRole.js
+++ b/test/src/api/commands/web-element/commands/testGetAriaRole.js
@@ -25,11 +25,16 @@ describe('element().getAriaRole() command', function () {
     const resultPromise = this.client.api.element('#signupSection').getAriaRole();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'signupSection');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'signupSection');
   });
 
   it('test .element().find().getAriaRole()', async function() {
@@ -44,11 +49,16 @@ describe('element().getAriaRole() command', function () {
     const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getAriaRole();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'button');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'button');
   });
 
   it('test .element.find().getAriaRole()', async function() {
@@ -63,10 +73,15 @@ describe('element().getAriaRole() command', function () {
     const resultPromise = this.client.api.element.find('#signupSection').getAriaRole();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'signupSection');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'signupSection');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetAriaRole.js
+++ b/test/src/api/commands/web-element/commands/testGetAriaRole.js
@@ -4,7 +4,7 @@ const MockServer  = require('../../../../../lib/mockserver.js');
 const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
 const Element = require('../../../../../../lib/element/index.js');
 
-describe('element().getAttribute() command', function () {
+describe('element().getAriaRole() command', function () {
   before(function (done) {
     CommandGlobals.beforeEach.call(this, done);
   });
@@ -13,60 +13,60 @@ describe('element().getAttribute() command', function () {
     CommandGlobals.afterEach.call(this, done);
   });
 
-  it('test .element().getAttribute()', async function() {
+  it('test .element().getAriaRole()', async function() {
     MockServer.addMock({
-      url: '/session/13521-10219-202/execute/sync',
-      method: 'POST',
+      url: '/session/13521-10219-202/element/0/computedrole',
+      method: 'GET',
       response: JSON.stringify({
-        value: 'text'
+        value: 'signupSection'
       })
     }, true);
 
-    const resultPromise = this.client.api.element('#signupSection').getAttribute('type');
+    const resultPromise = this.client.api.element('#signupSection').getAriaRole();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
     assert.strictEqual(resultPromise instanceof Promise, true);
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result, 'text');
+    assert.strictEqual(result, 'signupSection');
   });
 
-  it('test .element().find().getAttribute()', async function() {
+  it('test .element().find().getAriaRole()', async function() {
     MockServer.addMock({
-      url: '/session/13521-10219-202/execute/sync',
-      method: 'POST',
+      url: '/session/13521-10219-202/element/1/computedrole',
+      method: 'GET',
       response: JSON.stringify({
-        value: 'text'
+        value: 'button'
       })
     }, true);
 
-    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getAttribute('type');
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getAriaRole();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
     assert.strictEqual(resultPromise instanceof Promise, true);
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result, 'text');
+    assert.strictEqual(result, 'button');
   });
 
-  it('test .element.find().getAttribute()', async function() {
+  it('test .element.find().getAriaRole()', async function() {
     MockServer.addMock({
-      url: '/session/13521-10219-202/execute/sync',
-      method: 'POST',
+      url: '/session/13521-10219-202/element/0/computedrole',
+      method: 'GET',
       response: JSON.stringify({
-        value: 'text'
+        value: 'signupSection'
       })
     }, true);
 
-    const resultPromise = this.client.api.element.find('#signupSection').getAttribute('type');
+    const resultPromise = this.client.api.element.find('#signupSection').getAriaRole();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
     assert.strictEqual(resultPromise instanceof Promise, true);
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result, 'text');
+    assert.strictEqual(result, 'signupSection');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetAriaRole.js
+++ b/test/src/api/commands/web-element/commands/testGetAriaRole.js
@@ -84,4 +84,29 @@ describe('element().getAriaRole() command', function () {
     const resultValue = await resultPromise.value;
     assert.strictEqual(resultValue, 'signupSection');
   });
+
+  it('test .element().getAriaRole() assert', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/computedrole',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'signupSection'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getAriaRole();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    assert.strictEqual(await resultPromise.assert.equals('signupSection'), 'signupSection');
+    assert.strictEqual(await resultPromise.assert.contains('signup'), 'signupSection');
+    assert.strictEqual(await resultPromise.assert.matches(/si[a-z]{2}upS[a-z]{6}/), 'signupSection');
+
+    assert.strictEqual(await resultPromise.assert.not.equals('Signupx'), 'signupSection');
+    assert.strictEqual(await resultPromise.assert.not.contains('Signupx'), 'signupSection');
+    assert.strictEqual(await resultPromise.assert.not.matches(/Si[a-z]{2}upx/), 'signupSection');
+  });
 });

--- a/test/src/api/commands/web-element/commands/testGetAttribute.js
+++ b/test/src/api/commands/web-element/commands/testGetAttribute.js
@@ -25,11 +25,16 @@ describe('element().getAttribute() command', function () {
     const resultPromise = this.client.api.element('#signupSection').getAttribute('type');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'text');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'text');
   });
 
   it('test .element().find().getAttribute()', async function() {
@@ -44,11 +49,16 @@ describe('element().getAttribute() command', function () {
     const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getAttribute('type');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'text');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'text');
   });
 
   it('test .element.find().getAttribute()', async function() {
@@ -63,10 +73,15 @@ describe('element().getAttribute() command', function () {
     const resultPromise = this.client.api.element.find('#signupSection').getAttribute('type');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'text');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'text');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetAttribute.js
+++ b/test/src/api/commands/web-element/commands/testGetAttribute.js
@@ -1,0 +1,69 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().getAttribute() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().getAttribute()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: 'text'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getAttribute('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'text');
+  });
+
+  it('test .element().find().getAttribute()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: 'text'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getAttribute('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'text');
+  });
+
+  it('test .element.find().getAttribute()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: 'text'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').getAttribute('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'text');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testGetAttribute.js
+++ b/test/src/api/commands/web-element/commands/testGetAttribute.js
@@ -84,4 +84,29 @@ describe('element().getAttribute() command', function () {
     const resultValue = await resultPromise.value;
     assert.strictEqual(resultValue, 'text');
   });
+
+  it('test .element().getAttribute() assert', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: 'text'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getAttribute('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    assert.strictEqual(await resultPromise.assert.equals('text'), 'text');
+    assert.strictEqual(await resultPromise.assert.contains('tex'), 'text');
+    assert.strictEqual(await resultPromise.assert.matches(/te[a-z]{2}/), 'text');
+
+    assert.strictEqual(await resultPromise.assert.not.equals('texxt'), 'text');
+    assert.strictEqual(await resultPromise.assert.not.contains('texx'), 'text');
+    assert.strictEqual(await resultPromise.assert.not.matches(/te[a-z]{2}x/), 'text');
+  });
 });

--- a/test/src/api/commands/web-element/commands/testGetCssProperty.js
+++ b/test/src/api/commands/web-element/commands/testGetCssProperty.js
@@ -109,4 +109,29 @@ describe('element().getCssProperty() command', function () {
     const resultValue = await resultPromise.value;
     assert.strictEqual(resultValue, '150px');
   });
+
+  it('test .element().getCssProperty() assert', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/css/height',
+      method: 'GET',
+      response: JSON.stringify({
+        value: '150px'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getCssProperty('height');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    assert.strictEqual(await resultPromise.assert.equals('150px'), '150px');
+    assert.strictEqual(await resultPromise.assert.contains('150'), '150px');
+    assert.strictEqual(await resultPromise.assert.matches(/150[a-z]{2}/), '150px');
+
+    assert.strictEqual(await resultPromise.assert.not.equals('150x'), '150px');
+    assert.strictEqual(await resultPromise.assert.not.contains('150x'), '150px');
+    assert.strictEqual(await resultPromise.assert.not.matches(/150[a-z]{2}x/), '150px');
+  });
 });

--- a/test/src/api/commands/web-element/commands/testGetCssProperty.js
+++ b/test/src/api/commands/web-element/commands/testGetCssProperty.js
@@ -25,11 +25,17 @@ describe('element().getCssProperty() command', function () {
     const resultPromise = this.client.api.element('#signupSection').getCssProperty('height');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+    
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, '150px');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, '150px');
   });
 
   it('test .element().css()', async function() {
@@ -44,11 +50,16 @@ describe('element().getCssProperty() command', function () {
     const resultPromise = this.client.api.element('#signupSection').css('height');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+    
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, '150px');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, '150px');
   });
 
   it('test .element().find().getCssProperty()', async function() {
@@ -63,11 +74,16 @@ describe('element().getCssProperty() command', function () {
     const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getCssProperty('height');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, '34px');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, '34px');
   });
 
   it('test .element.find().getCssProperty()', async function() {
@@ -82,10 +98,15 @@ describe('element().getCssProperty() command', function () {
     const resultPromise = this.client.api.element.find('#signupSection').getCssProperty('height');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, '150px');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, '150px');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetCssProperty.js
+++ b/test/src/api/commands/web-element/commands/testGetCssProperty.js
@@ -4,7 +4,7 @@ const MockServer  = require('../../../../../lib/mockserver.js');
 const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
 const Element = require('../../../../../../lib/element/index.js');
 
-describe('element().getAccessibleName() command', function () {
+describe('element().getCssProperty() command', function () {
   before(function (done) {
     CommandGlobals.beforeEach.call(this, done);
   });
@@ -13,60 +13,79 @@ describe('element().getAccessibleName() command', function () {
     CommandGlobals.afterEach.call(this, done);
   });
 
-  it('test .element().getAccessibleName()', async function() {
+  it('test .element().getCssProperty()', async function() {
     MockServer.addMock({
-      url: '/session/13521-10219-202/element/0/computedlabel',
+      url: '/session/13521-10219-202/element/0/css/height',
       method: 'GET',
       response: JSON.stringify({
-        value: 'Signup'
+        value: '150px'
       })
     }, true);
 
-    const resultPromise = this.client.api.element('#signupSection').getAccessibleName();
+    const resultPromise = this.client.api.element('#signupSection').getCssProperty('height');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
     assert.strictEqual(resultPromise instanceof Promise, true);
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result, 'Signup');
+    assert.strictEqual(result, '150px');
   });
 
-  it('test .element().find().getAccessibleName()', async function() {
+  it('test .element().css()', async function() {
     MockServer.addMock({
-      url: '/session/13521-10219-202/element/1/computedlabel',
+      url: '/session/13521-10219-202/element/0/css/height',
       method: 'GET',
       response: JSON.stringify({
-        value: 'Help'
+        value: '150px'
       })
     }, true);
 
-    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getAccessibleName();
+    const resultPromise = this.client.api.element('#signupSection').css('height');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
     assert.strictEqual(resultPromise instanceof Promise, true);
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result, 'Help');
+    assert.strictEqual(result, '150px');
   });
 
-  it('test .element.find().getAccessibleName()', async function() {
+  it('test .element().find().getCssProperty()', async function() {
     MockServer.addMock({
-      url: '/session/13521-10219-202/element/0/computedlabel',
+      url: '/session/13521-10219-202/element/1/css/height',
       method: 'GET',
       response: JSON.stringify({
-        value: 'Signup'
+        value: '34px'
       })
     }, true);
 
-    const resultPromise = this.client.api.element.find('#signupSection').getAccessibleName();
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getCssProperty('height');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
     assert.strictEqual(resultPromise instanceof Promise, true);
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result, 'Signup');
+    assert.strictEqual(result, '34px');
+  });
+
+  it('test .element.find().getCssProperty()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/css/height',
+      method: 'GET',
+      response: JSON.stringify({
+        value: '150px'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').getCssProperty('height');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, '150px');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetFirstElementChild.js
+++ b/test/src/api/commands/web-element/commands/testGetFirstElementChild.js
@@ -1,0 +1,85 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().getFirstElementChild() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().getFirstElementChild()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'element-6066-11e4-a52e-4f735466cecf': '9'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getFirstElementChild();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    // TODO: getFirstElementChild() should return WebElement instead of JSON_WEB_OBJECT.
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
+    assert.strictEqual(result.getId(), '9');
+  });
+
+  it('test .element().find().getFirstElementChild()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'element-6066-11e4-a52e-4f735466cecf': '10'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getFirstElementChild('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '10');
+    assert.strictEqual(result.getId(), '10');
+  });
+
+  it('test .element.find().getFirstElementChild()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'element-6066-11e4-a52e-4f735466cecf': '9'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').getFirstElementChild('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
+    assert.strictEqual(result.getId(), '9');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testGetFirstElementChild.js
+++ b/test/src/api/commands/web-element/commands/testGetFirstElementChild.js
@@ -30,11 +30,9 @@ describe('element().getFirstElementChild() command', function () {
     assert.strictEqual(typeof resultPromise.find, 'function');
     assert.strictEqual(typeof resultPromise.getValue, 'function');
 
-    // TODO: getFirstElementChild() should return WebElement instead of JSON_WEB_OBJECT.
     const result = await resultPromise;
-    assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
-    assert.strictEqual(result.getId(), '9');
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
   });
 
   it('test .element().find().getFirstElementChild()', async function() {
@@ -55,9 +53,8 @@ describe('element().getFirstElementChild() command', function () {
     assert.strictEqual(typeof resultPromise.getValue, 'function');
 
     const result = await resultPromise;
-    assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '10');
-    assert.strictEqual(result.getId(), '10');
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '10');
   });
 
   it('test .element.find().getFirstElementChild()', async function() {
@@ -78,8 +75,7 @@ describe('element().getFirstElementChild() command', function () {
     assert.strictEqual(typeof resultPromise.getValue, 'function');
 
     const result = await resultPromise;
-    assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
-    assert.strictEqual(result.getId(), '9');
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetId.js
+++ b/test/src/api/commands/web-element/commands/testGetId.js
@@ -1,10 +1,9 @@
 const assert = require('assert');
 const {WebElement} = require('selenium-webdriver');
-const MockServer  = require('../../../../../lib/mockserver.js');
 const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
 const Element = require('../../../../../../lib/element/index.js');
 
-describe('element().getAttribute() command', function () {
+describe('element().getId() command', function () {
   before(function (done) {
     CommandGlobals.beforeEach.call(this, done);
   });
@@ -13,60 +12,36 @@ describe('element().getAttribute() command', function () {
     CommandGlobals.afterEach.call(this, done);
   });
 
-  it('test .element().getAttribute()', async function() {
-    MockServer.addMock({
-      url: '/session/13521-10219-202/execute/sync',
-      method: 'POST',
-      response: JSON.stringify({
-        value: 'text'
-      })
-    }, true);
-
-    const resultPromise = this.client.api.element('#signupSection').getAttribute('type');
+  it('test .element().getId()', async function() {
+    const resultPromise = this.client.api.element('#signupSection').getId();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
     assert.strictEqual(resultPromise instanceof Promise, true);
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result, 'text');
+    assert.strictEqual(result, '0');
   });
 
-  it('test .element().find().getAttribute()', async function() {
-    MockServer.addMock({
-      url: '/session/13521-10219-202/execute/sync',
-      method: 'POST',
-      response: JSON.stringify({
-        value: 'text'
-      })
-    }, true);
-
-    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getAttribute('type');
+  it('test .element().find().getId()', async function() {
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getId();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
     assert.strictEqual(resultPromise instanceof Promise, true);
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result, 'text');
+    assert.strictEqual(result, '1');
   });
 
-  it('test .element.find().getAttribute()', async function() {
-    MockServer.addMock({
-      url: '/session/13521-10219-202/execute/sync',
-      method: 'POST',
-      response: JSON.stringify({
-        value: 'text'
-      })
-    }, true);
-
-    const resultPromise = this.client.api.element.find('#signupSection').getAttribute('type');
+  it('test .element.find().getId()', async function() {
+    const resultPromise = this.client.api.element.find('#signupSection').getId();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
     assert.strictEqual(resultPromise instanceof Promise, true);
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result, 'text');
+    assert.strictEqual(result, '0');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetId.js
+++ b/test/src/api/commands/web-element/commands/testGetId.js
@@ -59,4 +59,21 @@ describe('element().getId() command', function () {
     const resultValue = await resultPromise.value;
     assert.strictEqual(resultValue, '0');
   });
+
+  it('test .element().getId() assert', async function() {
+    const resultPromise = this.client.api.element('#signupSection').getId();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    assert.strictEqual(await resultPromise.assert.equals('0'), '0');
+    assert.strictEqual(await resultPromise.assert.contains('0'), '0');
+    assert.strictEqual(await resultPromise.assert.matches(/[0-9]{1}/), '0');
+
+    assert.strictEqual(await resultPromise.assert.not.equals('1'), '0');
+    assert.strictEqual(await resultPromise.assert.not.contains('1'), '0');
+    assert.strictEqual(await resultPromise.assert.not.matches(/[0-1]{2}x/), '0');
+  });
 });

--- a/test/src/api/commands/web-element/commands/testGetId.js
+++ b/test/src/api/commands/web-element/commands/testGetId.js
@@ -16,32 +16,47 @@ describe('element().getId() command', function () {
     const resultPromise = this.client.api.element('#signupSection').getId();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, '0');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, '0');
   });
 
   it('test .element().find().getId()', async function() {
     const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getId();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, '1');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, '1');
   });
 
   it('test .element.find().getId()', async function() {
     const resultPromise = this.client.api.element.find('#signupSection').getId();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, '0');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, '0');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetLastElementChild.js
+++ b/test/src/api/commands/web-element/commands/testGetLastElementChild.js
@@ -32,9 +32,8 @@ describe('element().getLastElementChild() command', function () {
 
     // TODO: getLastElementChild() should return WebElement instead of JSON_WEB_OBJECT.
     const result = await resultPromise;
-    assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
-    assert.strictEqual(result.getId(), '9');
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
   });
 
   it('test .element().find().getLastElementChild()', async function() {
@@ -55,9 +54,8 @@ describe('element().getLastElementChild() command', function () {
     assert.strictEqual(typeof resultPromise.getValue, 'function');
 
     const result = await resultPromise;
-    assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '10');
-    assert.strictEqual(result.getId(), '10');
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '10');
   });
 
   it('test .element.find().getLastElementChild()', async function() {
@@ -78,8 +76,7 @@ describe('element().getLastElementChild() command', function () {
     assert.strictEqual(typeof resultPromise.getValue, 'function');
 
     const result = await resultPromise;
-    assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
-    assert.strictEqual(result.getId(), '9');
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetLastElementChild.js
+++ b/test/src/api/commands/web-element/commands/testGetLastElementChild.js
@@ -1,0 +1,85 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().getLastElementChild() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().getLastElementChild()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'element-6066-11e4-a52e-4f735466cecf': '9'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getLastElementChild();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    // TODO: getLastElementChild() should return WebElement instead of JSON_WEB_OBJECT.
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
+    assert.strictEqual(result.getId(), '9');
+  });
+
+  it('test .element().find().getLastElementChild()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'element-6066-11e4-a52e-4f735466cecf': '10'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getLastElementChild('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '10');
+    assert.strictEqual(result.getId(), '10');
+  });
+
+  it('test .element.find().getLastElementChild()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'element-6066-11e4-a52e-4f735466cecf': '9'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').getLastElementChild('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
+    assert.strictEqual(result.getId(), '9');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testGetNextElementSibling.js
+++ b/test/src/api/commands/web-element/commands/testGetNextElementSibling.js
@@ -30,11 +30,9 @@ describe('element().getNextElementSibling() command', function () {
     assert.strictEqual(typeof resultPromise.find, 'function');
     assert.strictEqual(typeof resultPromise.getValue, 'function');
 
-    // TODO: getNextElementSibling() should return WebElement instead of JSON_WEB_OBJECT.
     const result = await resultPromise;
-    assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
-    assert.strictEqual(result.getId(), '9');
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
   });
 
   it('test .element().find().getNextElementSibling()', async function() {
@@ -55,9 +53,8 @@ describe('element().getNextElementSibling() command', function () {
     assert.strictEqual(typeof resultPromise.getValue, 'function');
 
     const result = await resultPromise;
-    assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '10');
-    assert.strictEqual(result.getId(), '10');
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '10');
   });
 
   it('test .element.find().getNextElementSibling()', async function() {
@@ -78,8 +75,7 @@ describe('element().getNextElementSibling() command', function () {
     assert.strictEqual(typeof resultPromise.getValue, 'function');
 
     const result = await resultPromise;
-    assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
-    assert.strictEqual(result.getId(), '9');
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetNextElementSibling.js
+++ b/test/src/api/commands/web-element/commands/testGetNextElementSibling.js
@@ -1,0 +1,85 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().getNextElementSibling() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().getNextElementSibling()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'element-6066-11e4-a52e-4f735466cecf': '9'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getNextElementSibling();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    // TODO: getNextElementSibling() should return WebElement instead of JSON_WEB_OBJECT.
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
+    assert.strictEqual(result.getId(), '9');
+  });
+
+  it('test .element().find().getNextElementSibling()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'element-6066-11e4-a52e-4f735466cecf': '10'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getNextElementSibling('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '10');
+    assert.strictEqual(result.getId(), '10');
+  });
+
+  it('test .element.find().getNextElementSibling()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'element-6066-11e4-a52e-4f735466cecf': '9'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').getNextElementSibling('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
+    assert.strictEqual(result.getId(), '9');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testGetPreviousElementSibling.js
+++ b/test/src/api/commands/web-element/commands/testGetPreviousElementSibling.js
@@ -1,0 +1,85 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().getPreviousElementSibling() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().getPreviousElementSibling()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'element-6066-11e4-a52e-4f735466cecf': '9'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getPreviousElementSibling();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    // TODO: getPreviousElementSibling() should return WebElement instead of JSON_WEB_OBJECT.
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
+    assert.strictEqual(result.getId(), '9');
+  });
+
+  it('test .element().find().getPreviousElementSibling()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'element-6066-11e4-a52e-4f735466cecf': '10'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getPreviousElementSibling('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '10');
+    assert.strictEqual(result.getId(), '10');
+  });
+
+  it('test .element.find().getPreviousElementSibling()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'element-6066-11e4-a52e-4f735466cecf': '9'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').getPreviousElementSibling('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
+    assert.strictEqual(result.getId(), '9');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testGetPreviousElementSibling.js
+++ b/test/src/api/commands/web-element/commands/testGetPreviousElementSibling.js
@@ -30,11 +30,9 @@ describe('element().getPreviousElementSibling() command', function () {
     assert.strictEqual(typeof resultPromise.find, 'function');
     assert.strictEqual(typeof resultPromise.getValue, 'function');
 
-    // TODO: getPreviousElementSibling() should return WebElement instead of JSON_WEB_OBJECT.
     const result = await resultPromise;
-    assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
-    assert.strictEqual(result.getId(), '9');
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
   });
 
   it('test .element().find().getPreviousElementSibling()', async function() {
@@ -55,9 +53,8 @@ describe('element().getPreviousElementSibling() command', function () {
     assert.strictEqual(typeof resultPromise.getValue, 'function');
 
     const result = await resultPromise;
-    assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '10');
-    assert.strictEqual(result.getId(), '10');
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '10');
   });
 
   it('test .element.find().getPreviousElementSibling()', async function() {
@@ -78,8 +75,7 @@ describe('element().getPreviousElementSibling() command', function () {
     assert.strictEqual(typeof resultPromise.getValue, 'function');
 
     const result = await resultPromise;
-    assert.strictEqual(result instanceof WebElement, false);
-    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
-    assert.strictEqual(result.getId(), '9');
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetProperty.js
+++ b/test/src/api/commands/web-element/commands/testGetProperty.js
@@ -1,0 +1,91 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().getProperty() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().getProperty()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/property/classList',
+      method: 'GET',
+      response: JSON.stringify({
+        value: ['.signup']
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getProperty('classList');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.deepStrictEqual(result, ['.signup']);
+  });
+
+  it('test .element().property()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/property/classList',
+      method: 'GET',
+      response: JSON.stringify({
+        value: ['.signup']
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').property('classList');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.deepStrictEqual(result, ['.signup']);
+  });
+
+  it('test .element().find().getProperty()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/1/property/classList',
+      method: 'GET',
+      response: JSON.stringify({
+        value: ['.btn']
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getProperty('classList');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.deepStrictEqual(result, ['.btn']);
+  });
+
+  it('test .element.find().getProperty()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/property/classList',
+      method: 'GET',
+      response: JSON.stringify({
+        value: ['.signup']
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').getProperty('classList');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.deepStrictEqual(result, ['.signup']);
+  });
+});

--- a/test/src/api/commands/web-element/commands/testGetProperty.js
+++ b/test/src/api/commands/web-element/commands/testGetProperty.js
@@ -25,11 +25,16 @@ describe('element().getProperty() command', function () {
     const resultPromise = this.client.api.element('#signupSection').getProperty('classList');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.deepStrictEqual(result, ['.signup']);
+
+    const resultValue = await resultPromise.value;
+    assert.deepStrictEqual(resultValue, ['.signup']);
   });
 
   it('test .element().property()', async function() {
@@ -44,11 +49,16 @@ describe('element().getProperty() command', function () {
     const resultPromise = this.client.api.element('#signupSection').property('classList');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.deepStrictEqual(result, ['.signup']);
+
+    const resultValue = await resultPromise.value;
+    assert.deepStrictEqual(resultValue, ['.signup']);
   });
 
   it('test .element().find().getProperty()', async function() {
@@ -63,11 +73,16 @@ describe('element().getProperty() command', function () {
     const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getProperty('classList');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.deepStrictEqual(result, ['.btn']);
+
+    const resultValue = await resultPromise.value;
+    assert.deepStrictEqual(resultValue, ['.btn']);
   });
 
   it('test .element.find().getProperty()', async function() {
@@ -82,10 +97,15 @@ describe('element().getProperty() command', function () {
     const resultPromise = this.client.api.element.find('#signupSection').getProperty('classList');
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.deepStrictEqual(result, ['.signup']);
+
+    const resultValue = await resultPromise.value;
+    assert.deepStrictEqual(resultValue, ['.signup']);
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetRect.js
+++ b/test/src/api/commands/web-element/commands/testGetRect.js
@@ -1,0 +1,110 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().getRect() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().getRect()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/rect',
+      method: 'GET',
+      response: JSON.stringify({
+        value: {height: 34, width: 443, x: 356, y: 381.5}
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getRect();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.deepStrictEqual(result, {height: 34, width: 443, x: 356, y: 381.5});
+  });
+
+  it('test .element().getSize()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/rect',
+      method: 'GET',
+      response: JSON.stringify({
+        value: {height: 34, width: 443, x: 356, y: 381.5}
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getSize();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.deepStrictEqual(result, {height: 34, width: 443, x: 356, y: 381.5});
+  });
+
+  it('test .element().getLocation()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/rect',
+      method: 'GET',
+      response: JSON.stringify({
+        value: {height: 34, width: 443, x: 356, y: 381.5}
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getLocation();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.deepStrictEqual(result, {height: 34, width: 443, x: 356, y: 381.5});
+  });
+
+  it('test .element().find().getRect()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/1/rect',
+      method: 'GET',
+      response: JSON.stringify({
+        value: {height: 34, width: 443, x: 356, y: 381.5}
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getRect();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.deepStrictEqual(result, {height: 34, width: 443, x: 356, y: 381.5});
+  });
+
+  it('test .element.find().getRect()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/rect',
+      method: 'GET',
+      response: JSON.stringify({
+        value: {height: 34, width: 443, x: 356, y: 381.5}
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').getRect();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.deepStrictEqual(result, {height: 34, width: 443, x: 356, y: 381.5});
+  });
+});

--- a/test/src/api/commands/web-element/commands/testGetRect.js
+++ b/test/src/api/commands/web-element/commands/testGetRect.js
@@ -25,11 +25,16 @@ describe('element().getRect() command', function () {
     const resultPromise = this.client.api.element('#signupSection').getRect();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.deepStrictEqual(result, {height: 34, width: 443, x: 356, y: 381.5});
+
+    const resultValue = await resultPromise.value;
+    assert.deepStrictEqual(resultValue, {height: 34, width: 443, x: 356, y: 381.5});
   });
 
   it('test .element().getSize()', async function() {
@@ -44,11 +49,16 @@ describe('element().getRect() command', function () {
     const resultPromise = this.client.api.element('#signupSection').getSize();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.deepStrictEqual(result, {height: 34, width: 443, x: 356, y: 381.5});
+
+    const resultValue = await resultPromise.value;
+    assert.deepStrictEqual(resultValue, {height: 34, width: 443, x: 356, y: 381.5});
   });
 
   it('test .element().getLocation()', async function() {
@@ -63,11 +73,16 @@ describe('element().getRect() command', function () {
     const resultPromise = this.client.api.element('#signupSection').getLocation();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.deepStrictEqual(result, {height: 34, width: 443, x: 356, y: 381.5});
+
+    const resultValue = await resultPromise.value;
+    assert.deepStrictEqual(resultValue, {height: 34, width: 443, x: 356, y: 381.5});
   });
 
   it('test .element().find().getRect()', async function() {
@@ -82,11 +97,16 @@ describe('element().getRect() command', function () {
     const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getRect();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.deepStrictEqual(result, {height: 34, width: 443, x: 356, y: 381.5});
+
+    const resultValue = await resultPromise.value;
+    assert.deepStrictEqual(resultValue, {height: 34, width: 443, x: 356, y: 381.5});
   });
 
   it('test .element.find().getRect()', async function() {
@@ -101,10 +121,15 @@ describe('element().getRect() command', function () {
     const resultPromise = this.client.api.element.find('#signupSection').getRect();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.deepStrictEqual(result, {height: 34, width: 443, x: 356, y: 381.5});
+
+    const resultValue = await resultPromise.value;
+    assert.deepStrictEqual(resultValue, {height: 34, width: 443, x: 356, y: 381.5});
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetShadowRoot.js
+++ b/test/src/api/commands/web-element/commands/testGetShadowRoot.js
@@ -1,0 +1,85 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().getShadowRoot() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().getShadowRoot()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'shadow-6066-11e4-a52e-4f735466cecf': '9'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getShadowRoot();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    // TODO: getShadowRoot() should return WebElement instead of JSON_WEB_OBJECT.
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
+    assert.strictEqual(result.getId(), '9');
+  });
+
+  it('test .element().find().getShadowRoot()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'shadow-6066-11e4-a52e-4f735466cecf': '10'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getShadowRoot('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '10');
+    assert.strictEqual(result.getId(), '10');
+  });
+
+  it('test .element.find().getShadowRoot()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: {
+          'shadow-6066-11e4-a52e-4f735466cecf': '9'
+        }
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').getShadowRoot('type');
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(resultPromise instanceof Promise, true);
+    assert.strictEqual(typeof resultPromise.find, 'function');
+    assert.strictEqual(typeof resultPromise.getValue, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result['element-6066-11e4-a52e-4f735466cecf'], '9');
+    assert.strictEqual(result.getId(), '9');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testGetTagName.js
+++ b/test/src/api/commands/web-element/commands/testGetTagName.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().getTagName() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().getTagName()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/name',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'div'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getTagName();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'div');
+  });
+
+  it('test .element().find().getTagName()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/1/name',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'button'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getTagName();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'button');
+  });
+
+  it('test .element.find().getTagName()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/name',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'div'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').getTagName();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'div');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testGetTagName.js
+++ b/test/src/api/commands/web-element/commands/testGetTagName.js
@@ -25,11 +25,16 @@ describe('element().getTagName() command', function () {
     const resultPromise = this.client.api.element('#signupSection').getTagName();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'div');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'div');
   });
 
   it('test .element().find().getTagName()', async function() {
@@ -44,11 +49,16 @@ describe('element().getTagName() command', function () {
     const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getTagName();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'button');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'button');
   });
 
   it('test .element.find().getTagName()', async function() {
@@ -63,10 +73,15 @@ describe('element().getTagName() command', function () {
     const resultPromise = this.client.api.element.find('#signupSection').getTagName();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'div');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'div');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetTagName.js
+++ b/test/src/api/commands/web-element/commands/testGetTagName.js
@@ -84,4 +84,29 @@ describe('element().getTagName() command', function () {
     const resultValue = await resultPromise.value;
     assert.strictEqual(resultValue, 'div');
   });
+
+  it('test .element().getTagName() assert', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/name',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'div'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getTagName();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    assert.strictEqual(await resultPromise.assert.equals('div'), 'div');
+    assert.strictEqual(await resultPromise.assert.contains('di'), 'div');
+    assert.strictEqual(await resultPromise.assert.matches(/di[a-z]{1}/), 'div');
+
+    assert.strictEqual(await resultPromise.assert.not.equals('divx'), 'div');
+    assert.strictEqual(await resultPromise.assert.not.contains('dx'), 'div');
+    assert.strictEqual(await resultPromise.assert.not.matches(/di[a-z]{2}x/), 'div');
+  });
 });

--- a/test/src/api/commands/web-element/commands/testGetText.js
+++ b/test/src/api/commands/web-element/commands/testGetText.js
@@ -84,4 +84,29 @@ describe('element().getText() command', function () {
     const resultValue = await resultPromise.value;
     assert.strictEqual(resultValue, 'Signup');
   });
+
+  it('test .element().getText() assert', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/text',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'Signup'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getText();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    assert.strictEqual(await resultPromise.assert.equals('Signup'), 'Signup');
+    assert.strictEqual(await resultPromise.assert.contains('Sign'), 'Signup');
+    assert.strictEqual(await resultPromise.assert.matches(/Si[a-z]{2}up/), 'Signup');
+
+    assert.strictEqual(await resultPromise.assert.not.equals('Signupx'), 'Signup');
+    assert.strictEqual(await resultPromise.assert.not.contains('Signupx'), 'Signup');
+    assert.strictEqual(await resultPromise.assert.not.matches(/Si[a-z]{2}upx/), 'Signup');
+  });
 });

--- a/test/src/api/commands/web-element/commands/testGetText.js
+++ b/test/src/api/commands/web-element/commands/testGetText.js
@@ -25,11 +25,16 @@ describe('element().getText() command', function () {
     const resultPromise = this.client.api.element('#signupSection').getText();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'Signup');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'Signup');
   });
 
   it('test .element().find().getText()', async function() {
@@ -44,11 +49,16 @@ describe('element().getText() command', function () {
     const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getText();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'Help');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'Help');
   });
 
   it('test .element.find().getText()', async function() {
@@ -63,10 +73,15 @@ describe('element().getText() command', function () {
     const resultPromise = this.client.api.element.find('#signupSection').getText();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'Signup');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'Signup');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetText.js
+++ b/test/src/api/commands/web-element/commands/testGetText.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().getText() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().getText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/text',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'Signup'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getText();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'Signup');
+  });
+
+  it('test .element().find().getText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/1/text',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'Help'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getText();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'Help');
+  });
+
+  it('test .element.find().getText()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/text',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'Signup'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').getText();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'Signup');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testGetValue.js
+++ b/test/src/api/commands/web-element/commands/testGetValue.js
@@ -25,11 +25,16 @@ describe('element().getValue() command', function () {
     const resultPromise = this.client.api.element('#signupSection').getValue();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, '');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, '');
   });
 
   it('test .element().find().getValue()', async function() {
@@ -44,11 +49,16 @@ describe('element().getValue() command', function () {
     const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getValue();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, 'Help');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'Help');
   });
 
   it('test .element.find().getValue()', async function() {
@@ -63,10 +73,15 @@ describe('element().getValue() command', function () {
     const resultPromise = this.client.api.element.find('#signupSection').getValue();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, false);
     assert.strictEqual(result, '');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, '');
   });
 });

--- a/test/src/api/commands/web-element/commands/testGetValue.js
+++ b/test/src/api/commands/web-element/commands/testGetValue.js
@@ -84,4 +84,29 @@ describe('element().getValue() command', function () {
     const resultValue = await resultPromise.value;
     assert.strictEqual(resultValue, '');
   });
+
+  it('test .element().getValue() assert', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/property/value',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'Signup'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getValue();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    assert.strictEqual(await resultPromise.assert.equals('Signup'), 'Signup');
+    assert.strictEqual(await resultPromise.assert.contains('Sign'), 'Signup');
+    assert.strictEqual(await resultPromise.assert.matches(/Si[a-z]{2}up/), 'Signup');
+
+    assert.strictEqual(await resultPromise.assert.not.equals('Signupx'), 'Signup');
+    assert.strictEqual(await resultPromise.assert.not.contains('Signupx'), 'Signup');
+    assert.strictEqual(await resultPromise.assert.not.matches(/Si[a-z]{2}upx/), 'Signup');
+  });
 });

--- a/test/src/api/commands/web-element/commands/testGetValue.js
+++ b/test/src/api/commands/web-element/commands/testGetValue.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().getValue() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().getValue()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/property/value',
+      method: 'GET',
+      response: JSON.stringify({
+        value: ''
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getValue();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, '');
+  });
+
+  it('test .element().find().getValue()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/1/property/value',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'Help'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').getValue();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'Help');
+  });
+
+  it('test .element.find().getValue()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/property/value',
+      method: 'GET',
+      response: JSON.stringify({
+        value: ''
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').getValue();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, true);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, '');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testMoveTo.js
+++ b/test/src/api/commands/web-element/commands/testMoveTo.js
@@ -1,0 +1,122 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().moveTo() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().moveTo()', async function() {
+    let moveToArgs;
+    this.client.transport.Actions.session.moveTo = function(args) {
+      moveToArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element('#signupSection').moveTo();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+
+    const webElementArg = await moveToArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '0');
+    assert.strictEqual(moveToArgs.args[1], 0);
+    assert.strictEqual(moveToArgs.args[2], 0);
+  });
+
+  it('test .element().moveTo(x, y)', async function() {
+    let moveToArgs;
+    this.client.transport.Actions.session.moveTo = function(args) {
+      moveToArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element('#signupSection').moveTo(50, 100);
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+
+    const webElementArg = await moveToArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '0');
+    assert.strictEqual(moveToArgs.args[1], 50);
+    assert.strictEqual(moveToArgs.args[2], 100);
+  });
+
+  it('test .element().find().moveTo()', async function() {
+    let moveToArgs;
+    this.client.transport.Actions.session.moveTo = function(args) {
+      moveToArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').moveTo();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '1');
+
+    const webElementArg = await moveToArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '1');
+    assert.strictEqual(moveToArgs.args[1], 0);
+    assert.strictEqual(moveToArgs.args[2], 0);
+  });
+
+  it('test .element.find().moveTo()', async function() {
+    let moveToArgs;
+    this.client.transport.Actions.session.moveTo = function(args) {
+      moveToArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element.find('#signupSection').moveTo();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+
+    const webElementArg = await moveToArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '0');
+    assert.strictEqual(moveToArgs.args[1], 0);
+    assert.strictEqual(moveToArgs.args[2], 0);
+  });
+});

--- a/test/src/api/commands/web-element/commands/testRightClick.js
+++ b/test/src/api/commands/web-element/commands/testRightClick.js
@@ -1,0 +1,89 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().rightClick() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().rightClick()', async function() {
+    let contextClickArgs;
+    this.client.transport.Actions.session.contextClick = function(args) {
+      contextClickArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element('#signupSection').rightClick();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+
+    const webElementArg = await contextClickArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '0');
+  });
+
+  it('test .element().find().rightClick()', async function() {
+    let contextClickArgs;
+    this.client.transport.Actions.session.contextClick = function(args) {
+      contextClickArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').rightClick();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '1');
+
+    const webElementArg = await contextClickArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '1');
+  });
+
+  it('test .element.find().rightClick()', async function() {
+    let contextClickArgs;
+    this.client.transport.Actions.session.contextClick = function(args) {
+      contextClickArgs = args;
+
+      return Promise.resolve({
+        status: 0,
+        value: null
+      });
+    };
+
+    const resultPromise = this.client.api.element.find('#signupSection').rightClick();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+
+    const webElementArg = await contextClickArgs.args[0];
+    assert.deepStrictEqual(await webElementArg.getId(), '0');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testSendKeys.js
+++ b/test/src/api/commands/web-element/commands/testSendKeys.js
@@ -1,0 +1,111 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().sendKeys() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().sendKeys()', async function() {
+    MockServer
+      .addMock({
+        url: '/session/13521-10219-202/elements',
+        postdata: {
+          using: 'css selector',
+          value: 'input[name=q]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '9'}]
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/9/value',
+        method: 'POST',
+        response: JSON.stringify({
+          value: null
+        })
+      }, true);
+
+    const resultPromise = this.client.api.element('input[name=q]').sendKeys('nightwatch');
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
+  });
+
+  it('test .element().find().sendKeys()', async function() {
+    MockServer
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'css selector',
+          value: 'input[name=q]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '9'}]
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/9/value',
+        method: 'POST',
+        response: JSON.stringify({
+          value: null
+        })
+      }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('input[name=q]').sendKeys('nightwatch');
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
+  });
+
+  it('test .element.find().sendKeys()', async function() {
+    MockServer
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'css selector',
+          value: 'input[name=q]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '9'}]
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/9/value',
+        method: 'POST',
+        response: JSON.stringify({
+          value: null
+        })
+      }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').find('input[name=q]').sendKeys('nightwatch');
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testSetAttribute.js
+++ b/test/src/api/commands/web-element/commands/testSetAttribute.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().setAttribute() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().setAttribute()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: true
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').setAttribute('some-name', 'some-value');
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+  });
+
+  it('test .element().find().setAttribute()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: true
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').setAttribute('some-name', 'some-value');
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '1');
+  });
+
+  it('test .element.find().setAttribute()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: true
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').setAttribute('some-name', 'some-value');
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testSetProperty.js
+++ b/test/src/api/commands/web-element/commands/testSetProperty.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().setProperty() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().setProperty()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: null
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').setProperty('some-name', 'some-value');
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+  });
+
+  it('test .element().find().setProperty()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: null
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').setProperty('some-name', 'some-value');
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '1');
+  });
+
+  it('test .element.find().setProperty()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: null
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').setProperty('some-name', 'some-value');
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testSubmit.js
+++ b/test/src/api/commands/web-element/commands/testSubmit.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().submit() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().submit()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: null
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').submit();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+  });
+
+  it('test .element().find().submit()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: null
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').submit();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '1');
+  });
+
+  it('test .element.find().submit()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: null
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').submit();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testTakeScreenshot.js
+++ b/test/src/api/commands/web-element/commands/testTakeScreenshot.js
@@ -1,0 +1,78 @@
+const assert = require('assert');
+const {WebElement} = require('selenium-webdriver');
+const MockServer  = require('../../../../../lib/mockserver.js');
+const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
+const Element = require('../../../../../../lib/element/index.js');
+
+describe('element().takeScreenshot() command', function () {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element().takeScreenshot()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/screenshot',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'iVBORw0KGgoAAAANSUhEUgAAAbsAAAAiCAYAAADGd3chAAABK',
+        suppressBase64Data: true
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').takeScreenshot();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+  });
+
+  it('test .element().find().takeScreenshot()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/1/screenshot',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'iVBORw0KGgoAAAANSUhEUgAAAbsAAAAiCAYAAADGd3chAAABK',
+        suppressBase64Data: true
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').takeScreenshot();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '1');
+  });
+
+  it('test .element.find().takeScreenshot()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/screenshot',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'iVBORw0KGgoAAAANSUhEUgAAAbsAAAAiCAYAAADGd3chAAABK',
+        suppressBase64Data: true
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').takeScreenshot();
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '0');
+  });
+});

--- a/test/src/api/commands/web-element/commands/testUpdate.js
+++ b/test/src/api/commands/web-element/commands/testUpdate.js
@@ -4,7 +4,7 @@ const MockServer  = require('../../../../../lib/mockserver.js');
 const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
 const Element = require('../../../../../../lib/element/index.js');
 
-describe('element().sendKeys() command', function () {
+describe('element().update() command', function () {
   before(function (done) {
     CommandGlobals.beforeEach.call(this, done);
   });
@@ -13,7 +13,7 @@ describe('element().sendKeys() command', function () {
     CommandGlobals.afterEach.call(this, done);
   });
 
-  it('test .element().sendKeys()', async function() {
+  it('test .element().update()', async function() {
     MockServer
       .addMock({
         url: '/session/13521-10219-202/elements',
@@ -27,41 +27,11 @@ describe('element().sendKeys() command', function () {
         })
       }, true)
       .addMock({
-        url: '/session/13521-10219-202/element/9/value',
+        url: '/session/13521-10219-202/element/9/clear',
         method: 'POST',
-        postdata: {
-          text: 'nightwatch',
-          value: [
-            'n', 'i', 'g', 'h', 't', 'w', 'a', 't', 'c', 'h'
-          ]
-        },
+        postdata: {},
         response: JSON.stringify({
           value: null
-        })
-      }, true);
-
-    const resultPromise = this.client.api.element('input[name=q]').sendKeys('nightwatch');
-    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
-    assert.strictEqual(resultPromise instanceof Element, false);
-    assert.strictEqual(typeof resultPromise.find, 'undefined');
-    assert.strictEqual(resultPromise instanceof Promise, false);
-
-    const result = await resultPromise;
-    assert.strictEqual(result instanceof WebElement, true);
-    assert.strictEqual(await result.getId(), '9');
-  });
-
-  it('test .element().find().sendKeys()', async function() {
-    MockServer
-      .addMock({
-        url: '/session/13521-10219-202/element/0/elements',
-        postdata: {
-          using: 'css selector',
-          value: 'input[name=q]'
-        },
-        method: 'POST',
-        response: JSON.stringify({
-          value: [{'element-6066-11e4-a52e-4f735466cecf': '9'}]
         })
       }, true)
       .addMock({
@@ -78,7 +48,7 @@ describe('element().sendKeys() command', function () {
         })
       }, true);
 
-    const resultPromise = this.client.api.element('#signupSection').find('input[name=q]').sendKeys('nightwatch');
+    const resultPromise = this.client.api.element('input[name=q]').update('nightwatch');
     // neither an instance of Element or Promise, but an instance of ScopedWebElement.
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
@@ -89,7 +59,7 @@ describe('element().sendKeys() command', function () {
     assert.strictEqual(await result.getId(), '9');
   });
 
-  it('test .element.find().sendKeys()', async function() {
+  it('test .element().find().update()', async function() {
     MockServer
       .addMock({
         url: '/session/13521-10219-202/element/0/elements',
@@ -100,6 +70,14 @@ describe('element().sendKeys() command', function () {
         method: 'POST',
         response: JSON.stringify({
           value: [{'element-6066-11e4-a52e-4f735466cecf': '9'}]
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/9/clear',
+        method: 'POST',
+        postdata: {},
+        response: JSON.stringify({
+          value: null
         })
       }, true)
       .addMock({
@@ -116,7 +94,53 @@ describe('element().sendKeys() command', function () {
         })
       }, true);
 
-    const resultPromise = this.client.api.element.find('#signupSection').find('input[name=q]').sendKeys('nightwatch');
+    const resultPromise = this.client.api.element('#signupSection').find('input[name=q]').update('nightwatch');
+    // neither an instance of Element or Promise, but an instance of ScopedWebElement.
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+    assert.strictEqual(resultPromise instanceof Promise, false);
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
+  });
+
+  it('test .element.find().update()', async function() {
+    MockServer
+      .addMock({
+        url: '/session/13521-10219-202/element/0/elements',
+        postdata: {
+          using: 'css selector',
+          value: 'input[name=q]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '9'}]
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/9/clear',
+        method: 'POST',
+        postdata: {},
+        response: JSON.stringify({
+          value: null
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/9/value',
+        method: 'POST',
+        postdata: {
+          text: 'nightwatch',
+          value: [
+            'n', 'i', 'g', 'h', 't', 'w', 'a', 't', 'c', 'h'
+          ]
+        },
+        response: JSON.stringify({
+          value: null
+        })
+      }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').find('input[name=q]').update('nightwatch');
     // neither an instance of Element or Promise, but an instance of ScopedWebElement.
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');

--- a/test/src/api/commands/web-element/commands/testUpload.js
+++ b/test/src/api/commands/web-element/commands/testUpload.js
@@ -4,7 +4,7 @@ const MockServer  = require('../../../../../lib/mockserver.js');
 const CommandGlobals = require('../../../../../lib/globals/commands-w3c.js');
 const Element = require('../../../../../../lib/element/index.js');
 
-describe('element().sendKeys() command', function () {
+describe('element().upload() command', function () {
   before(function (done) {
     CommandGlobals.beforeEach.call(this, done);
   });
@@ -13,13 +13,13 @@ describe('element().sendKeys() command', function () {
     CommandGlobals.afterEach.call(this, done);
   });
 
-  it('test .element().sendKeys()', async function() {
+  it('test .element().upload()', async function() {
     MockServer
       .addMock({
         url: '/session/13521-10219-202/elements',
         postdata: {
           using: 'css selector',
-          value: 'input[name=q]'
+          value: '#choosefile'
         },
         method: 'POST',
         response: JSON.stringify({
@@ -30,9 +30,9 @@ describe('element().sendKeys() command', function () {
         url: '/session/13521-10219-202/element/9/value',
         method: 'POST',
         postdata: {
-          text: 'nightwatch',
+          text: '/file.js',
           value: [
-            'n', 'i', 'g', 'h', 't', 'w', 'a', 't', 'c', 'h'
+            '/', 'f', 'i', 'l', 'e', '.', 'j', 's'
           ]
         },
         response: JSON.stringify({
@@ -40,7 +40,7 @@ describe('element().sendKeys() command', function () {
         })
       }, true);
 
-    const resultPromise = this.client.api.element('input[name=q]').sendKeys('nightwatch');
+    const resultPromise = this.client.api.element('#choosefile').upload('/file.js');
     // neither an instance of Element or Promise, but an instance of ScopedWebElement.
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
@@ -51,13 +51,13 @@ describe('element().sendKeys() command', function () {
     assert.strictEqual(await result.getId(), '9');
   });
 
-  it('test .element().find().sendKeys()', async function() {
+  it('test .element().find().upload()', async function() {
     MockServer
       .addMock({
         url: '/session/13521-10219-202/element/0/elements',
         postdata: {
           using: 'css selector',
-          value: 'input[name=q]'
+          value: '#choosefile'
         },
         method: 'POST',
         response: JSON.stringify({
@@ -68,9 +68,9 @@ describe('element().sendKeys() command', function () {
         url: '/session/13521-10219-202/element/9/value',
         method: 'POST',
         postdata: {
-          text: 'nightwatch',
+          text: '/file.js',
           value: [
-            'n', 'i', 'g', 'h', 't', 'w', 'a', 't', 'c', 'h'
+            '/', 'f', 'i', 'l', 'e', '.', 'j', 's'
           ]
         },
         response: JSON.stringify({
@@ -78,7 +78,7 @@ describe('element().sendKeys() command', function () {
         })
       }, true);
 
-    const resultPromise = this.client.api.element('#signupSection').find('input[name=q]').sendKeys('nightwatch');
+    const resultPromise = this.client.api.element('#signupSection').find('#choosefile').upload('/file.js');
     // neither an instance of Element or Promise, but an instance of ScopedWebElement.
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
@@ -89,13 +89,13 @@ describe('element().sendKeys() command', function () {
     assert.strictEqual(await result.getId(), '9');
   });
 
-  it('test .element.find().sendKeys()', async function() {
+  it('test .element.find().upload()', async function() {
     MockServer
       .addMock({
         url: '/session/13521-10219-202/element/0/elements',
         postdata: {
           using: 'css selector',
-          value: 'input[name=q]'
+          value: '#choosefile'
         },
         method: 'POST',
         response: JSON.stringify({
@@ -106,9 +106,9 @@ describe('element().sendKeys() command', function () {
         url: '/session/13521-10219-202/element/9/value',
         method: 'POST',
         postdata: {
-          text: 'nightwatch',
+          text: '/file.js',
           value: [
-            'n', 'i', 'g', 'h', 't', 'w', 'a', 't', 'c', 'h'
+            '/', 'f', 'i', 'l', 'e', '.', 'j', 's'
           ]
         },
         response: JSON.stringify({
@@ -116,7 +116,7 @@ describe('element().sendKeys() command', function () {
         })
       }, true);
 
-    const resultPromise = this.client.api.element.find('#signupSection').find('input[name=q]').sendKeys('nightwatch');
+    const resultPromise = this.client.api.element.find('#signupSection').find('#choosefile').upload('/file.js');
     // neither an instance of Element or Promise, but an instance of ScopedWebElement.
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');


### PR DESCRIPTION
Tests for all commands are added, except for the following:
* All commands using `runQueuedCommand` method. -- I've added tests for these commands, but they do not verify if the last call actually went through because we have no way to get the command result to verify it.

In the added tests, the following functionality is remaining to be tested:
* `.assert` functionality
* Error handling