### PR TITLE
Fix element api support in POM.

### DIFF
--- a/lib/api/web-element/element-locator.js
+++ b/lib/api/web-element/element-locator.js
@@ -3,6 +3,7 @@ const {By, RelativeBy} = require('selenium-webdriver');
 const Utils = require('../../utils');
 const Element = require('../../element/index.js');
 const Locator = require('../../element/locator.js');
+const NightwatchLocator = require('../../element/locator-factory');
 
 class ElementLocator {
   constructor(selector, options = {}) {
@@ -74,8 +75,12 @@ class ElementLocator {
   static getCondition(element, strategy) {
     const locateStrategy = ElementLocator.getLocateStrategy(element, strategy);
 
-    if (element instanceof By || element instanceof RelativeBy || element instanceof Element) {
+    if (element instanceof By || element instanceof RelativeBy) {
       return element;
+    }
+
+    if (element instanceof Element) {
+      return NightwatchLocator.create(element);
     }
 
     if (!ElementLocator.isElementDescriptor(element)) {


### PR DESCRIPTION
This PR fixes the issue with `pageObject.element('@someElement')`. The problem was that the `condition` should be an instance of `By` or `RelativeBy` as it is directly passed to Selenium methods, but it was an instance of `Element` in case of page object.