### PR TITLE
fix #3571: return correct status code for waitForElementNotPresent

### DIFF
--- a/lib/api/element-commands/waitForElementNotPresent.js
+++ b/lib/api/element-commands/waitForElementNotPresent.js
@@ -101,11 +101,17 @@ class WaitForElementNotPresent extends WaitForElement {
   elementFound(result) {
     let defaultMsg = 'Timed out while waiting for element <%s> to be removed for %d milliseconds.';
 
+    result.status = -1;
+
     return this.fail(result, 'found', this.expectedValue, defaultMsg);
   }
 
   elementNotFound(result) {
     let defaultMsg = 'Element <%s> was not present after %d milliseconds.';
+
+    // if result contains error, then the report interprets the step as error
+    delete result.error;
+    result.status = 0;
 
     return this.pass(result, defaultMsg, this.executor.elapsedTime);
   }

--- a/test/src/api/commands/element/testWaitForElementNotPresent.js
+++ b/test/src/api/commands/element/testWaitForElementNotPresent.js
@@ -50,7 +50,7 @@ describe('waitForElementNotPresent', function () {
     this.client.api.waitForElementNotPresent('#weblogin', 15, false, commandCallback);
 
     return this.client.start(function (err) {
-      strictEqual(commandResult.status, 0);
+      strictEqual(commandResult.status, -1);
       strictEqual(commandInstance.abortOnFailure, false);
       strictEqual(commandInstance.elementId, null);
     });
@@ -61,16 +61,30 @@ describe('waitForElementNotPresent', function () {
     this.client.api.waitForElementNotPresent('#weblogin', 15, 10, false, commandCallback);
 
     this.client.api.waitForElementNotPresent('#weblogin', 15, 10, false, function(result, instance) {
-      strictEqual(result.status, 0);
+      strictEqual(result.status, -1);
       strictEqual(instance.rescheduleInterval, 10);
       strictEqual(instance.ms, 15);
       strictEqual(instance.abortOnFailure, false);
     });
 
     return this.client.start(function (err) {
-      strictEqual(commandResult.status, 0);
+      strictEqual(commandResult.status, -1);
       strictEqual(commandInstance.ms, 15);
       strictEqual(commandInstance.rescheduleInterval, 10);
     });
+  });
+
+  it('client.waitForElementNotPresent() success result should have correct status', function (done) {
+    this.client.api.globals.waitForConditionPollInterval = 10;
+
+    this.client.api.waitForElementNotPresent('#badElement', 15, 10, false, function(result, instance) {
+      strictEqual(result.status, 0);
+      strictEqual(result.error, undefined);
+      strictEqual(instance.rescheduleInterval, 10);
+      strictEqual(instance.ms, 15);
+      strictEqual(instance.abortOnFailure, false);
+    });
+
+    this.client.start(done);
   });
 });

--- a/test/src/element/testCommandsElementSelectors.js
+++ b/test/src/element/testCommandsElementSelectors.js
@@ -199,11 +199,11 @@ describe('test commands element selectors', function() {
 
     Nightwatch.api()
       .waitForElementNotPresent('.nock-string', 50, 20, false, function callback(result) {
-        assert.strictEqual(result.status, 0, 'waitForElementNotPresent "succeeds"');
+        assert.strictEqual(result.status, -1, 'waitForElementNotPresent "succeeds"');
         assert.strictEqual(result.value.length, 1, 'waitForElementNotPresent returns the found elements');
       })
       .waitForElementNotPresent({selector: '.nock-object', timeout: 50, retryInterval: 20, abortOnFailure: false}, function callback(result) {
-        assert.strictEqual(result.status, 0, 'waitForElementNotPresent "succeeds"');
+        assert.strictEqual(result.status, -1, 'waitForElementNotPresent "succeeds"');
         assert.strictEqual(result.value.length, 1, 'waitForElementNotPresent returns the found elements');
       });
 


### PR DESCRIPTION
Fixes #3571 

The status returned by `waitForElementNotPresent` inverse of what other commands produce. This cause the reporter to miss interpret the result. 

The fix in this PR fixes that problem, but potentially introduces a breaking change.