### PR TITLE
Added a fix for too many error messages on a single failure in windowPosition

### DIFF
--- a/lib/api/_loaders/command.js
+++ b/lib/api/_loaders/command.js
@@ -191,7 +191,10 @@ class CommandLoader extends BaseCommandLoader {
 
             if (!['NightwatchAssertError', 'NightwatchMountError', 'TestingLibraryError'].includes(err.name)) {
               Logger.error(err);
-              instance.client.reporter.registerTestError(err);
+
+              if (err.detailedLogging) {
+                instance.client.reporter.registerTestError(err);
+              }
             }
 
             return err;

--- a/lib/api/protocol/windowPosition.js
+++ b/lib/api/protocol/windowPosition.js
@@ -31,12 +31,16 @@ const ProtocolAction = require('./_base-action.js');
 module.exports = class Session extends ProtocolAction {
   command(windowHandle, offsetX, offsetY, callback) {
     if (typeof windowHandle !== 'string') {
-      throw new Error('First argument must be a window handle string.');
+      const err = new Error('First argument must be a window handle string.');
+      err.detailedLogging = false;
+      throw err;
     }
 
     if (arguments.length <= 2) {
       if (typeof arguments[1] != 'function') {
-        throw new Error(`Second argument passed to .windowPosition() should be a callback when not passing offsetX and offsetY - ${typeof arguments[1]} given.`);
+        const err = new Error(`Second argument passed to .windowPosition() should be a callback when not passing offsetX and offsetY - ${typeof arguments[1]} given.`);
+        err.detailedLogging = false;
+        throw err;
       }
 
       return this.transportActions.getWindowPosition(windowHandle, arguments[1]);
@@ -46,11 +50,15 @@ module.exports = class Session extends ProtocolAction {
     offsetY = Number(offsetY);
 
     if (typeof offsetX !== 'number' || isNaN(offsetX)) {
-      throw new Error('offsetX argument passed to .windowPosition() must be a number.');
+      const err = new Error('offsetX argument passed to .windowPosition() must be a number.');
+      err.detailedLogging = false;
+      throw err;
     }
 
     if (typeof offsetY !== 'number' || isNaN(offsetY)) {
-      throw new Error('offsetY argument passed to .windowPosition() must be a number.');
+      const err = new Error('offsetY argument passed to .windowPosition() must be a number.');
+      err.detailedLogging = false;
+      throw err;
     }
 
     return this.transportActions.setWindowPosition(offsetX, offsetY, callback);


### PR DESCRIPTION
Ideally, the implementation of this fix should apply universally across all of Nightwatch after creating an error wrapper. However, at present, I am only focusing on resolving the #3631 bug.

### Result 
<img width="541" alt="Screenshot 2023-04-13 at 3 06 57 AM" src="https://user-images.githubusercontent.com/94462364/231591464-2b833ee6-3ba9-4e6e-9043-3b53908ece2b.png">
