### PR TITLE
Make new element api available as named export.

### DIFF
--- a/lib/api/_loaders/element-global.js
+++ b/lib/api/_loaders/element-global.js
@@ -235,7 +235,7 @@ class ElementGlobal {
         const isElement = await this.setElement(stackTrace);
         if (!isElement) {
           return null;
-        }3;
+        }
 
         if (commandName === 'findElement' && args.length === 0) {
           return this.element;

--- a/lib/index.js
+++ b/lib/index.js
@@ -389,15 +389,6 @@ Object.defineProperty(Nightwatch, 'Capabilities', {
   }
 });
 
-Object.defineProperty(Nightwatch, 'element', {
-  configurable: true,
-  value: function(locator) {
-    const client = global.nightwatch_client || global.browser;
-
-    return ElementGlobal.element({locator, client});
-  }
-});
-
 // Named exports
 const {
   browser, app, appium, alerts, cookies, document, window,


### PR DESCRIPTION
The removed block of code was overwriting the Proxy for `module.exports.element` defined at the end of `lib/index.js` file.

We can safely remove this block of code as right now this anyway does not work for normal Nightwatch tests (`client` should be set to an instance of `NightwatchClient` and not `NightwatchAPI`), but only works for programmatic API I assume. And for programmatic API, we are anyways overwriting it [here](https://github.com/nightwatchjs/nightwatch/blob/main/lib/index.js#L114-L119).

So, removing this code would:
* Have no side-effects on normal Nightwtach tests as it didn't work earlier.
* Have no side-effects on programmatic api as we are still overwriting `Nightwatch.element` as linked above.