### PR TITLE
Migrate namespaces to client-commands and get them working on page-objects.

### DIFF
--- a/lib/api/client-commands/alerts/accept.js
+++ b/lib/api/client-commands/alerts/accept.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Accepts the currently displayed alert dialog. Usually, this is equivalent to clicking on the 'OK' button in the dialog.

--- a/lib/api/client-commands/alerts/accept.js
+++ b/lib/api/client-commands/alerts/accept.js
@@ -34,12 +34,7 @@ class AcceptAlert extends ClientCommand {
   }
 
   performAction(callback) {
-    this.transportActions
-      .acceptAlert(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.acceptAlert(callback);
   }
 }
 

--- a/lib/api/client-commands/alerts/accept.js
+++ b/lib/api/client-commands/alerts/accept.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Accepts the currently displayed alert dialog. Usually, this is equivalent to clicking on the 'OK' button in the dialog.
@@ -27,12 +28,19 @@ const ProtocolAction = require('../_base-action.js');
  * @link /#accept-alert
  * @api protocol.userprompts
  */
-module.exports = class Session extends ProtocolAction {
+class AcceptAlert extends ClientCommand {
   static get isTraceable() {
     return true;
   }
 
-  command(callback) {
-    return this.transportActions.acceptAlert(callback);
+  performAction(callback) {
+    this.transportActions
+      .acceptAlert(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+}
+
+module.exports = AcceptAlert;

--- a/lib/api/client-commands/alerts/dismiss.js
+++ b/lib/api/client-commands/alerts/dismiss.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Dismisses the currently displayed alert dialog.
@@ -29,12 +30,19 @@ const ProtocolAction = require('../_base-action.js');
  * @link /#dismiss-alert
  * @api protocol.userprompts
  */
-module.exports = class Session extends ProtocolAction {
+class DismissAlert extends ClientCommand {
   static get isTraceable() {
     return true;
   }
 
-  command(callback) {
-    return this.transportActions.dismissAlert(callback);
+  performAction(callback) {
+    this.transportActions
+      .dismissAlert(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+}
+
+module.exports = DismissAlert;

--- a/lib/api/client-commands/alerts/dismiss.js
+++ b/lib/api/client-commands/alerts/dismiss.js
@@ -36,12 +36,7 @@ class DismissAlert extends ClientCommand {
   }
 
   performAction(callback) {
-    this.transportActions
-      .dismissAlert(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.dismissAlert(callback);
   }
 }
 

--- a/lib/api/client-commands/alerts/dismiss.js
+++ b/lib/api/client-commands/alerts/dismiss.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Dismisses the currently displayed alert dialog.

--- a/lib/api/client-commands/alerts/getText.js
+++ b/lib/api/client-commands/alerts/getText.js
@@ -31,12 +31,7 @@ const {Logger} = require('../../../utils');
  */
 class GetAlertText extends ClientCommand {
   performAction(callback) {
-    this.transportActions
-      .getAlertText(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.getAlertText(callback);
   }
 }
 

--- a/lib/api/client-commands/alerts/getText.js
+++ b/lib/api/client-commands/alerts/getText.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Get the text of the currently displayed JavaScript alert(), confirm(), or prompt() dialog.
@@ -28,8 +29,15 @@ const ProtocolAction = require('../_base-action.js');
  * @link /#get-alert-text
  * @api protocol.userprompts
  */
-module.exports = class Session extends ProtocolAction {
-  command(callback) {
-    return this.transportActions.getAlertText(callback);
+class GetAlertText extends ClientCommand {
+  performAction(callback) {
+    this.transportActions
+      .getAlertText(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+}
+
+module.exports = GetAlertText;

--- a/lib/api/client-commands/alerts/getText.js
+++ b/lib/api/client-commands/alerts/getText.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Get the text of the currently displayed JavaScript alert(), confirm(), or prompt() dialog.

--- a/lib/api/client-commands/alerts/setText.js
+++ b/lib/api/client-commands/alerts/setText.js
@@ -36,12 +36,7 @@ class SetAlertText extends ClientCommand {
   performAction(callback) {
     const {alertText} = this;
 
-    this.transportActions
-      .setAlertText(alertText, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.setAlertText(alertText, callback);
   }
 
   command(value, callback) {

--- a/lib/api/client-commands/alerts/setText.js
+++ b/lib/api/client-commands/alerts/setText.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Send keystrokes to a JavaScript prompt() dialog.
@@ -27,12 +28,31 @@ const ProtocolAction = require('../_base-action.js');
  * @link /#send-alert-text
  * @api protocol.userprompts
  */
-module.exports = class Session extends ProtocolAction {
+class SetAlertText extends ClientCommand {
   static get isTraceable() {
     return true;
   }
 
-  command(value, callback) {
-    return this.transportActions.setAlertText(value, callback);
+  performAction(callback) {
+    const {alertText} = this;
+
+    this.transportActions
+      .setAlertText(alertText, callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+
+  command(value, callback) {
+    if (typeof value !== 'string') {
+      throw new Error('First argument passed to .alerts.setText() must be a string.');
+    }
+
+    this.alertText = value;
+  
+    return super.command(callback);
+  }
+}
+
+module.exports = SetAlertText;

--- a/lib/api/client-commands/alerts/setText.js
+++ b/lib/api/client-commands/alerts/setText.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Send keystrokes to a JavaScript prompt() dialog.

--- a/lib/api/client-commands/captureBrowserConsoleLogs.js
+++ b/lib/api/client-commands/captureBrowserConsoleLogs.js
@@ -44,12 +44,7 @@ class StartCapturingLogs extends ClientCommand {
       return callback(error);
     }
     
-    this.transportActions
-      .startLogsCapture(userCallback, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.startLogsCapture(userCallback, callback);
   }
 
   command(userCallback, callback) {

--- a/lib/api/client-commands/captureBrowserExceptions.js
+++ b/lib/api/client-commands/captureBrowserExceptions.js
@@ -48,12 +48,7 @@ class CatchJsExceptions extends ClientCommand {
       return callback(error);
     }
 
-    this.transportActions
-      .catchJsExceptions(userCallback, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.catchJsExceptions(userCallback, callback);
   }
 
   command(userCallback, callback) {

--- a/lib/api/client-commands/captureNetworkRequests.js
+++ b/lib/api/client-commands/captureNetworkRequests.js
@@ -45,12 +45,7 @@ class CaptureNetworkCalls extends ClientCommand {
       return callback(error);
     }
     
-    this.transportActions
-      .interceptNetworkCalls(userCallback, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.interceptNetworkCalls(userCallback, callback);
   }
 
   command(userCallback, callback) {

--- a/lib/api/client-commands/cookies/delete.js
+++ b/lib/api/client-commands/cookies/delete.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Delete the cookie with the given name. This command is a no-op if there is no such cookie visible to the current page.

--- a/lib/api/client-commands/cookies/delete.js
+++ b/lib/api/client-commands/cookies/delete.js
@@ -36,12 +36,7 @@ class DeleteCookie extends ClientCommand {
   performAction(callback) {
     const {cookieName} = this;
 
-    this.transportActions
-      .deleteCookie(cookieName, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.deleteCookie(cookieName, callback);
   }
 
   command(cookieName, callback) {

--- a/lib/api/client-commands/cookies/deleteAll.js
+++ b/lib/api/client-commands/cookies/deleteAll.js
@@ -33,12 +33,7 @@ class DeleteCookies extends ClientCommand {
   }
 
   performAction(callback) {
-    this.transportActions
-      .deleteAllCookies(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.deleteAllCookies(callback);
   }
 }
 

--- a/lib/api/client-commands/cookies/deleteAll.js
+++ b/lib/api/client-commands/cookies/deleteAll.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Delete all cookies visible to the current page.

--- a/lib/api/client-commands/cookies/get.js
+++ b/lib/api/client-commands/cookies/get.js
@@ -39,12 +39,7 @@ class GetCookie extends ClientCommand {
   performAction(callback) {
     const {cookieName} = this;
 
-    this.transportActions
-      .getCookie(cookieName, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.getCookie(cookieName, callback);
   }
 
   command(name, callback) {

--- a/lib/api/client-commands/cookies/get.js
+++ b/lib/api/client-commands/cookies/get.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Retrieve a single cookie visible to the current page.

--- a/lib/api/client-commands/cookies/getAll.js
+++ b/lib/api/client-commands/cookies/getAll.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Retrieve all cookies visible to the current page.

--- a/lib/api/client-commands/cookies/getAll.js
+++ b/lib/api/client-commands/cookies/getAll.js
@@ -36,12 +36,7 @@ const {Logger} = require('../../../utils');
 
 class GetCookies extends ClientCommand {
   performAction(callback) {
-    this.transportActions
-      .getCookies(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.getCookies(callback);
   }
 }
 

--- a/lib/api/client-commands/cookies/set.js
+++ b/lib/api/client-commands/cookies/set.js
@@ -1,6 +1,5 @@
 const ClientCommand = require('../_base-command.js');
 const Utils = require('../../../utils/index.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Set a cookie, specified as a cookie JSON object, with properties as defined [here](https://www.w3.org/TR/webdriver/#dfn-table-for-cookie-conversion).

--- a/lib/api/client-commands/cookies/set.js
+++ b/lib/api/client-commands/cookies/set.js
@@ -48,12 +48,7 @@ class SetCookie extends ClientCommand {
   performAction(callback) {
     const {cookie} = this;
 
-    this.transportActions
-      .addCookie(cookie, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.addCookie(cookie, callback);
   }
 
   command(cookie, callback) {

--- a/lib/api/client-commands/document/injectScript.js
+++ b/lib/api/client-commands/document/injectScript.js
@@ -34,12 +34,7 @@ class InjectScript extends ClientCommand {
   performAction(callback) {
     const {scriptFn, scriptArgs} = this;
 
-    this.transportActions
-      .executeScript(scriptFn, scriptArgs, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.executeScript(scriptFn, scriptArgs, callback);
   }
 
   command(scriptUrl, id, callback) {

--- a/lib/api/client-commands/document/injectScript.js
+++ b/lib/api/client-commands/document/injectScript.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Utility command to load an external script into the page specified by url.

--- a/lib/api/client-commands/document/injectScript.js
+++ b/lib/api/client-commands/document/injectScript.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Utility command to load an external script into the page specified by url.
@@ -25,9 +26,20 @@ const ProtocolAction = require('../_base-action.js');
  * @returns {HTMLScriptElement} The newly created script tag.
  * @api protocol.document
  */
-module.exports = class InjectScript extends ProtocolAction {
+class InjectScript extends ClientCommand {
   static get isTraceable() {
     return true;
+  }
+
+  performAction(callback) {
+    const {scriptFn, scriptArgs} = this;
+
+    this.transportActions
+      .executeScript(scriptFn, scriptArgs, callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
 
   command(scriptUrl, id, callback) {
@@ -42,6 +54,12 @@ module.exports = class InjectScript extends ProtocolAction {
     // eslint-disable-next-line
     const script = function(u,i) {return (function(d){var e=d.createElement('script');var m=d.getElementsByTagName('head')[0];e.src=u;if(i){e.id=i;}m.appendChild(e);return e;})(document);};
 
-    return this.executeScriptHandler('executeScript', script, args, callback);
+    this.scriptFn = 'var passedArgs = Array.prototype.slice.call(arguments,0); return (' +
+      script.toString() + ').apply(window, passedArgs);';
+    this.scriptArgs = args; 
+
+    return super.command(callback);
   }
 };
+
+module.exports = InjectScript;

--- a/lib/api/client-commands/document/source.js
+++ b/lib/api/client-commands/document/source.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Get the string serialized source of the current page.

--- a/lib/api/client-commands/document/source.js
+++ b/lib/api/client-commands/document/source.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Get the string serialized source of the current page.
@@ -24,12 +25,19 @@ const ProtocolAction = require('../_base-action.js');
  * @link /#get-page-source
  * @api protocol.document
  */
-module.exports = class Source extends ProtocolAction {
+class Source extends ClientCommand {
   static get AliasName() {
     return 'pageSource';
   }
 
-  command(callback) {
-    return this.transportActions.getPageSource(callback);
+  performAction(callback) {
+    this.transportActions
+      .getPageSource(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+}
+
+module.exports = Source;

--- a/lib/api/client-commands/document/source.js
+++ b/lib/api/client-commands/document/source.js
@@ -31,12 +31,7 @@ class Source extends ClientCommand {
   }
 
   performAction(callback) {
-    this.transportActions
-      .getPageSource(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.getPageSource(callback);
   }
 }
 

--- a/lib/api/client-commands/enablePerformanceMetrics.js
+++ b/lib/api/client-commands/enablePerformanceMetrics.js
@@ -41,12 +41,7 @@ class EnablePerformanceMetrics extends ClientCommand {
 
     const {enable = true} = this;
     
-    this.transportActions
-      .enablePerformanceMetrics(enable, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.enablePerformanceMetrics(enable, callback);
   }
 
   command(enable, callback) {

--- a/lib/api/client-commands/getPerformanceMetrics.js
+++ b/lib/api/client-commands/getPerformanceMetrics.js
@@ -39,12 +39,7 @@ class GetPerformanceMetrics extends ClientCommand {
       return callback(error);
     }
     
-    this.transportActions
-      .getPerformanceMetrics(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.getPerformanceMetrics(callback);
   }
 
   command(callback) {

--- a/lib/api/client-commands/mockNetworkResponse.js
+++ b/lib/api/client-commands/mockNetworkResponse.js
@@ -50,12 +50,7 @@ class MockNetworkResponse extends ClientCommand {
       urlToIntercept = `${launchUrl}${slashDel}${urlToIntercept}`;
     }
     
-    this.transportActions
-      .mockNetworkResponse(urlToIntercept, response, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.mockNetworkResponse(urlToIntercept, response, callback);
   }
 
   command(urlToIntercept, response, callback) {

--- a/lib/api/client-commands/setDeviceDimensions.js
+++ b/lib/api/client-commands/setDeviceDimensions.js
@@ -49,12 +49,7 @@ class SetDeviceDimensions extends ClientCommand {
     const {width = 0, height = 0, deviceScaleFactor = 0, mobile = false} = this.metrics;
     const metrics = {width, height, deviceScaleFactor, mobile};
 
-    this.transportActions
-      .setDeviceMetrics(metrics, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.setDeviceMetrics(metrics, callback);
   }
 
   command(metrics, callback) {

--- a/lib/api/client-commands/setGeolocation.js
+++ b/lib/api/client-commands/setGeolocation.js
@@ -51,24 +51,14 @@ class SetGeolocation extends ClientCommand {
       // Set accuracy as 100 if not provided.
       if (accuracy === undefined) {coordinates.accuracy = 100}
 
-      this.transportActions
-        .setGeolocation(coordinates, callback)
-        .catch(err => {
-          Logger.error(err);
-          callback(err);
-        });
+      this.transportActions.setGeolocation(coordinates, callback);
 
       return;
     }
 
     if (latitude === undefined && longitude === undefined) {
       // Clear geolocation override.
-      this.transportActions
-        .clearGeolocation(callback)
-        .catch(err => {
-          Logger.error(err);
-          callback(err);
-        });
+      this.transportActions.clearGeolocation(callback);
 
       return;
     }

--- a/lib/api/client-commands/setNetworkConditions.js
+++ b/lib/api/client-commands/setNetworkConditions.js
@@ -24,7 +24,6 @@ const {Logger} = require('../../utils');
  */
 class SetNetworkConditions extends ClientCommand {
   performAction(callback) {
-
     if (!this.api.isChrome() && !this.api.isEdge()) {
       const error = new Error('SetNetworkConditions is not supported while using this driver');
       Logger.error(error);
@@ -34,14 +33,7 @@ class SetNetworkConditions extends ClientCommand {
 
     const {spec} = this;
 
-    this.transportActions
-      .setNetworkConditions(spec, callback)
-      .then((result) => {
-        callback(result);
-      })
-      .catch((err) => {
-        return err;
-      });
+    this.transportActions.setNetworkConditions(spec, callback);
   }
 
   command(spec, callback) {

--- a/lib/api/client-commands/takeHeapSnapshot.js
+++ b/lib/api/client-commands/takeHeapSnapshot.js
@@ -39,12 +39,7 @@ class TakeHeapSnapshot extends ClientCommand {
 
     const {heapSnapshotLocation} = this;
     
-    this.transportActions
-      .takeHeapSnapshot(heapSnapshotLocation, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.takeHeapSnapshot(heapSnapshotLocation, callback);
   }
 
   command(heapSnapshotLocation, callback) {

--- a/lib/api/client-commands/window/close.js
+++ b/lib/api/client-commands/window/close.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Close the current window or tab. This can be useful when you're working with multiple windows/tabs open (e.g. an OAuth login).
@@ -26,8 +27,15 @@ const ProtocolAction = require('../_base-action.js');
  * @see window.open
  * @api protocol.window
  */
-module.exports = class Action extends ProtocolAction {
-  command(callback) {
-    return this.transportActions.closeWindow(callback);
+class CloseWindow extends ClientCommand {
+  performAction(callback) {
+    this.transportActions
+      .closeWindow(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+}
+
+module.exports = CloseWindow;

--- a/lib/api/client-commands/window/close.js
+++ b/lib/api/client-commands/window/close.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Close the current window or tab. This can be useful when you're working with multiple windows/tabs open (e.g. an OAuth login).

--- a/lib/api/client-commands/window/close.js
+++ b/lib/api/client-commands/window/close.js
@@ -29,12 +29,7 @@ const {Logger} = require('../../../utils');
  */
 class CloseWindow extends ClientCommand {
   performAction(callback) {
-    this.transportActions
-      .closeWindow(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.closeWindow(callback);
   }
 }
 

--- a/lib/api/client-commands/window/fullscreen.js
+++ b/lib/api/client-commands/window/fullscreen.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Set the current window state to fullscreen, similar to pressing F11 in most browsers.

--- a/lib/api/client-commands/window/fullscreen.js
+++ b/lib/api/client-commands/window/fullscreen.js
@@ -27,12 +27,7 @@ const {Logger} = require('../../../utils');
  */
 class FullscreenWindow extends ClientCommand {
   performAction(callback) {
-    this.transportActions
-      .fullscreenWindow(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.fullscreenWindow(callback);
   }
 }
 

--- a/lib/api/client-commands/window/fullscreen.js
+++ b/lib/api/client-commands/window/fullscreen.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Set the current window state to fullscreen, similar to pressing F11 in most browsers.
@@ -24,8 +25,15 @@ const ProtocolAction = require('../_base-action.js');
  * @see window.minimize
  * @api protocol.window
  */
-module.exports = class Session extends ProtocolAction {
-  command(callback) {
-    return this.transportActions.fullscreenWindow(callback);
+class FullscreenWindow extends ClientCommand {
+  performAction(callback) {
+    this.transportActions
+      .fullscreenWindow(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+}
+
+module.exports = FullscreenWindow;

--- a/lib/api/client-commands/window/getAllHandles.js
+++ b/lib/api/client-commands/window/getAllHandles.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Retrieve the list of all window handles available to the session.

--- a/lib/api/client-commands/window/getAllHandles.js
+++ b/lib/api/client-commands/window/getAllHandles.js
@@ -29,12 +29,7 @@ const {Logger} = require('../../../utils');
  */
 class GetAllWindowHandles extends ClientCommand {
   performAction(callback) {
-    this.transportActions
-      .getAllWindowHandles(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.getAllWindowHandles(callback);
   }
 }
 

--- a/lib/api/client-commands/window/getAllHandles.js
+++ b/lib/api/client-commands/window/getAllHandles.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Retrieve the list of all window handles available to the session.
@@ -26,8 +27,15 @@ const ProtocolAction = require('../_base-action.js');
  * @link /#get-window-handles
  * @api protocol.window
  */
-module.exports = class Action extends ProtocolAction {
-  command(callback) {
-    return this.transportActions.getAllWindowHandles(callback);
+class GetAllWindowHandles extends ClientCommand {
+  performAction(callback) {
+    this.transportActions
+      .getAllWindowHandles(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+}
+
+module.exports = GetAllWindowHandles;

--- a/lib/api/client-commands/window/getHandle.js
+++ b/lib/api/client-commands/window/getHandle.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Retrieve the current window handle.

--- a/lib/api/client-commands/window/getHandle.js
+++ b/lib/api/client-commands/window/getHandle.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Retrieve the current window handle.
@@ -28,8 +29,15 @@ const ProtocolAction = require('../_base-action.js');
  * @see window.switchTo
  * @api protocol.window
  */
-module.exports = class Action extends ProtocolAction {
-  command(callback) {
-    return this.transportActions.getWindowHandle(callback);
+class GetWindowHandle extends ClientCommand {
+  performAction(callback) {
+    this.transportActions
+      .getWindowHandle(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+}
+
+module.exports = GetWindowHandle;

--- a/lib/api/client-commands/window/getHandle.js
+++ b/lib/api/client-commands/window/getHandle.js
@@ -31,12 +31,7 @@ const {Logger} = require('../../../utils');
  */
 class GetWindowHandle extends ClientCommand {
   performAction(callback) {
-    this.transportActions
-      .getWindowHandle(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.getWindowHandle(callback);
   }
 }
 

--- a/lib/api/client-commands/window/getPosition.js
+++ b/lib/api/client-commands/window/getPosition.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Get the coordinates of the top left corner of the current window.
@@ -25,8 +26,15 @@ const ProtocolAction = require('../_base-action.js');
  * @see window.getRect
  * @api protocol.window
  */
-module.exports = class Session extends ProtocolAction {
-  command(callback) {
-    return this.transportActions.getWindowPosition(callback);
+class GetWindowPosition extends ClientCommand {
+  performAction(callback) {
+    this.transportActions
+      .getWindowPosition(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+}
+
+module.exports = GetWindowPosition;

--- a/lib/api/client-commands/window/getPosition.js
+++ b/lib/api/client-commands/window/getPosition.js
@@ -28,12 +28,7 @@ const {Logger} = require('../../../utils');
  */
 class GetWindowPosition extends ClientCommand {
   performAction(callback) {
-    this.transportActions
-      .getWindowPosition(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.getWindowPosition(callback);
   }
 }
 

--- a/lib/api/client-commands/window/getPosition.js
+++ b/lib/api/client-commands/window/getPosition.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Get the coordinates of the top left corner of the current window.

--- a/lib/api/client-commands/window/getRect.js
+++ b/lib/api/client-commands/window/getRect.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Fetches the [window rect](https://w3c.github.io/webdriver/#dfn-window-rect) - size and position of the current window.
@@ -36,8 +37,15 @@ const ProtocolAction = require('../_base-action.js');
  * @see window.getSize
  * @api protocol.window
  */
-module.exports = class Session extends ProtocolAction {
-  command(callback) {
-    return this.transportActions.getWindowRect(callback);
+class GetWindowRect extends ClientCommand {
+  performAction(callback) {
+    this.transportActions
+      .getWindowRect(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+}
+
+module.exports = GetWindowRect;

--- a/lib/api/client-commands/window/getRect.js
+++ b/lib/api/client-commands/window/getRect.js
@@ -39,12 +39,7 @@ const {Logger} = require('../../../utils');
  */
 class GetWindowRect extends ClientCommand {
   performAction(callback) {
-    this.transportActions
-      .getWindowRect(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.getWindowRect(callback);
   }
 }
 

--- a/lib/api/client-commands/window/getRect.js
+++ b/lib/api/client-commands/window/getRect.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Fetches the [window rect](https://w3c.github.io/webdriver/#dfn-window-rect) - size and position of the current window.

--- a/lib/api/client-commands/window/getSize.js
+++ b/lib/api/client-commands/window/getSize.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Get the size of the current window in pixels.
@@ -25,8 +26,15 @@ const ProtocolAction = require('../_base-action.js');
  * @see window.getRect
  * @api protocol.window
  */
-module.exports = class Session extends ProtocolAction {
-  command(callback) {
-    return this.transportActions.getWindowSize(callback);
+class GetWindowSize extends ClientCommand {
+  performAction(callback) {
+    this.transportActions
+      .getWindowSize(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+}
+
+module.exports = GetWindowSize;

--- a/lib/api/client-commands/window/getSize.js
+++ b/lib/api/client-commands/window/getSize.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Get the size of the current window in pixels.

--- a/lib/api/client-commands/window/getSize.js
+++ b/lib/api/client-commands/window/getSize.js
@@ -28,12 +28,7 @@ const {Logger} = require('../../../utils');
  */
 class GetWindowSize extends ClientCommand {
   performAction(callback) {
-    this.transportActions
-      .getWindowSize(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.getWindowSize(callback);
   }
 }
 

--- a/lib/api/client-commands/window/maximize.js
+++ b/lib/api/client-commands/window/maximize.js
@@ -27,12 +27,7 @@ const {Logger} = require('../../../utils');
  */
 class MaximizeWindow extends ClientCommand {
   performAction(callback) {
-    this.transportActions
-      .maximizeWindow(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.maximizeWindow(callback);
   }
 }
 

--- a/lib/api/client-commands/window/maximize.js
+++ b/lib/api/client-commands/window/maximize.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Increases the window to the maximum available size without going full-screen.

--- a/lib/api/client-commands/window/maximize.js
+++ b/lib/api/client-commands/window/maximize.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Increases the window to the maximum available size without going full-screen.
@@ -24,8 +25,15 @@ const ProtocolAction = require('../_base-action.js');
  * @see window.fullscreen
  * @api protocol.window
  */
-module.exports = class Session extends ProtocolAction {
-  command(callback) {
-    return this.transportActions.maximizeWindow(callback);
+class MaximizeWindow extends ClientCommand {
+  performAction(callback) {
+    this.transportActions
+      .maximizeWindow(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+}
+
+module.exports = MaximizeWindow;

--- a/lib/api/client-commands/window/minimize.js
+++ b/lib/api/client-commands/window/minimize.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Hides the window in the system tray. If the window happens to be in fullscreen mode, it is restored the normal state then it will be "iconified" - minimize or hide the window from the visible screen.

--- a/lib/api/client-commands/window/minimize.js
+++ b/lib/api/client-commands/window/minimize.js
@@ -27,12 +27,7 @@ const {Logger} = require('../../../utils');
  */
 class MinimizeWindow extends ClientCommand {
   performAction(callback) {
-    this.transportActions
-      .minimizeWindow(callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.minimizeWindow(callback);
   }
 }
 

--- a/lib/api/client-commands/window/minimize.js
+++ b/lib/api/client-commands/window/minimize.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Hides the window in the system tray. If the window happens to be in fullscreen mode, it is restored the normal state then it will be "iconified" - minimize or hide the window from the visible screen.
@@ -24,8 +25,15 @@ const ProtocolAction = require('../_base-action.js');
  * @see window.fullscreen
  * @api protocol.window
  */
-module.exports = class Session extends ProtocolAction {
-  command(callback) {
-    return this.transportActions.minimizeWindow(callback);
+class MinimizeWindow extends ClientCommand {
+  performAction(callback) {
+    this.transportActions
+      .minimizeWindow(callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
-};
+}
+
+module.exports = MinimizeWindow;

--- a/lib/api/client-commands/window/open.js
+++ b/lib/api/client-commands/window/open.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Opens a new tab (default) or a separate new window, and changes focus to the newly opened tab/window.
@@ -38,7 +39,7 @@ const ProtocolAction = require('../_base-action.js');
  * @see window.switchTo
  * @api protocol.window
  */
-module.exports = class Session extends ProtocolAction {
+class OpenNewWindow extends ClientCommand {
   static get isTraceable() {
     return true;
   }
@@ -47,12 +48,27 @@ module.exports = class Session extends ProtocolAction {
     return 'openNew';
   }
 
+  performAction(callback) {
+    const {windowType} = this;
+
+    this.transportActions
+      .openNewWindow(windowType, callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
+  }
+
   command(type = 'tab', callback) {
     if (typeof type == 'function' && callback === undefined) {
       callback = arguments[0];
       type = 'tab';
     }
 
-    return this.transportActions.openNewWindow(type, callback);
+    this.windowType = type;
+
+    return super.command(callback);
   }
-};
+}
+
+module.exports = OpenNewWindow;

--- a/lib/api/client-commands/window/open.js
+++ b/lib/api/client-commands/window/open.js
@@ -51,12 +51,7 @@ class OpenNewWindow extends ClientCommand {
   performAction(callback) {
     const {windowType} = this;
 
-    this.transportActions
-      .openNewWindow(windowType, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.openNewWindow(windowType, callback);
   }
 
   command(type = 'tab', callback) {

--- a/lib/api/client-commands/window/open.js
+++ b/lib/api/client-commands/window/open.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Opens a new tab (default) or a separate new window, and changes focus to the newly opened tab/window.

--- a/lib/api/client-commands/window/setPosition.js
+++ b/lib/api/client-commands/window/setPosition.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Set the position of the current window - move the window to the chosen position.

--- a/lib/api/client-commands/window/setPosition.js
+++ b/lib/api/client-commands/window/setPosition.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Set the position of the current window - move the window to the chosen position.
@@ -27,12 +28,28 @@ const ProtocolAction = require('../_base-action.js');
  * @see window.setRect
  * @api protocol.window
  */
-module.exports = class Session extends ProtocolAction {
+class SetWIndowPosition extends ClientCommand {
+  performAction(callback) {
+    const {xOffset, yOffset} = this;
+
+    this.transportActions
+      .setWindowPosition(xOffset, yOffset, callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
+  }
+
   command(x, y, callback) {
     if (typeof x !== 'number' || typeof y !== 'number') {
       throw new Error('Coordinates passed to .window.getPosition() must be of type number.');
     }
 
-    return this.transportActions.setWindowPosition(x, y, callback);
+    this.xOffset = x;
+    this.yOffset = y;
+
+    return super.command(callback);
   }
-};
+}
+
+module.exports = SetWIndowPosition;

--- a/lib/api/client-commands/window/setPosition.js
+++ b/lib/api/client-commands/window/setPosition.js
@@ -32,12 +32,7 @@ class SetWIndowPosition extends ClientCommand {
   performAction(callback) {
     const {xOffset, yOffset} = this;
 
-    this.transportActions
-      .setWindowPosition(xOffset, yOffset, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.setWindowPosition(xOffset, yOffset, callback);
   }
 
   command(x, y, callback) {

--- a/lib/api/client-commands/window/setRect.js
+++ b/lib/api/client-commands/window/setRect.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 const Utils = require('../../../utils/index.js');
 
 /**

--- a/lib/api/client-commands/window/setRect.js
+++ b/lib/api/client-commands/window/setRect.js
@@ -1,5 +1,6 @@
-const ProtocolAction = require('../_base-action.js');
-const Utils = require('../../../utils');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
+const Utils = require('../../../utils/index.js');
 
 /**
  * Change the [window rect](https://w3c.github.io/webdriver/#dfn-window-rect) - size and position of the current window.
@@ -44,7 +45,18 @@ const Utils = require('../../../utils');
  * @see window.setSize
  * @api protocol.window
  */
-module.exports = class Session extends ProtocolAction {
+class SetWindowRect extends ClientCommand {
+  performAction(callback) {
+    const {windowOptions} = this;
+
+    this.transportActions
+      .setWindowRect(windowOptions, callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
+  }
+
   command(options, callback) {
     const {width, height, x, y} = options;
 
@@ -78,6 +90,10 @@ module.exports = class Session extends ProtocolAction {
       }
     }
 
-    return this.transportActions.setWindowRect(options, callback);
+    this.windowOptions = options;
+
+    return super.command(callback);
   }
-};
+}
+
+module.exports = SetWindowRect;

--- a/lib/api/client-commands/window/setRect.js
+++ b/lib/api/client-commands/window/setRect.js
@@ -49,12 +49,7 @@ class SetWindowRect extends ClientCommand {
   performAction(callback) {
     const {windowOptions} = this;
 
-    this.transportActions
-      .setWindowRect(windowOptions, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.setWindowRect(windowOptions, callback);
   }
 
   command(options, callback) {

--- a/lib/api/client-commands/window/setSize.js
+++ b/lib/api/client-commands/window/setSize.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Set the size of the current window in CSS pixels.
@@ -25,9 +26,20 @@ const ProtocolAction = require('../_base-action.js');
  * @see window.setRect
  * @api protocol.window
  */
-module.exports = class Session extends ProtocolAction {
+class SetWindowSize extends ClientCommand {
   static get AliasName() {
     return 'resize';
+  }
+
+  performAction(callback) {
+    const {width, height} = this;
+
+    this.transportActions
+      .setWindowSize(width, height, callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
   }
 
   command(width, height, callback) {
@@ -35,6 +47,11 @@ module.exports = class Session extends ProtocolAction {
       throw new Error('First two arguments passed to .window.getPosition() must be of type number.');
     }
 
-    return this.transportActions.setWindowSize(width, height, callback);
+    this.width = width;
+    this.height = height;
+
+    return super.command(callback);
   }
-};
+}
+
+module.exports = SetWindowSize;

--- a/lib/api/client-commands/window/setSize.js
+++ b/lib/api/client-commands/window/setSize.js
@@ -34,12 +34,7 @@ class SetWindowSize extends ClientCommand {
   performAction(callback) {
     const {width, height} = this;
 
-    this.transportActions
-      .setWindowSize(width, height, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.setWindowSize(width, height, callback);
   }
 
   command(width, height, callback) {

--- a/lib/api/client-commands/window/setSize.js
+++ b/lib/api/client-commands/window/setSize.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Set the size of the current window in CSS pixels.

--- a/lib/api/client-commands/window/switchTo.js
+++ b/lib/api/client-commands/window/switchTo.js
@@ -85,12 +85,7 @@ class SwitchToWindow extends ClientCommand {
   performAction(callback) {
     const {windowHandle} = this;
 
-    this.transportActions
-      .switchToWindow(windowHandle, callback)
-      .catch(err => {
-        Logger.error(err);
-        callback(err);
-      });
+    this.transportActions.switchToWindow(windowHandle, callback);
   }
 
   command(windowHandle, callback) {

--- a/lib/api/client-commands/window/switchTo.js
+++ b/lib/api/client-commands/window/switchTo.js
@@ -1,4 +1,5 @@
-const ProtocolAction = require('../_base-action.js');
+const ClientCommand = require('../_base-command.js');
+const {Logger} = require('../../../utils');
 
 /**
  * Change focus to another window.
@@ -72,7 +73,7 @@ const ProtocolAction = require('../_base-action.js');
  * @link /#switch-to-window
  * @api protocol.window
  */
-module.exports = class Action extends ProtocolAction {
+class SwitchToWindow extends ClientCommand {
   static get isTraceable() {
     return true;
   }
@@ -81,11 +82,26 @@ module.exports = class Action extends ProtocolAction {
     return 'switch';
   }
 
+  performAction(callback) {
+    const {windowHandle} = this;
+
+    this.transportActions
+      .switchToWindow(windowHandle, callback)
+      .catch(err => {
+        Logger.error(err);
+        callback(err);
+      });
+  }
+
   command(windowHandle, callback) {
     if (typeof windowHandle !== 'string') {
       throw new Error(`windowHandle argument passed to .window.switchTo() must be a string; received: ${typeof windowHandle} (${windowHandle}).`);
     }
 
-    return this.transportActions.switchToWindow(windowHandle, callback);
+    this.windowHandle = windowHandle;
+
+    return super.command(callback);
   }
-};
+}
+
+module.exports = SwitchToWindow;

--- a/lib/api/client-commands/window/switchTo.js
+++ b/lib/api/client-commands/window/switchTo.js
@@ -1,5 +1,4 @@
 const ClientCommand = require('../_base-command.js');
-const {Logger} = require('../../../utils');
 
 /**
  * Change focus to another window.

--- a/lib/api/protocol/windowRect.js
+++ b/lib/api/protocol/windowRect.js
@@ -22,13 +22,13 @@ const ProtocolAction = require('./_base-action.js');
  *      browser.windowRect({width: 600, height: 300});
  *
  *      // Retrieve the attributes
- *      browser.windowRect(function(result) {
+ *      browser.windowRect(null, function(result) {
  *        console.log(result.value);
  *      });
  *   },
  *
  *   'windowRect ES6 demo test': async function(browser) {
- *      const resultValue = await browser.windowRect();
+ *      const resultValue = await browser.windowRect(null);
  *      console.log('result value', resultValue);
  *   }
  * }

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -310,6 +310,10 @@ class NightwatchClient extends EventEmitter {
                 }
 
                 return newResult;
+              })
+              .catch(err => {
+                Logger.error(err);
+                callback(err);
               });
           }
 

--- a/lib/page-object/command-wrapper.js
+++ b/lib/page-object/command-wrapper.js
@@ -1,8 +1,13 @@
 const Element = require('../element');
 const Utils = require('../utils');
 
-function isValidAssertion(commandName) {
-  return ['assert', 'verify', 'expect'].indexOf(commandName) > -1;
+const ALLOWED_NAMESPACES = [
+  'alerts', 'cookies', 'document',
+  'assert', 'verify', 'expect'
+];
+
+function isAllowedNamespace(commandName) {
+  return ALLOWED_NAMESPACES.indexOf(commandName) > -1;
 }
 
 class Command {
@@ -292,22 +297,27 @@ class CommandLoader {
    */
   static applyCommandsToTarget(parent, target, commands) {
     Object.keys(commands).forEach(function(commandName) {
-      if (isValidAssertion(commandName)) {
+      if (isAllowedNamespace(commandName)) {
         target[commandName] = target[commandName] || {};
 
         const isChaiAssertion = commandName === 'expect';
-        const assertions = commands[commandName];
+        const namespace = commands[commandName];
 
-        Object.keys(assertions).forEach(function(assertionName) {
-          target[commandName][assertionName] = CommandLoader.addCommand({
+        Object.keys(namespace).forEach(function(nsCommandName) {
+          target[commandName][nsCommandName] = CommandLoader.addCommand({
             target: target[commandName],
-            commandFn: assertions[assertionName],
-            commandName: assertionName,
+            commandFn: namespace[nsCommandName],
+            commandName: nsCommandName,
             parent,
             isChaiAssertion
           });
         });
       } else {
+        // don't load namespaces here, otherwise they'll be wrapped by a function.
+        if (Utils.isObject(commands[commandName])) {
+          return;
+        }
+
         target[commandName] = CommandLoader.addCommand({
           target,
           commandFn: commands[commandName],

--- a/lib/page-object/index.js
+++ b/lib/page-object/index.js
@@ -56,16 +56,13 @@ class Page extends BaseObject {
     CommandWrapper.addWrappedCommands(this, this.commandLoader);
     CommandWrapper.wrapProtocolCommands(this, this.api, BaseObject.WrappedProtocolCommands);
 
-    ['element', 'alerts', 'document'].forEach((command) => {
-      Object.defineProperty(this, command, {
-        get() {
-          return this.api[command];
-        },
-        enumerable: true,
-        configurable: false
-      });
+    Object.defineProperty(this, 'element', {
+      get() {
+        return this.api.element;
+      },
+      enumerable: true,
+      configurable: false
     });
-
   }
 
   get api() {

--- a/test/src/api/protocol/testAlerts.js
+++ b/test/src/api/protocol/testAlerts.js
@@ -120,11 +120,32 @@ describe('alert commands', function () {
       assertion: function (value) {
         assert.strictEqual(value, text);
       },
-      commandName: 'setAlertText',
+      commandName: 'alerts.setText',
       args: [text]
     }).then((result) => {
       assert.strictEqual(result.value, null);
       assert.strictEqual(result.status, 0);
+    }).catch(err => {
+      return err;
+    }).then(err => {
+      done(err);
+    });
+  });
+
+  it('test alerts.setText() with error', function (done) {
+    const text = 2;
+
+    Globals.protocolTest({
+      assertion: function (value) {
+        assert.strictEqual(value, text);
+      },
+      commandName: 'alerts.setText',
+      args: [text]
+    }).catch(err => {
+      assert.strictEqual(
+        err.message,
+        'Error while running "alerts.setText" command: First argument passed to .alerts.setText() must be a string.'
+      );
     }).catch(err => {
       return err;
     }).then(err => {


### PR DESCRIPTION
This PR migrate all the new namespaces from `protocol` to `client-commands` so that they are directly available on page-objects.