### PR TITLE
fixed issues with findByLabelText

### DIFF
--- a/lib/api/web-element/commands/findByLabelText.js
+++ b/lib/api/web-element/commands/findByLabelText.js
@@ -1,43 +1,28 @@
 const {By} = require('selenium-webdriver');
 
-module.exports.command = function (text, {exact = true, ...options} = {}) {
-  const findByForId = async (text, {exact, ...options}) => {
-    const expr = exact ? `text()="${text}"` : `contains(text(),"${text}")`;
-    const selector = By.xpath(`//label[${expr}]`);
+module.exports.command = function (text, {exact = true, timeout, retryInterval, suppressNotFoundErrors} = {}) {
 
-    const labelWebElement = await this.find({
-      ...options,
-      selector,
-      suppressNotFoundErrors: true
-    });
-
-    if (!labelWebElement) {
+  const findByForId = async (instance, labelElement) => {
+    if (!labelElement) {
       return null;
     }
 
-    const forAttribute = await labelWebElement.getAttribute('for');
+    const forAttribute = await labelElement.getAttribute('for');
 
     if (!forAttribute) {
       return null;
     }
 
-    return this.find({
-      ...options,
+    const element = await instance.waitUntilElementsLocated({
       selector: By.css(`input[id="${forAttribute}"]`),
-      suppressNotFoundErrors: true
+      timeout,
+      retryInterval
     });
+
+    return element;
   };
 
-  const findByAriaLabelled = async (text, {exact, ...options}) => {
-    const expr = exact ? `text()="${text}"` : `contains(text(),"${text}")`;
-    const selector = By.xpath(`//label[${expr}]`);
-
-    const labelWebElement = await this.find({
-      ...options,
-      selector,
-      suppressNotFoundErrors: true
-    });
-
+  const findByAriaLabelled = async (instance, labelWebElement) => {
     if (!labelWebElement) {
       return null;
     }
@@ -48,121 +33,144 @@ module.exports.command = function (text, {exact = true, ...options} = {}) {
       return null;
     }
 
-    return this.find({
-      ...options,
+    return instance.waitUntilElementsLocated({
       selector: By.css(`input[aria-labelledby="${idAttribute}"]`),
-      suppressNotFoundErrors: true
+      timeout,
+      retryInterval
     });
   };
 
-  const findByDirectNesting = async (text, {exact, ...options}) => {
-    const expr = exact ? `text()="${text}"` : `contains(text(),"${text}")`;
+  const findByDirectNesting = async (labelWebElement) => {
+    if (!labelWebElement) {
+      return null;
+    }
+
+    const elements = await labelWebElement.findElement(By.css('input'));
+    if (!elements) {
+      return null;
+    }
+
+    return elements[0];
+  };
+
+  const findByDeepNesting = async (text, {exact}) => {
+    const expr = exact ? `*[text()="${text}"]` : `*[contains(text(), "${text}")]`;
     const selector = By.xpath(`//label[${expr}]`);
 
-    const labelElementPromise = this.find({
-      ...options,
+    const labelElement = await this.find({
       selector,
+      timeout,
+      retryInterval,
       suppressNotFoundErrors: true
     });
-
-    const labelElement = await labelElementPromise;
 
     if (!labelElement) {
       return null;
     }
-
-    return labelElementPromise.find({
-      ...options,
-      selector: By.css('input'),
-      suppressNotFoundErrors: true
-    });
-  };
-
-  const findByDeepNesting = async (text, {exact, ...options}) => {
-    const selector = exact
-      ? By.xpath(`//label[*[text() = "${text}"]]`)
-      : By.xpath(`//label[*[contains(text(), "${text}")]]`);
-
-    const labelElementPromise = this.find({
-      ...options,
-      selector,
-      suppressNotFoundErrors: true
-    });
-
-    const labelElement = await labelElementPromise;
-
-    if (!labelElement) {
-      return null;
-    }
-
-    return labelElementPromise.find({
-      ...options,
-      selector: By.css('input'),
-      suppressNotFoundErrors: true
-    });
-  };
-
-  const findByAriaLabel = async (text, {exact, ...options}) => {
-    return this.find({
-      ...options,
-      selector: By.css(`input[aria-label${exact ? '' : '*'}="${text}"]`),
-      suppressNotFoundErrors: true
-    });
-  };
-
-  const createAction = (actions, webElement) => async function() {
-    let element;
 
     try {
-      element = await findByForId(text, {exact, ...options});
-    } catch {
-      // Ignore.
-    }
+      const element = await labelElement.findElement(By.css('input'));
 
-    if (!element) {
-      try {
-        element = await findByAriaLabelled(text, {exact, ...options});
-      } catch {
-        // Ignore.
+      if (element.length === 0) {
+        return null;
       }
+
+      return element[0];
+    } catch (err) {
+      return null;
     }
-
-    if (!element) {
-      try {
-        element = await findByDirectNesting(text, {exact, ...options});
-      } catch {
-        // Ignore.
-      }
-    }
-
-    if (!element) {
-      try {
-        element = await findByDeepNesting(text, {exact, ...options});
-      } catch {
-        // Ignore.
-      }
-    }
-
-    if (!element) {
-      try {
-        element = await findByAriaLabel(text, {exact, ...options});
-      } catch {
-        // Ignore.
-      }
-    }
-
-    if (element) {
-      return element;
-    }
-
-    const error = new Error(`The element associated with label whose text ${exact ? 'equals' : 'contains'} "${text}" has not been found.`);
-
-    throw error;
   };
 
-  const node = this.queueAction({name: 'findByLabelText', createAction});
+  const findByAriaLabel = async (text, {exact}) => {
+    const labelElement = await this.find({
+      selector: By.css(`input[aria-label${exact ? '' : '*'}="${text}"]`),
+      timeout,
+      retryInterval,
+      suppressNotFoundErrors: true
+    });
 
-  return this.createScopedElement(node.deferred.promise);
+    return labelElement;
+  };
+
+  const findFromLabel = async (instance, labelElement) => {
+    let element = null;
+
+    if (labelElement) {
+      try {
+        element = await findByForId(instance, labelElement);
+      } catch (err) {
+        // ignore
+      }
+
+      if (!element) {
+        try {
+          element = await findByAriaLabelled(instance, labelElement);
+        } catch (err) {
+          // ignore
+        }
+      }
+
+      if (!element) {
+        try {
+          element = await findByDirectNesting(labelElement);
+        } catch (err) {
+          // ignore
+        }
+      }
+    }
+
+    return element;
+  };
+
+  const createAction = function (labelElement) {
+    const instance = this;
+
+    return async function() {
+      let element = await findFromLabel(instance, labelElement);
+
+      if (element) {
+        return element;
+      }
+
+      const error = new Error(`The element associated with label whose text ${exact ? 'equals' : 'contains'} "${text}" has not been found.`);
+      if (!suppressNotFoundErrors) {
+        throw error;
+      }
+
+      return null;
+    };
+  };
+
+  const expr = exact ? `text()="${text}"` : `contains(text(),"${text}")`;
+  const selector = By.xpath(`//label[${expr}]`);
+
+  // eslint-disable-next-line no-async-promise-executor
+  return this.createScopedElement(new Promise(async (resolve, reject) => {
+    const labelElement = await this.find({
+      selector,
+      timeout,
+      retryInterval,
+      suppressNotFoundErrors: true
+    });
+
+    if (labelElement) {
+      const node = this.queueAction({name: 'findByLabelText', createAction: function () {
+        return createAction.call(this, labelElement);
+      }});
+
+      node.deferred.promise.then(resolve, reject);
+
+      return;
+    }
+
+    const byDeepNesting = await findByDeepNesting(text, {exact});
+    if (byDeepNesting) {
+      return resolve(byDeepNesting);
+    }
+
+    const byAriaLabel = await findByAriaLabel(text, {exact});
+    if (byAriaLabel) {
+      return resolve(byAriaLabel);
+    }
+  }));
 };
-
-

--- a/lib/api/web-element/element-locator.js
+++ b/lib/api/web-element/element-locator.js
@@ -25,7 +25,9 @@ class ElementLocator {
 
   static getOrDefault(obj, prop, defaultValue) {
     // eslint-disable-next-line no-prototype-builtins
-    return Utils.isObject(obj) && obj.hasOwnProperty(prop) ? obj[prop] : defaultValue;
+    const isDefined = Utils.isObject(obj) && obj.hasOwnProperty(prop) && Utils.isDefined(obj[prop]);
+
+    return isDefined ? obj[prop] : defaultValue;
   }
 
   static getLocateStrategy(element, strategy) {

--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const {until, WebElement, WebElementPromise} = require('selenium-webdriver');
+const {until, WebElement, WebElementPromise, Condition} = require('selenium-webdriver');
 const {ShadowRoot} = require('selenium-webdriver/lib/webdriver');
 
 const {Logger, isFunction, createPromise} = require('../../utils/');
@@ -75,31 +75,63 @@ class ScopedWebElement {
 
   }
 
+  async waitUntilElementsLocated(selector) {
+    const {timeout, condition, retryInterval} = ScopedElementLocator.create(selector, this.nightwatchInstance);
+    const webElements = await this.driver.wait(until.elementsLocated(condition), timeout, null, retryInterval);
+
+    if (webElements.length === 0) {
+      return null;
+    }
+
+    return webElements[0];
+  }
+
+  async locateElements({parentElement, selector, timeout, retryInterval}) {
+    const createLocateElement = () => {
+      return parentElement && parentElement.webElement ? function(locator) {
+        return new Condition('for at least one element to be located ' + locator, function (driver) {
+          return parentElement.webElement.findElements(locator).then(function (elements) {
+            return elements.length > 0 ? elements : null;
+          });
+        });
+      } : until.elementsLocated;
+    };
+
+    const locateFn = createLocateElement();
+    const webElements = await this.driver.wait(locateFn(selector), timeout, null, retryInterval);
+
+    return webElements;
+  }
+
   async findElement({parentElement, condition, index, timeout, retryInterval}) {
+
     const createAction = () => async ({args}) => {
       const parentElement = args[0];
-      const webElements = parentElement && parentElement.webElement
-        ? await parentElement.webElement.findElements(condition)
-        : await this.driver.wait(until.elementsLocated(condition), timeout, null, retryInterval);
 
-      if (webElements.length === 0) {
-        const err = new Error(`Cannot find element with "${condition}" selector in ${timeout} milliseconds.`);
-        this.reporter.registerTestError(err);
+      try {
+        const webElements = await this.locateElements({parentElement, selector: condition, timeout, retryInterval});
+        if (webElements.length === 0) {
+          const err = new Error(`Cannot find element with "${condition}" selector in ${timeout} milliseconds.`);
+          this.reporter.registerTestError(err);
 
-        return;
+          return;
+        }
+
+        if (index > webElements.length) {
+          const err = new Error(`The index "${index}" is out of bounds for selector "${condition}".`);
+          this.reporter.registerTestError(err);
+
+          return;
+        }
+
+        return webElements[index];
+      } catch (error) {
+        return null;
       }
-
-      if (index > webElements.length) {
-        const err = new Error(`The index "${index}" is out of bounds for selector "${condition}".`);
-        this.reporter.registerTestError(err);
-
-        return;
-      }
-
-      return webElements[index];
     };
 
     const node = this.queueAction({name: 'find', createAction, namespace: 'element', args: [parentElement]});
+
     node.printArgs = function() {
       if (condition.selector) {
         return `{ ${condition.selector} }`;
@@ -228,7 +260,7 @@ class ScopedWebElement {
       args,
       context: null,
       deferred: createPromise(),
-      commandFn: createAction(this.nightwatchInstance.transportActions, this.webElement),
+      commandFn: createAction.call(this, this.nightwatchInstance.transportActions, this.webElement),
       namespace,
       rejectPromise,
       commandName: name

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -1,4 +1,4 @@
-const {WebElement, WebDriver, Origin, By} = require('selenium-webdriver');
+const {WebElement, WebDriver, Origin, By, until} = require('selenium-webdriver');
 const {Locator} = require('../../element');
 const NightwatchLocator = require('../../element/locator-factory.js');
 const {isString} = require('../../utils');
@@ -841,8 +841,8 @@ module.exports = class MethodMappings {
 
         /**
          * @param {string|WebElement|null} origin
-         * @param {number} xOffset
-         * @param {number} yOffset
+         * @param {number} x
+         * @param {number} y
          * @param {object} [options]
          * @param {number} [duration]
          */
@@ -1050,6 +1050,10 @@ module.exports = class MethodMappings {
           return {
             value: null
           };
+        },
+
+        waitUntilElementsLocated({condition, timeout, retryInterval}) {
+          return this.driver.wait(until.elementsLocated(condition), timeout, null, retryInterval);
         },
 
         ///////////////////////////////////////////////////////////////////////////

--- a/test/src/api/commands/web-element/testFindByLabelText.js
+++ b/test/src/api/commands/web-element/testFindByLabelText.js
@@ -5,12 +5,13 @@ const CommandGlobals = require('../../../../lib/globals/commands-w3c.js');
 const Element = require('../../../../../lib/element/index.js');
 
 describe('.findByLabelText() commands', function () {
-  this.timeout(10000000);
-  before(function (done) {
+  this.timeout(5000);
+
+  beforeEach(function (done) {
     CommandGlobals.beforeEach.call(this, done);
   });
 
-  after(function (done) {
+  afterEach(function (done) {
     CommandGlobals.afterEach.call(this, done);
   });
 
@@ -35,7 +36,7 @@ describe('.findByLabelText() commands', function () {
         })
       }, true)
       .addMock({
-        url: '/session/13521-10219-202/element/0/elements',
+        url: '/session/13521-10219-202/elements',
         postdata: {
           using: 'css selector',
           value: 'input[id="email"]'
@@ -52,7 +53,8 @@ describe('.findByLabelText() commands', function () {
     assert.strictEqual(typeof resultPromise.find, 'function');
     assert.strictEqual(typeof resultPromise.getValue, 'function');
     assert.strictEqual(typeof resultPromise.assert, 'object');
-    assert.strictEqual(await resultPromise.getId(), '2');
+    const id = await resultPromise.getId();
+    assert.strictEqual(id, '2');
 
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, true);
@@ -80,7 +82,7 @@ describe('.findByLabelText() commands', function () {
         })
       }, true)
       .addMock({
-        url: '/session/13521-10219-202/element/0/elements',
+        url: '/session/13521-10219-202/elements',
         postdata: {
           using: 'css selector',
           value: 'input[id="email"]'
@@ -104,8 +106,7 @@ describe('.findByLabelText() commands', function () {
     assert.strictEqual(await result.getId(), '2');
   });
 
-  // FIXME: unstable test
-  xit('test .findByLabelText() (findByAriaLabelled)', async function() {
+  it('test .findByLabelText() (findByAriaLabelled)', async function() {
     MockServer
       .addMock({
         url: '/session/13521-10219-202/element/0/elements',
@@ -133,7 +134,7 @@ describe('.findByLabelText() commands', function () {
         })
       }, true)
       .addMock({
-        url: '/session/13521-10219-202/element/0/elements',
+        url: '/session/13521-10219-202/elements',
         postdata: {
           using: 'css selector',
           value: 'input[aria-labelledby="email-label"]'
@@ -179,7 +180,7 @@ describe('.findByLabelText() commands', function () {
         })
       }, true, true)
       .addMock({
-        url: '/session/13521-10219-202/element/1/elements',
+        url: '/session/13521-10219-202/element/1/element',
         postdata: {
           using: 'css selector',
           value: 'input'
@@ -221,7 +222,7 @@ describe('.findByLabelText() commands', function () {
         url: '/session/13521-10219-202/element/0/elements',
         postdata: {
           using: 'xpath',
-          value: '//label[*[text() = "Email"]]'
+          value: '//label[*[text()="Email"]]'
         },
         method: 'POST',
         response: JSON.stringify({
@@ -229,7 +230,7 @@ describe('.findByLabelText() commands', function () {
         })
       }, true)
       .addMock({
-        url: '/session/13521-10219-202/element/1/elements',
+        url: '/session/13521-10219-202/element/1/element',
         postdata: {
           using: 'css selector',
           value: 'input'
@@ -240,14 +241,20 @@ describe('.findByLabelText() commands', function () {
         })
       }, true);
 
-    const resultPromise = this.client.api.element('#signupSection').findByLabelText('Email');
+    const resultPromise = this.client.api.element('#signupSection').findByLabelText('Email', {
+      timeout: 200,
+      retryInterval: 100
+    });
+
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(resultPromise instanceof Promise, true);
     assert.strictEqual(typeof resultPromise.find, 'function');
     assert.strictEqual(typeof resultPromise.getValue, 'function');
     assert.strictEqual(typeof resultPromise.assert, 'object');
-    assert.strictEqual(await resultPromise.getId(), '2');
 
+    const id = await resultPromise.getId();
+    assert.strictEqual(id, '2');
+    //
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, true);
     assert.strictEqual(await result.getId(), '2');
@@ -271,13 +278,14 @@ describe('.findByLabelText() commands', function () {
         url: '/session/13521-10219-202/element/0/elements',
         postdata: {
           using: 'xpath',
-          value: '//label[*[text() = "Email"]]'
+          value: '//label[*[text()="Email"]]'
         },
         method: 'POST',
         response: JSON.stringify({
           value: []
-        })
-      }, true)
+        }),
+        times: 3
+      })
       .addMock({
         url: '/session/13521-10219-202/element/0/elements',
         postdata: {
@@ -290,7 +298,10 @@ describe('.findByLabelText() commands', function () {
         })
       }, true);
 
-    const resultPromise = this.client.api.element('#signupSection').findByLabelText('Email');
+    const resultPromise = this.client.api.element('#signupSection').findByLabelText('Email', {
+      timeout: 200,
+      retryInterval: 100
+    });
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(resultPromise instanceof Promise, true);
     assert.strictEqual(typeof resultPromise.find, 'function');

--- a/test/src/api/commands/web-element/testFindByLabelText.js
+++ b/test/src/api/commands/web-element/testFindByLabelText.js
@@ -5,7 +5,7 @@ const CommandGlobals = require('../../../../lib/globals/commands-w3c.js');
 const Element = require('../../../../../lib/element/index.js');
 
 describe('.findByLabelText() commands', function () {
-  before(function (done) {
+  beforeEach(function (done) {
     CommandGlobals.beforeEach.call(this, done);
   });
 
@@ -116,7 +116,7 @@ describe('.findByLabelText() commands', function () {
         response: JSON.stringify({
           value: [{'element-6066-11e4-a52e-4f735466cecf': '1'}]
         })
-      }, true, true)
+      }, true)
       .addMock({
         url: '/session/13521-10219-202/execute/sync',
         method: 'POST',
@@ -167,9 +167,8 @@ describe('.findByLabelText() commands', function () {
         method: 'POST',
         response: JSON.stringify({
           value: [{'element-6066-11e4-a52e-4f735466cecf': '1'}]
-        }),
-        times: 3
-      })
+        })
+      }, true)
       .addMock({
         url: '/session/13521-10219-202/execute/sync',
         method: 'POST',
@@ -220,7 +219,7 @@ describe('.findByLabelText() commands', function () {
         url: '/session/13521-10219-202/element/0/elements',
         postdata: {
           using: 'xpath',
-          value: './/label[*[text() = "Email"]]'
+          value: './/label[*[text()="Email"]]'
         },
         method: 'POST',
         response: JSON.stringify({
@@ -276,7 +275,7 @@ describe('.findByLabelText() commands', function () {
         url: '/session/13521-10219-202/element/0/elements',
         postdata: {
           using: 'xpath',
-          value: './/label[*[text() = "Email"]]'
+          value: './/label[*[text()="Email"]]'
         },
         method: 'POST',
         response: JSON.stringify({


### PR DESCRIPTION
Refactored the implementation to rely less on the queue. There are some caveats:
- taken into account the `timeout` and `retryInterval` only for the initial  label element lookup and the following input element lookup will not be retried (to do so would add significantly more complexity and I'm not sure it is needed; in case it is needed we will revisit it later)
- `findByDeepNesting` and `findByAriaLabel` will be queued with the command name as `find`
- normally all these 3 requests could be parallelised and we can use `Promise.any()` instead but our existing queue implementation does not support executing nodes in parallel nor does it support cancellation of nodes; the straightforward solution to this is to not use the queue, which means not using the `.find()`; however, not using find() will means that we have to retrieve the parent element in a different way, so more complexity etc., hence the serial implementation. 

Anyway, other than that it works nicely.