### PR TITLE
feat/retry-data: Added retry test data to global reporter

### DIFF
--- a/lib/reporter/results.js
+++ b/lib/reporter/results.js
@@ -49,6 +49,7 @@ module.exports = class Results {
     this.buildName = capabilities.buildName || desiredCapabilities.buildName || '';
     const {webdriver = {}} = settings;
     this.host = webdriver.host || '';
+    this.__retryTest = false;
 
     this.initCount(tests);
   }
@@ -271,12 +272,20 @@ module.exports = class Results {
     return this.currentTestName;
   }
 
+  set retryTest(value) {
+    this.__retryTest = value;
+  }
+
+  get retryTest() {
+    return this.__retryTest;
+  }
+  
   /**
    * @param {TestCase} testcase
    * @return {Object}
    */
   createTestCaseResults(testcase) {
-    return {
+    const result = {
       time: 0,
       assertions: [],
       commands: [],
@@ -288,6 +297,22 @@ module.exports = class Results {
       tests: 0,
       status: Results.TEST_PASS
     };
+
+    if (this.retryTest && this.testSections[testcase.testName]) {
+      const retryTestData = this.testSections[testcase.testName];
+
+      result['retryTestData'] = [retryTestData];
+
+      if (retryTestData['retryTestData']) {
+        result['retryTestData'].push(...retryTestData['retryTestData']);
+
+        delete retryTestData['retryTestData'];
+      }
+
+      this.retryTest = false;
+    }
+
+    return result;
   }
 
   resetLastError() {

--- a/lib/testsuite/index.js
+++ b/lib/testsuite/index.js
@@ -824,13 +824,16 @@ class TestSuite {
     return !this.reporter.currentTestCasePassed && this.suiteRetries.shouldRetryTest(this.testcase.testName);
   }
 
-  retryCurrentTestCase() {
+  async retryCurrentTestCase() {
     let currentTestName = this.testcase.testName;
     this.suiteRetries.incrementTestRetriesCount(currentTestName);
     this.reporter.resetCurrentTestPassedCount();
+    this.reporter.testResults.retryTest = true;
     this.commandQueue.clearScheduled();
 
-    return this.runCurrentTest(currentTestName);
+    const result = await this.runCurrentTest(currentTestName);
+
+    return result;
   }
 
   isScreenshotEnabled() {

--- a/lib/testsuite/index.js
+++ b/lib/testsuite/index.js
@@ -824,16 +824,14 @@ class TestSuite {
     return !this.reporter.currentTestCasePassed && this.suiteRetries.shouldRetryTest(this.testcase.testName);
   }
 
-  async retryCurrentTestCase() {
+  retryCurrentTestCase() {
     let currentTestName = this.testcase.testName;
     this.suiteRetries.incrementTestRetriesCount(currentTestName);
     this.reporter.resetCurrentTestPassedCount();
     this.reporter.testResults.retryTest = true;
     this.commandQueue.clearScheduled();
 
-    const result = await this.runCurrentTest(currentTestName);
-
-    return result;
+    return this.runCurrentTest(currentTestName);
   }
 
   isScreenshotEnabled() {

--- a/test/src/runner/testReporter.js
+++ b/test/src/runner/testReporter.js
@@ -394,4 +394,30 @@ describe('testReporter', function() {
       assert.deepStrictEqual(result, ['nightwatch_reporter_output', 'html_reporter_output']);
     });
   });
+
+  it('test to check retry data logging', function() {
+    this.timeout(100000);
+
+    const testsPath = path.join(__dirname, '../../sampletests/withfailures');
+    const globals = {
+      calls: 0,
+      reporter(results, cb) {
+        assert.ok('sample' in results.modules);
+        assert.ok('completedSections' in results.modules['sample']);
+        assert.ok('demoTest' in results.modules['sample']['completedSections']);
+        assert.ok('retryTestData' in results.modules['sample']['completedSections']['demoTest']);
+        assert.ok(results.modules['sample']['completedSections']['demoTest']['retryTestData'].length <= 3);
+        cb();
+      },
+      retryAssertionTimeout: 0
+    };
+
+    return runTests({
+      retries: 3,
+      _source: [testsPath]
+    }, settings({
+      skip_testcases_on_fail: false,
+      globals
+    }));
+  });
 });


### PR DESCRIPTION
### Issue
The retry data is not getting populated in global reporter when tests get failed. We push only the latest data but loose the previous retries data for that particular test.

### Solution
Suppose we have a test which will have following data inside reporter:

```
"Demo test ecosia.org ": {
        "time": 0,     
        "assertions": [],
        "commands": [ ],
        "passed": 0,
        "errors": 0,
        "failed": 0,
        "skipped": 0,
        "tests": 0,
        "status": "pass"
      },
```

Previously we are not pushing the retried data anywhere. But now I added a key `retryTestData` and pushed all retried data inside it and keeps the latest data as it is.
```
"Demo test ecosia.org": {
        "time": 0,                     
        "assertions": [],          
        "commands": [ ],       
        "passed": 0,                     ===>   latest data
        "errors": 0,                    
        "failed": 0                      
        "skipped": 0,                 
        "tests": 0,                      
        "status": "pass",          
        "retryTestData": [{ "time": 0, .... }, { "time": 0, .... }]        ==> retries data
      },
```