### PR TITLE
Skipped tests have categorized as either user-marked or runtime-failed

### DIFF
--- a/lib/reporter/base-reporter.js
+++ b/lib/reporter/base-reporter.js
@@ -11,7 +11,7 @@ module.exports = class BaseReporter {
 
   adaptAssertions(module) {
     module.completed = Object.keys(module.completed).reduce(function(prev, item) {
-      if (module.skippedAtRuntime.includes(item) || module.skippedByUser.includes(item)) {
+      if ((module.skippedAtRuntime && module.skippedAtRuntime.includes(item)) || (module.skippedByUser && module.skippedByUser.includes(item))) {
         return prev;
       }
 

--- a/lib/reporter/base-reporter.js
+++ b/lib/reporter/base-reporter.js
@@ -11,7 +11,7 @@ module.exports = class BaseReporter {
 
   adaptAssertions(module) {
     module.completed = Object.keys(module.completed).reduce(function(prev, item) {
-      if (module.skipped.includes(item)) {
+      if (module.skippedAtRuntime.includes(item) || module.skippedByUser.includes(item)) {
         return prev;
       }
 
@@ -39,8 +39,18 @@ module.exports = class BaseReporter {
     }, {});
 
     module.completedSections = Object.keys(module.completedSections).reduce(function(prev, item) {
-      if (module.skipped && module.skipped.includes(item)) {
-        return prev;
+      if (module.skippedAtRuntime && module.skippedAtRuntime.includes(item)) {
+        return {
+          status: 'skipped',
+          runtimeSkips: true
+        };
+      }
+
+      if (module.skippedByUser && module.skippedByUser.includes(item)) {
+        return {
+          status: 'skipped',
+          runtimeSkips: true
+        };
       }
 
       const testcase = module.completedSections[item];

--- a/lib/reporter/base-reporter.js
+++ b/lib/reporter/base-reporter.js
@@ -39,18 +39,10 @@ module.exports = class BaseReporter {
     }, {});
 
     module.completedSections = Object.keys(module.completedSections).reduce(function(prev, item) {
-      if (module.skippedAtRuntime && module.skippedAtRuntime.includes(item)) {
-        return {
-          status: 'skipped',
-          runtimeSkips: true
-        };
-      }
-
-      if (module.skippedByUser && module.skippedByUser.includes(item)) {
-        return {
-          status: 'skipped',
-          runtimeSkips: true
-        };
+      if ((module.skippedAtRuntime && module.skippedAtRuntime.includes(item)) || 
+          (module.skippedByUser && module.skippedByUser.includes(item))
+      ) {
+        return prev;
       }
 
       const testcase = module.completedSections[item];

--- a/lib/reporter/base-reporter.js
+++ b/lib/reporter/base-reporter.js
@@ -11,7 +11,7 @@ module.exports = class BaseReporter {
 
   adaptAssertions(module) {
     module.completed = Object.keys(module.completed).reduce(function(prev, item) {
-      if ((module.skippedAtRuntime && module.skippedAtRuntime.includes(item)) || (module.skippedByUser && module.skippedByUser.includes(item))) {
+      if ((module.skipped.includes(item))) {
         return prev;
       }
 

--- a/lib/reporter/base-reporter.js
+++ b/lib/reporter/base-reporter.js
@@ -11,7 +11,7 @@ module.exports = class BaseReporter {
 
   adaptAssertions(module) {
     module.completed = Object.keys(module.completed).reduce(function(prev, item) {
-      if ((module.skipped.includes(item))) {
+      if ((module.skipped && module.skipped.includes(item))) {
         return prev;
       }
 

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -22,12 +22,12 @@ class Reporter extends SimplifiedReporter {
    * @param {Object} settings
    * @param {Object} addOpts
    */
-  constructor({settings, tests, suiteRetries, addOpts = {}}) {
+  constructor({settings, tests, suiteRetries, addOpts = {}, skippedTests, allScreenedTests}) {
     super(settings);
 
     this.suiteRetries = suiteRetries;
     this.suiteName = addOpts.suiteName;
-    this.testResults = new TestResults(tests, addOpts, settings);
+    this.testResults = new TestResults(tests, addOpts, settings, skippedTests, allScreenedTests);
     this.currentContext = null;
     this.__printA11Report = false;
     this.reporter = addOpts.repoter;

--- a/lib/reporter/reporters/html.js
+++ b/lib/reporter/reporters/html.js
@@ -202,10 +202,19 @@ class HtmlReporter extends BaseReporter {
       }
     }
 
-    // Add skipped tests in completed section
-    for (const skippedTestName of module.skipped) {
+    // Add skipped tests by user in completed section
+    for (const skippedTestName of module.skippedByUser) {
       module.completedSections[skippedTestName] = {
-        status: 'skip'
+        status: 'skip',
+        userSkips: true
+      };
+    }
+
+    // Add skipped tests at runtime in completed section
+    for (const skippedTestName of module.skippedAtRuntime) {
+      module.completedSections[skippedTestName] = {
+        status: 'skip',
+        runtimeSkips: true
       };
     }
 

--- a/lib/reporter/reporters/html.js
+++ b/lib/reporter/reporters/html.js
@@ -203,20 +203,20 @@ class HtmlReporter extends BaseReporter {
     }
 
     // Add skipped tests by user in completed section
-    for (const skippedTestName of module.skippedByUser) {
+    module.skippedByUser && module.skippedByUser.forEach(skippedTestName => {
       module.completedSections[skippedTestName] = {
         status: 'skip',
         userSkips: true
       };
-    }
+    });
 
     // Add skipped tests at runtime in completed section
-    for (const skippedTestName of module.skippedAtRuntime) {
+    module.skippedAtRuntime && module.skippedAtRuntime.forEach(skippedTestName => {
       module.completedSections[skippedTestName] = {
         status: 'skip',
         runtimeSkips: true
       };
-    }
+    });
 
     return result;
   }

--- a/lib/reporter/reporters/html.js
+++ b/lib/reporter/reporters/html.js
@@ -214,7 +214,7 @@ class HtmlReporter extends BaseReporter {
     module.skippedAtRuntime && module.skippedAtRuntime.forEach(skippedTestName => {
       module.completedSections[skippedTestName] = {
         status: 'skip',
-        runtimeSkips: true
+        runtimeFailure: true
       };
     });
 

--- a/lib/reporter/reporters/html.js
+++ b/lib/reporter/reporters/html.js
@@ -206,7 +206,7 @@ class HtmlReporter extends BaseReporter {
     module.skippedByUser && module.skippedByUser.forEach(skippedTestName => {
       module.completedSections[skippedTestName] = {
         status: 'skip',
-        userSkips: true
+        runtimeFailure: false
       };
     });
 

--- a/lib/reporter/reporters/junit.xml.ejs
+++ b/lib/reporter/reporters/junit.xml.ejs
@@ -4,7 +4,7 @@
             tests="<%= module.tests %>">
 
   <testsuite name="<%= className %>"
-    errors="<%= module.errors %>" failures="<%= module.failures %>" hostname="" id="" package="<%= module.group || moduleName %>" skipped="<%= (Array.isArray(module.skipped)) ? module.skipped.length : 0 %>"
+    errors="<%= module.errors %>" failures="<%= module.failures %>" hostname="" id="" package="<%= module.group || moduleName %>" skipped="<%= (Array.isArray(module.skippedAtRuntime)) ? module.skippedAtRuntime.length : 0 %>"
     tests="<%= module.tests %>" time="<%= module.time %>" timestamp="<%= module.timestamp %>">
   <% for (var item in module.completed) {
     var testcase = module.completed[item];
@@ -34,10 +34,10 @@
       <%= module.lastError.stack %>
       ]]></error>  <% } %>
 
-  <% if (module.skipped && (module.skipped.length > 0)) { %>
-    <% for (var j = 0; j < module.skipped.length; j++) { %>
+  <% if (module.skippedAtRuntime && (module.skippedAtRuntime.length > 0)) { %>
+    <% for (var j = 0; j < module.skippedAtRuntime.length; j++) { %>
     <testcase
-      name="<%= module.skipped[j] %>" classname="<%= className %>">
+      name="<%= module.skippedAtRuntime[j] %>" classname="<%= className %>">
       <skipped />
     </testcase>
     <% } %>

--- a/lib/reporter/results.js
+++ b/lib/reporter/results.js
@@ -215,6 +215,7 @@ module.exports = class Results {
     suiteResults.results.lastError = lastError;
     suiteResults.results.skippedAtRuntime = this.skipped;
     suiteResults.results.skippedByUser = this.skippedByUser;
+    suiteResults.results.skipped = [...this.skipped, ...this.skippedByUser];
     suiteResults.results.time = this.time;
     suiteResults.results.timeMs = this.timeMs;
     suiteResults.results.completed = this.testcases;

--- a/lib/reporter/results.js
+++ b/lib/reporter/results.js
@@ -18,7 +18,7 @@ module.exports = class Results {
 
   constructor(tests = [], opts, settings, skippedTests=[], allScreenedTests=[]) {
     this.skippedByUser = skippedTests;
-    this.skipped = tests.slice(0);
+    this.skippedAtRuntime = tests.slice(0);
     this.testcases = {};
     this.testSections = {};
     this.suiteName = opts.suiteName;
@@ -79,7 +79,7 @@ module.exports = class Results {
     const currentTest = this.testcases[testName];
 
     if (returnFullResult) {
-      currentTest.steps = this.skipped;
+      currentTest.steps = this.skippedAtRuntime;
       currentTest.stackTrace = this.stackTrace;
       currentTest.testcases = Object.keys(this.testcases).reduce((prev, key) => {
         prev[key] = Object.keys(this.testcases[key]).reduce((prevVal, prop) => {
@@ -213,9 +213,9 @@ module.exports = class Results {
     }
 
     suiteResults.results.lastError = lastError;
-    suiteResults.results.skippedAtRuntime = this.skipped;
+    suiteResults.results.skippedAtRuntime = this.skippedAtRuntime;
     suiteResults.results.skippedByUser = this.skippedByUser;
-    suiteResults.results.skipped = [...this.skipped, ...this.skippedByUser];
+    suiteResults.results.skipped = [...this.skippedAtRuntime, ...this.skippedByUser];
     suiteResults.results.time = this.time;
     suiteResults.results.timeMs = this.timeMs;
     suiteResults.results.completed = this.testcases;
@@ -447,9 +447,9 @@ module.exports = class Results {
     this.currentTestName = testName;
     this.testcases[testName] = this.createTestCaseResults(testcase);
 
-    const index = this.skipped.indexOf(testName);
+    const index = this.skippedAtRuntime.indexOf(testName);
     if (index > -1) {
-      this.skipped.splice(index, 1);
+      this.skippedAtRuntime.splice(index, 1);
       this.__skippedCount -= 1;
     }
 

--- a/lib/reporter/results.js
+++ b/lib/reporter/results.js
@@ -16,7 +16,8 @@ module.exports = class Results {
     return 'skip';
   }
 
-  constructor(tests = [], opts, settings) {
+  constructor(tests = [], opts, settings, skippedTests=[], allScreenedTests=[]) {
+    this.skippedByUser = skippedTests;
     this.skipped = tests.slice(0);
     this.testcases = {};
     this.testSections = {};
@@ -50,7 +51,7 @@ module.exports = class Results {
     const {webdriver = {}} = settings;
     this.host = webdriver.host || '';
 
-    this.initCount(tests);
+    this.initCount(allScreenedTests);
   }
 
   get initialResult() {
@@ -212,7 +213,8 @@ module.exports = class Results {
     }
 
     suiteResults.results.lastError = lastError;
-    suiteResults.results.skipped = this.skipped;
+    suiteResults.results.skippedAtRuntime = this.skipped;
+    suiteResults.results.skippedByUser = this.skippedByUser;
     suiteResults.results.time = this.time;
     suiteResults.results.timeMs = this.timeMs;
     suiteResults.results.completed = this.testcases;
@@ -377,11 +379,11 @@ module.exports = class Results {
     return this;
   }
   
-  initCount(tests) {
+  initCount(allScreenedTests) {
     this.__passedCount = 0;
     this.__failedCount = 0;
     this.__errorsCount = 0;
-    this.__skippedCount = tests.length;
+    this.__skippedCount = allScreenedTests.length;
     this.__testsCount = 0;
     this.__timestamp = new Date().toUTCString();
     this.errmessages = [];

--- a/lib/reporter/summary.js
+++ b/lib/reporter/summary.js
@@ -98,10 +98,19 @@ module.exports = class Summary {
    * @param {object} testSuite
    */
   static printSkipped(testSuite) {
-    if (testSuite.skipped.length > 0) {
+    if (testSuite.skippedAtRuntime.length > 0) {
       // eslint-disable-next-line no-console
-      console.log(colors.cyan('    SKIPPED:'));
-      testSuite.skipped.forEach(function(testcase) {
+      console.log(colors.cyan('    SKIPPED (at runtime):'));
+      testSuite.skippedAtRuntime.forEach(function(testcase) {
+        // eslint-disable-next-line no-console
+        console.log(`    - ${testcase}`);
+      });
+    }
+
+    if (testSuite.skippedByUser.length > 0) {
+      // eslint-disable-next-line no-console
+      console.log(colors.cyan('    SKIPPED (by user):'));
+      testSuite.skippedByUser.forEach(function(testcase) {
         // eslint-disable-next-line no-console
         console.log(`    - ${testcase}`);
       });

--- a/lib/testsuite/context.js
+++ b/lib/testsuite/context.js
@@ -74,6 +74,8 @@ class Context extends EventEmitter {
 
     this.__hooks = [];
     this.__testcases = [];
+    this.__skippedTestCases = [];
+    this.__allScreenedTests = [];
     this.__contextBinding = {};
 
     this.__transforms = client ? await client.transforms : [];
@@ -136,6 +138,22 @@ class Context extends EventEmitter {
 
   set tests(value) {
     this.__testcases = value;
+  }
+
+  get skippedTests() {
+    return this.__skippedTestCases;
+  }
+
+  set skippedTests(value) {
+    this.__skippedTestCases = value;
+  }
+
+  get allScreenedTests() {
+    return this.__allScreenedTests;
+  }
+
+  set allScreenedTests(value) {
+    this.__allScreenedTests = value;
   }
 
   get hooks() {
@@ -297,11 +315,20 @@ class Context extends EventEmitter {
     // TODO: warn if test name already exists
     if (!skipTest) {
       this.tests.push(testName);
+    } else {
+      this.skippedTests.push(testName);
     }
+
     this.addTestSuiteMethod(testName, testFn, describeInstance);
     if (runOnly) {
       this.__currentTestName = testName;
+      this.skippedTests = [...this.allScreenedTests];
+      this.runOnly = true;
+    } else if(this.runOnly) {
+      this.skippedTests.push(testName);
     }
+
+    this.allScreenedTests.push(testName);
   }
 
   /**

--- a/lib/testsuite/context.js
+++ b/lib/testsuite/context.js
@@ -324,7 +324,7 @@ class Context extends EventEmitter {
       this.__currentTestName = testName;
       this.skippedTests = [...this.allScreenedTests];
       this.runOnly = true;
-    } else if(this.runOnly) {
+    } else if (this.runOnly) {
       this.skippedTests.push(testName);
     }
 

--- a/lib/testsuite/index.js
+++ b/lib/testsuite/index.js
@@ -215,7 +215,7 @@ class TestSuite {
     }
 
     const {suiteRetries, suiteName} = this;
-    const {tests, moduleKey, modulePath, groupName} = this.context;
+    const {tests, moduleKey, modulePath, groupName, skippedTests, allScreenedTests} = this.context;
 
     this.reporter = new Reporter({
       settings: this.client.settings,
@@ -230,7 +230,9 @@ class TestSuite {
         reportFileName: this.argv['report-filename'],
         groupName,
         isMobile: this.client.api.isMobile()
-      }
+      },
+      skippedTests,
+      allScreenedTests
     });
   }
 

--- a/test/extra/reportObject.js
+++ b/test/extra/reportObject.js
@@ -12,7 +12,7 @@ module.exports = {
       reportPrefix: 'FIREFOX_111.0.1__',
       assertionsCount: 1,
       lastError: null,
-      skipped: [
+      skippedAtRuntime: [
       ],
       time: '1.082',
       timeMs: 1082,
@@ -507,7 +507,7 @@ module.exports = {
         abortOnFailure: true,
         stack: '+ actual - expected\n\n  [\n+   \'abortOnFailure\'\n-   \'documents\',\n-   \'strings\'\n  ]\n    at Assertion.assert (/Users/vaibhavsingh/Dev/nightwatch/lib/api/_loaders/static.js:112:34)\n    at StaticAssert.assertFn (/Users/vaibhavsingh/Dev/nightwatch/lib/api/_loaders/static.js:146:17)\n    at Proxy.<anonymous> (/Users/vaibhavsingh/Dev/nightwatch/lib/api/index.js:157:30)\n    at DescribeInstance.<anonymous> (/Users/vaibhavsingh/Dev/nightwatch/examples/tests/chromeCDP_example.js:10:20)'
       },
-      skipped: [
+      skippedAtRuntime: [
       ],
       time: '4.669',
       timeMs: 4669,
@@ -919,7 +919,7 @@ module.exports = {
       reportPrefix: 'FIREFOX_111.0.1__',
       assertionsCount: 2,
       lastError: null,
-      skipped: [
+      skippedAtRuntime: [
       ],
       time: '1.908',
       timeMs: 1908,
@@ -1477,7 +1477,7 @@ module.exports = {
         waitFor: true,
         stack: 'Error\n    at DescribeInstance.<anonymous> (/Users/vaibhavsingh/Dev/nightwatch/examples/tests/duckDuckGo.js:8:8)\n    at Context.call (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/context.js:478:35)\n    at TestCase.run (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/testcase.js:58:31)\n    at Runnable.__runFn (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:759:80)\n    at Runnable.run (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/runnable.js:126:21)\n    at TestSuite.executeRunnable (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:912:49)\n    at TestSuite.handleRunnable (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:927:33)\n    at /Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:759:21\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async DefaultRunner.runTestSuite (/Users/vaibhavsingh/Dev/nightwatch/lib/runner/test-runners/default.js:78:7)'
       },
-      skipped: [
+      skippedAtRuntime: [
       ],
       time: '5.777',
       timeMs: 5777,
@@ -2069,7 +2069,7 @@ module.exports = {
       reportPrefix: '',
       assertionsCount: 0,
       lastError: null,
-      skipped: [
+      skippedAtRuntime: [
         'should complete the consent form'
       ],
       time: 0,
@@ -2118,7 +2118,7 @@ module.exports = {
       reportPrefix: 'FIREFOX_111.0.1__',
       assertionsCount: 2,
       lastError: null,
-      skipped: [
+      skippedAtRuntime: [
       ],
       time: '10.68',
       timeMs: 10675,
@@ -2833,7 +2833,7 @@ module.exports = {
       reportPrefix: '',
       assertionsCount: 0,
       lastError: null,
-      skipped: [
+      skippedAtRuntime: [
         'retrieve the shadowRoot'
       ],
       time: 0,
@@ -2882,7 +2882,7 @@ module.exports = {
       reportPrefix: 'FIREFOX_111.0.1__',
       assertionsCount: 3,
       lastError: null,
-      skipped: [
+      skippedAtRuntime: [
       ],
       time: '1.251',
       timeMs: 1251,
@@ -3467,7 +3467,7 @@ module.exports = {
       reportPrefix: 'CHROME_111.0.5563.146__',
       assertionsCount: 5,
       lastError: null,
-      skipped: [
+      skippedAtRuntime: [
       ],
       time: '3.056',
       timeMs: 3056,
@@ -4166,7 +4166,7 @@ module.exports = {
       reportPrefix: 'CHROME_111.0.5563.146__',
       assertionsCount: 5,
       lastError: null,
-      skipped: [
+      skippedAtRuntime: [
       ],
       time: '0.2180',
       timeMs: 218,
@@ -4926,7 +4926,7 @@ module.exports = {
         reportPrefix: 'CHROME_111.0.5563.146__',
         assertionsCount: 1,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '2.865',
         timeMs: 2865,
@@ -5417,7 +5417,7 @@ module.exports = {
         reportPrefix: 'CHROME_111.0.5563.146__',
         assertionsCount: 1,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '4.659',
         timeMs: 4659,
@@ -5732,7 +5732,7 @@ module.exports = {
         reportPrefix: 'CHROME_111.0.5563.146__',
         assertionsCount: 2,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '3.868',
         timeMs: 3868,
@@ -6292,7 +6292,7 @@ module.exports = {
           waitFor: true,
           stack: 'Error\n    at DescribeInstance.<anonymous> (/Users/vaibhavsingh/Dev/nightwatch/examples/tests/duckDuckGo.js:8:8)\n    at Context.call (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/context.js:478:35)\n    at TestCase.run (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/testcase.js:58:31)\n    at Runnable.__runFn (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:759:80)\n    at Runnable.run (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/runnable.js:126:21)\n    at TestSuite.executeRunnable (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:912:49)\n    at TestSuite.handleRunnable (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:927:33)\n    at /Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:759:21\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async DefaultRunner.runTestSuite (/Users/vaibhavsingh/Dev/nightwatch/lib/runner/test-runners/default.js:78:7)'
         },
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '8.932',
         timeMs: 8932,
@@ -6883,7 +6883,7 @@ module.exports = {
         reportPrefix: 'CHROME_111.0.5563.146__',
         assertionsCount: 0,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '5.086',
         timeMs: 5086,
@@ -7373,7 +7373,7 @@ module.exports = {
         reportPrefix: 'CHROME_111.0.5563.146__',
         assertionsCount: 2,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '49.04',
         timeMs: 49044,
@@ -8050,7 +8050,7 @@ module.exports = {
         reportPrefix: 'CHROME_111.0.5563.146__',
         assertionsCount: 3,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '1.116',
         timeMs: 1116,
@@ -8615,7 +8615,7 @@ module.exports = {
         reportPrefix: 'CHROME_111.0.5563.146__',
         assertionsCount: 3,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '0.8370',
         timeMs: 837,
@@ -9202,7 +9202,7 @@ module.exports = {
         reportPrefix: 'CHROME_111.0.5563.146__',
         assertionsCount: 5,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '0.2180',
         timeMs: 218,
@@ -9959,7 +9959,7 @@ module.exports = {
         reportPrefix: 'CHROME_111.0.5563.146__',
         assertionsCount: 5,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '3.056',
         timeMs: 3056,
@@ -10660,7 +10660,7 @@ module.exports = {
         reportPrefix: 'FIREFOX_111.0.1__',
         assertionsCount: 2,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '1.908',
         timeMs: 1908,
@@ -11217,7 +11217,7 @@ module.exports = {
           abortOnFailure: true,
           stack: '+ actual - expected\n\n  [\n+   \'abortOnFailure\'\n-   \'documents\',\n-   \'strings\'\n  ]\n    at Assertion.assert (/Users/vaibhavsingh/Dev/nightwatch/lib/api/_loaders/static.js:112:34)\n    at StaticAssert.assertFn (/Users/vaibhavsingh/Dev/nightwatch/lib/api/_loaders/static.js:146:17)\n    at Proxy.<anonymous> (/Users/vaibhavsingh/Dev/nightwatch/lib/api/index.js:157:30)\n    at DescribeInstance.<anonymous> (/Users/vaibhavsingh/Dev/nightwatch/examples/tests/chromeCDP_example.js:10:20)'
         },
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '4.669',
         timeMs: 4669,
@@ -11636,7 +11636,7 @@ module.exports = {
           waitFor: true,
           stack: 'Error\n    at DescribeInstance.<anonymous> (/Users/vaibhavsingh/Dev/nightwatch/examples/tests/duckDuckGo.js:8:8)\n    at Context.call (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/context.js:478:35)\n    at TestCase.run (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/testcase.js:58:31)\n    at Runnable.__runFn (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:759:80)\n    at Runnable.run (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/runnable.js:126:21)\n    at TestSuite.executeRunnable (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:912:49)\n    at TestSuite.handleRunnable (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:927:33)\n    at /Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:759:21\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async DefaultRunner.runTestSuite (/Users/vaibhavsingh/Dev/nightwatch/lib/runner/test-runners/default.js:78:7)'
         },
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '5.777',
         timeMs: 5777,
@@ -12228,7 +12228,7 @@ module.exports = {
         reportPrefix: '',
         assertionsCount: 0,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
           'should complete the consent form'
         ],
         time: 0,
@@ -12277,7 +12277,7 @@ module.exports = {
         reportPrefix: 'FIREFOX_111.0.1__',
         assertionsCount: 5,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '3.401',
         timeMs: 3401,
@@ -12974,7 +12974,7 @@ module.exports = {
         reportPrefix: 'FIREFOX_111.0.1__',
         assertionsCount: 1,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '1.082',
         timeMs: 1082,
@@ -13463,7 +13463,7 @@ module.exports = {
         reportPrefix: 'FIREFOX_111.0.1__',
         assertionsCount: 5,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '0.09500',
         timeMs: 95,
@@ -14218,7 +14218,7 @@ module.exports = {
         reportPrefix: '',
         assertionsCount: 0,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
           'retrieve the shadowRoot'
         ],
         time: 0,
@@ -14267,7 +14267,7 @@ module.exports = {
         reportPrefix: 'FIREFOX_111.0.1__',
         assertionsCount: 2,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '10.68',
         timeMs: 10675,
@@ -14982,7 +14982,7 @@ module.exports = {
         reportPrefix: 'FIREFOX_111.0.1__',
         assertionsCount: 3,
         lastError: null,
-        skipped: [
+        skippedAtRuntime: [
         ],
         time: '1.251',
         timeMs: 1251,

--- a/test/extra/reportObject.js
+++ b/test/extra/reportObject.js
@@ -14,6 +14,8 @@ module.exports = {
       lastError: null,
       skippedAtRuntime: [
       ],
+      skipped: [
+      ],
       time: '1.082',
       timeMs: 1082,
       completed: {
@@ -509,6 +511,8 @@ module.exports = {
       },
       skippedAtRuntime: [
       ],
+      skipped: [
+      ],
       time: '4.669',
       timeMs: 4669,
       completed: {
@@ -920,6 +924,8 @@ module.exports = {
       assertionsCount: 2,
       lastError: null,
       skippedAtRuntime: [
+      ],
+      skipped: [
       ],
       time: '1.908',
       timeMs: 1908,
@@ -1478,6 +1484,8 @@ module.exports = {
         stack: 'Error\n    at DescribeInstance.<anonymous> (/Users/vaibhavsingh/Dev/nightwatch/examples/tests/duckDuckGo.js:8:8)\n    at Context.call (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/context.js:478:35)\n    at TestCase.run (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/testcase.js:58:31)\n    at Runnable.__runFn (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:759:80)\n    at Runnable.run (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/runnable.js:126:21)\n    at TestSuite.executeRunnable (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:912:49)\n    at TestSuite.handleRunnable (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:927:33)\n    at /Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:759:21\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async DefaultRunner.runTestSuite (/Users/vaibhavsingh/Dev/nightwatch/lib/runner/test-runners/default.js:78:7)'
       },
       skippedAtRuntime: [
+      ],
+      skipped: [
       ],
       time: '5.777',
       timeMs: 5777,
@@ -2072,6 +2080,9 @@ module.exports = {
       skippedAtRuntime: [
         'should complete the consent form'
       ],
+      skipped: [
+        'should complete the consent form'
+      ],
       time: 0,
       completed: {
       },
@@ -2119,6 +2130,8 @@ module.exports = {
       assertionsCount: 2,
       lastError: null,
       skippedAtRuntime: [
+      ],
+      skipped: [
       ],
       time: '10.68',
       timeMs: 10675,
@@ -2836,6 +2849,9 @@ module.exports = {
       skippedAtRuntime: [
         'retrieve the shadowRoot'
       ],
+      skipped: [
+        'retrieve the shadowRoot'
+      ],
       time: 0,
       completed: {
       },
@@ -2883,6 +2899,8 @@ module.exports = {
       assertionsCount: 3,
       lastError: null,
       skippedAtRuntime: [
+      ],
+      skipped: [
       ],
       time: '1.251',
       timeMs: 1251,
@@ -3468,6 +3486,8 @@ module.exports = {
       assertionsCount: 5,
       lastError: null,
       skippedAtRuntime: [
+      ],
+      skipped: [
       ],
       time: '3.056',
       timeMs: 3056,
@@ -4167,6 +4187,8 @@ module.exports = {
       assertionsCount: 5,
       lastError: null,
       skippedAtRuntime: [
+      ],
+      skipped: [
       ],
       time: '0.2180',
       timeMs: 218,
@@ -4928,6 +4950,8 @@ module.exports = {
         lastError: null,
         skippedAtRuntime: [
         ],
+        skipped: [
+        ],
         time: '2.865',
         timeMs: 2865,
         completed: {
@@ -5419,6 +5443,8 @@ module.exports = {
         lastError: null,
         skippedAtRuntime: [
         ],
+        skipped: [
+        ],
         time: '4.659',
         timeMs: 4659,
         completed: {
@@ -5733,6 +5759,8 @@ module.exports = {
         assertionsCount: 2,
         lastError: null,
         skippedAtRuntime: [
+        ],
+        skipped: [
         ],
         time: '3.868',
         timeMs: 3868,
@@ -6293,6 +6321,8 @@ module.exports = {
           stack: 'Error\n    at DescribeInstance.<anonymous> (/Users/vaibhavsingh/Dev/nightwatch/examples/tests/duckDuckGo.js:8:8)\n    at Context.call (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/context.js:478:35)\n    at TestCase.run (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/testcase.js:58:31)\n    at Runnable.__runFn (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:759:80)\n    at Runnable.run (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/runnable.js:126:21)\n    at TestSuite.executeRunnable (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:912:49)\n    at TestSuite.handleRunnable (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:927:33)\n    at /Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:759:21\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async DefaultRunner.runTestSuite (/Users/vaibhavsingh/Dev/nightwatch/lib/runner/test-runners/default.js:78:7)'
         },
         skippedAtRuntime: [
+        ],
+        skipped: [
         ],
         time: '8.932',
         timeMs: 8932,
@@ -6885,6 +6915,8 @@ module.exports = {
         lastError: null,
         skippedAtRuntime: [
         ],
+        skipped: [
+        ],
         time: '5.086',
         timeMs: 5086,
         completed: {
@@ -7374,6 +7406,8 @@ module.exports = {
         assertionsCount: 2,
         lastError: null,
         skippedAtRuntime: [
+        ],
+        skipped: [
         ],
         time: '49.04',
         timeMs: 49044,
@@ -8052,6 +8086,8 @@ module.exports = {
         lastError: null,
         skippedAtRuntime: [
         ],
+        skipped: [
+        ],
         time: '1.116',
         timeMs: 1116,
         completed: {
@@ -8616,6 +8652,8 @@ module.exports = {
         assertionsCount: 3,
         lastError: null,
         skippedAtRuntime: [
+        ],
+        skipped: [
         ],
         time: '0.8370',
         timeMs: 837,
@@ -9203,6 +9241,8 @@ module.exports = {
         assertionsCount: 5,
         lastError: null,
         skippedAtRuntime: [
+        ],
+        skipped: [
         ],
         time: '0.2180',
         timeMs: 218,
@@ -9961,6 +10001,8 @@ module.exports = {
         lastError: null,
         skippedAtRuntime: [
         ],
+        skipped: [
+        ],
         time: '3.056',
         timeMs: 3056,
         completed: {
@@ -10662,6 +10704,8 @@ module.exports = {
         lastError: null,
         skippedAtRuntime: [
         ],
+        skipped: [
+        ],
         time: '1.908',
         timeMs: 1908,
         completed: {
@@ -11219,6 +11263,8 @@ module.exports = {
         },
         skippedAtRuntime: [
         ],
+        skipped: [
+        ],
         time: '4.669',
         timeMs: 4669,
         completed: {
@@ -11637,6 +11683,8 @@ module.exports = {
           stack: 'Error\n    at DescribeInstance.<anonymous> (/Users/vaibhavsingh/Dev/nightwatch/examples/tests/duckDuckGo.js:8:8)\n    at Context.call (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/context.js:478:35)\n    at TestCase.run (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/testcase.js:58:31)\n    at Runnable.__runFn (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:759:80)\n    at Runnable.run (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/runnable.js:126:21)\n    at TestSuite.executeRunnable (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:912:49)\n    at TestSuite.handleRunnable (/Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:927:33)\n    at /Users/vaibhavsingh/Dev/nightwatch/lib/testsuite/index.js:759:21\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async DefaultRunner.runTestSuite (/Users/vaibhavsingh/Dev/nightwatch/lib/runner/test-runners/default.js:78:7)'
         },
         skippedAtRuntime: [
+        ],
+        skipped: [
         ],
         time: '5.777',
         timeMs: 5777,
@@ -12231,6 +12279,9 @@ module.exports = {
         skippedAtRuntime: [
           'should complete the consent form'
         ],
+        skipped: [
+          'should complete the consent form'
+        ],
         time: 0,
         completed: {
         },
@@ -12278,6 +12329,8 @@ module.exports = {
         assertionsCount: 5,
         lastError: null,
         skippedAtRuntime: [
+        ],
+        skipped: [
         ],
         time: '3.401',
         timeMs: 3401,
@@ -12976,6 +13029,8 @@ module.exports = {
         lastError: null,
         skippedAtRuntime: [
         ],
+        skipped: [
+        ],
         time: '1.082',
         timeMs: 1082,
         completed: {
@@ -13464,6 +13519,8 @@ module.exports = {
         assertionsCount: 5,
         lastError: null,
         skippedAtRuntime: [
+        ],
+        skipped: [
         ],
         time: '0.09500',
         timeMs: 95,
@@ -14221,6 +14278,9 @@ module.exports = {
         skippedAtRuntime: [
           'retrieve the shadowRoot'
         ],
+        skipped: [
+          'retrieve the shadowRoot'
+        ],
         time: 0,
         completed: {
         },
@@ -14268,6 +14328,8 @@ module.exports = {
         assertionsCount: 2,
         lastError: null,
         skippedAtRuntime: [
+        ],
+        skipped: [
         ],
         time: '10.68',
         timeMs: 10675,
@@ -14983,6 +15045,8 @@ module.exports = {
         assertionsCount: 3,
         lastError: null,
         skippedAtRuntime: [
+        ],
+        skipped: [
         ],
         time: '1.251',
         timeMs: 1251,

--- a/test/src/runner/testRunnerJunitOutput.js
+++ b/test/src/runner/testRunnerJunitOutput.js
@@ -142,7 +142,7 @@ describe('testRunnerJUnitOutput', function() {
           assert.strictEqual(results.modules.sampleWithAssertionFailedInBefore.assertionsCount, 1);
           assert.strictEqual(results.modules.sampleWithAssertionFailedInBefore.errmessages.length, 1);
           assert.strictEqual(results.modules.sampleWithAssertionFailedInBefore.failedCount, 1);
-          assert.strictEqual(results.modules.sampleWithAssertionFailedInBefore.skipped.length, 0);
+          assert.strictEqual(results.modules.sampleWithAssertionFailedInBefore.skippedAtRuntime.length, 0);
           assert.strictEqual(results.modules.sampleWithAssertionFailedInBefore.completed['demo test async'].assertions.length, 0);
         }
       },
@@ -182,7 +182,7 @@ describe('testRunnerJUnitOutput', function() {
           assert.strictEqual(results.modules.sampleWithAssertionFailedInAfter.assertionsCount, 1);
           assert.strictEqual(results.modules.sampleWithAssertionFailedInAfter.errmessages.length, 1);
           assert.strictEqual(results.modules.sampleWithAssertionFailedInAfter.failedCount, 1);
-          assert.strictEqual(results.modules.sampleWithAssertionFailedInAfter.skipped.length, 0);
+          assert.strictEqual(results.modules.sampleWithAssertionFailedInAfter.skippedAtRuntime.length, 0);
           assert.strictEqual(results.modules.sampleWithAssertionFailedInAfter.completed.demoTestAsyncOne.assertions.length, 0);
         }
       },
@@ -222,7 +222,7 @@ describe('testRunnerJUnitOutput', function() {
           assert.strictEqual(results.modules.sampleWithFailureInTestcaseAndAfter.assertionsCount, 2);
           assert.strictEqual(results.modules.sampleWithFailureInTestcaseAndAfter.errmessages.length, 1);
           assert.strictEqual(results.modules.sampleWithFailureInTestcaseAndAfter.failedCount, 2);
-          assert.strictEqual(results.modules.sampleWithFailureInTestcaseAndAfter.skipped.length, 0);
+          assert.strictEqual(results.modules.sampleWithFailureInTestcaseAndAfter.skippedAtRuntime.length, 0);
           assert.strictEqual(results.modules.sampleWithFailureInTestcaseAndAfter.completed['demo test async'].assertions.length, 1);
         }
       },
@@ -263,7 +263,7 @@ describe('testRunnerJUnitOutput', function() {
           assert.strictEqual(results.modules.sampleWithErrorInTestcaseAndAfter.assertionsCount, 1);
           assert.strictEqual(results.modules.sampleWithErrorInTestcaseAndAfter.errmessages.length, 2);
           assert.strictEqual(results.modules.sampleWithErrorInTestcaseAndAfter.failedCount, 1);
-          assert.strictEqual(results.modules.sampleWithErrorInTestcaseAndAfter.skipped.length, 0);
+          assert.strictEqual(results.modules.sampleWithErrorInTestcaseAndAfter.skippedAtRuntime.length, 0);
           assert.strictEqual(results.modules.sampleWithErrorInTestcaseAndAfter.completed['demo test async'].assertions.length, 0);
           assert.strictEqual(results.modules.sampleWithErrorInTestcaseAndAfter.completed['demo test async'].errors, 1);
           assert.ok(results.modules.sampleWithErrorInTestcaseAndAfter.completed['demo test async'].lastError instanceof Error);
@@ -307,7 +307,7 @@ describe('testRunnerJUnitOutput', function() {
           assert.strictEqual(results.modules.sampleWithFailureInBeforeAndAfter.assertionsCount, 2);
           assert.strictEqual(results.modules.sampleWithFailureInBeforeAndAfter.errmessages.length, 2);
           assert.strictEqual(results.modules.sampleWithFailureInBeforeAndAfter.failedCount, 2);
-          assert.strictEqual(results.modules.sampleWithFailureInBeforeAndAfter.skipped.length, 0);
+          assert.strictEqual(results.modules.sampleWithFailureInBeforeAndAfter.skippedAtRuntime.length, 0);
         }
       },
       screenshots: {

--- a/test/src/runner/testRunnerJunitOutput.js
+++ b/test/src/runner/testRunnerJunitOutput.js
@@ -143,6 +143,7 @@ describe('testRunnerJUnitOutput', function() {
           assert.strictEqual(results.modules.sampleWithAssertionFailedInBefore.errmessages.length, 1);
           assert.strictEqual(results.modules.sampleWithAssertionFailedInBefore.failedCount, 1);
           assert.strictEqual(results.modules.sampleWithAssertionFailedInBefore.skippedAtRuntime.length, 0);
+          assert.strictEqual(results.modules.sampleWithAssertionFailedInBefore.skipped.length, 0);
           assert.strictEqual(results.modules.sampleWithAssertionFailedInBefore.completed['demo test async'].assertions.length, 0);
         }
       },
@@ -183,6 +184,7 @@ describe('testRunnerJUnitOutput', function() {
           assert.strictEqual(results.modules.sampleWithAssertionFailedInAfter.errmessages.length, 1);
           assert.strictEqual(results.modules.sampleWithAssertionFailedInAfter.failedCount, 1);
           assert.strictEqual(results.modules.sampleWithAssertionFailedInAfter.skippedAtRuntime.length, 0);
+          assert.strictEqual(results.modules.sampleWithAssertionFailedInAfter.skipped.length, 0);
           assert.strictEqual(results.modules.sampleWithAssertionFailedInAfter.completed.demoTestAsyncOne.assertions.length, 0);
         }
       },
@@ -223,6 +225,7 @@ describe('testRunnerJUnitOutput', function() {
           assert.strictEqual(results.modules.sampleWithFailureInTestcaseAndAfter.errmessages.length, 1);
           assert.strictEqual(results.modules.sampleWithFailureInTestcaseAndAfter.failedCount, 2);
           assert.strictEqual(results.modules.sampleWithFailureInTestcaseAndAfter.skippedAtRuntime.length, 0);
+          assert.strictEqual(results.modules.sampleWithFailureInTestcaseAndAfter.skipped.length, 0);
           assert.strictEqual(results.modules.sampleWithFailureInTestcaseAndAfter.completed['demo test async'].assertions.length, 1);
         }
       },
@@ -264,6 +267,7 @@ describe('testRunnerJUnitOutput', function() {
           assert.strictEqual(results.modules.sampleWithErrorInTestcaseAndAfter.errmessages.length, 2);
           assert.strictEqual(results.modules.sampleWithErrorInTestcaseAndAfter.failedCount, 1);
           assert.strictEqual(results.modules.sampleWithErrorInTestcaseAndAfter.skippedAtRuntime.length, 0);
+          assert.strictEqual(results.modules.sampleWithErrorInTestcaseAndAfter.skipped.length, 0);
           assert.strictEqual(results.modules.sampleWithErrorInTestcaseAndAfter.completed['demo test async'].assertions.length, 0);
           assert.strictEqual(results.modules.sampleWithErrorInTestcaseAndAfter.completed['demo test async'].errors, 1);
           assert.ok(results.modules.sampleWithErrorInTestcaseAndAfter.completed['demo test async'].lastError instanceof Error);
@@ -308,6 +312,7 @@ describe('testRunnerJUnitOutput', function() {
           assert.strictEqual(results.modules.sampleWithFailureInBeforeAndAfter.errmessages.length, 2);
           assert.strictEqual(results.modules.sampleWithFailureInBeforeAndAfter.failedCount, 2);
           assert.strictEqual(results.modules.sampleWithFailureInBeforeAndAfter.skippedAtRuntime.length, 0);
+          assert.strictEqual(results.modules.sampleWithFailureInBeforeAndAfter.skipped.length, 0);
         }
       },
       screenshots: {


### PR DESCRIPTION
### Issue
The skipped tests that were marked by the user were not getting logged.

### Changes
The reporter now differentiates between tests that were skipped at runtime and those skipped by the user, using `skippedAtRuntime` and `skippedByUser` properties respectively, instead of just `skipped`.

**Note** : _This change should also be incorporated in the HTML reporter._