### PR TITLE
Fix xpath selectors to locate within elements.

### DIFF
--- a/lib/api/web-element/commands/findAllByText.js
+++ b/lib/api/web-element/commands/findAllByText.js
@@ -2,7 +2,7 @@ const {By} = require('selenium-webdriver');
 
 module.exports.command = function (text, {exact = true} = {}) {
   const expr = exact ? `text()="${text}"` : `contains(text(),"${text}")`;
-  const selector = By.xpath(`//*[${expr}]`);
+  const selector = By.xpath(`.//*[${expr}]`);
 
   return this.createScopedElements({selector}, {parentElement: this, commandName: 'findAllByText'});
 };

--- a/lib/api/web-element/commands/findByLabelText.js
+++ b/lib/api/web-element/commands/findByLabelText.js
@@ -3,7 +3,7 @@ const {By} = require('selenium-webdriver');
 module.exports.command = function (text, {exact = true, ...options} = {}) {
   const findByForId = async (text, {exact, ...options}) => {
     const expr = exact ? `text()="${text}"` : `contains(text(),"${text}")`;
-    const selector = By.xpath(`//label[${expr}]`);
+    const selector = By.xpath(`.//label[${expr}]`);
 
     const labelWebElement = await this.find({
       ...options,
@@ -30,7 +30,7 @@ module.exports.command = function (text, {exact = true, ...options} = {}) {
 
   const findByAriaLabelled = async (text, {exact, ...options}) => {
     const expr = exact ? `text()="${text}"` : `contains(text(),"${text}")`;
-    const selector = By.xpath(`//label[${expr}]`);
+    const selector = By.xpath(`.//label[${expr}]`);
 
     const labelWebElement = await this.find({
       ...options,
@@ -57,7 +57,7 @@ module.exports.command = function (text, {exact = true, ...options} = {}) {
 
   const findByDirectNesting = async (text, {exact, ...options}) => {
     const expr = exact ? `text()="${text}"` : `contains(text(),"${text}")`;
-    const selector = By.xpath(`//label[${expr}]`);
+    const selector = By.xpath(`.//label[${expr}]`);
 
     const labelElementPromise = this.find({
       ...options,
@@ -80,8 +80,8 @@ module.exports.command = function (text, {exact = true, ...options} = {}) {
 
   const findByDeepNesting = async (text, {exact, ...options}) => {
     const selector = exact
-      ? By.xpath(`//label[*[text() = "${text}"]]`)
-      : By.xpath(`//label[*[contains(text(), "${text}")]]`);
+      ? By.xpath(`.//label[*[text() = "${text}"]]`)
+      : By.xpath(`.//label[*[contains(text(), "${text}")]]`);
 
     const labelElementPromise = this.find({
       ...options,

--- a/lib/api/web-element/commands/findByText.js
+++ b/lib/api/web-element/commands/findByText.js
@@ -2,8 +2,8 @@ const {By} = require('selenium-webdriver');
 
 module.exports.command = function(text, {exact = true, ...options} = {}) {
   const selector = exact
-    ? By.xpath(`//*[text()="${text}"]`)
-    : By.xpath(`//*[contains(text(),"${text}")]`);
+    ? By.xpath(`.//*[text()="${text}"]`)
+    : By.xpath(`.//*[contains(text(),"${text}")]`);
 
   return this.find({
     ...options,


### PR DESCRIPTION
Earlier, xpath selectors were always locating from the root even when they were chained to locate within an element. Prepending `.` on the selectors resolves the issue.

Earlier: 

![image](https://user-images.githubusercontent.com/39924567/229609070-9ba15d19-2f49-43b7-85df-b3a7866dd5e2.png)

Now: 

![image](https://user-images.githubusercontent.com/39924567/229609095-b6b89b7b-e820-49c3-974f-141b545e6f2b.png)

