### PR TITLE
Always throw uncaught exceptions

### DIFF
--- a/lib/runner/process-listener.js
+++ b/lib/runner/process-listener.js
@@ -80,7 +80,10 @@ module.exports = class {
   }
 
   uncaught(err, {type = 'uncaughtException'} = {}) {
-    console.error(`${type}: ${err.message}\n${err.stack}`);
+    Logger.setOutputEnabled(true); // force log for uncaught exception
+    Logger.enable();
+
+    Logger.error(`${type}: ${err.message}\n${err.stack}`);
     analyticsCollector.exception(err);
 
     if (['TimeoutError', 'NoSuchElementError'].includes(err.name) && this.testRunner.type !== 'cucumber') {

--- a/lib/runner/process-listener.js
+++ b/lib/runner/process-listener.js
@@ -80,7 +80,7 @@ module.exports = class {
   }
 
   uncaught(err, {type = 'uncaughtException'} = {}) {
-    Logger.error(`${type}: ${err.message}\n${err.stack}`);
+    console.error(`${type}: ${err.message}\n${err.stack}`);
     analyticsCollector.exception(err);
 
     if (['TimeoutError', 'NoSuchElementError'].includes(err.name) && this.testRunner.type !== 'cucumber') {


### PR DESCRIPTION
While running unit tests on nightwatch, a lot of times the process exits abruptly without showing any errors. This happens mostly due to uncaught exceptions within nightwatch which kiss the process. 
I am updating the log line here so that such uncaught exceptions gets printed regardless of logger settings.
