### PR TITLE
added waitUntil module to element apis

### DIFF
--- a/lib/api/web-element/factory.js
+++ b/lib/api/web-element/factory.js
@@ -45,19 +45,19 @@ const createScopedWebElement = function(selector, parentElement, nightwatchInsta
   });
 
   Object.defineProperty(exported, 'waitUntil', {
-    value(arguments) {
+    value(args) {
 
 
       return createScopedWebElement(new Promise(function (resolve, reject) {
 
-        if (typeof argument === 'string') {
-          argument = {action: argument};
+        if (typeof args === 'string') {
+          args = {action: args};
         }
 
         const waitUntil = new WaitUntil(instance, {
           selector,
           nightwatchInstance,
-          ...argument
+          ...args
         });
   
         return waitUntil.wait()

--- a/lib/api/web-element/factory.js
+++ b/lib/api/web-element/factory.js
@@ -1,6 +1,7 @@
 const ScopedWebElements = require('./scoped-elements.js');
 const ScopedWebElement = require('./scoped-element.js');
 const ScopedElementAssertions = require('./assert/element-assertions.js');
+const WaitUntil = require('./waitUntil.js');
 
 const Element = require('../../element');
 const ScopedValueAssertions = require('./assert/value-assertions.js');
@@ -41,6 +42,30 @@ const createScopedWebElement = function(selector, parentElement, nightwatchInsta
     },
     enumerable: true,
     configurable: true
+  });
+
+  Object.defineProperty(exported, 'waitUntil', {
+    value(argument) {
+
+
+      return createScopedWebElement(new Promise(function (resolve, reject) {
+
+        if (typeof argument === 'string') {
+          argument = {action: argument};
+        }
+
+        const waitUntil = new WaitUntil(instance, {
+          selector,
+          nightwatchInstance,
+          ...argument
+        });
+  
+        return waitUntil.wait()
+          .then(element => resolve(element));
+        
+      }.bind(instance)), parentElement, nightwatchInstance);
+    }
+    
   });
 
   Object.defineProperty(exported, 'then', {

--- a/lib/api/web-element/factory.js
+++ b/lib/api/web-element/factory.js
@@ -45,7 +45,7 @@ const createScopedWebElement = function(selector, parentElement, nightwatchInsta
   });
 
   Object.defineProperty(exported, 'waitUntil', {
-    value(argument) {
+    value(arguments) {
 
 
       return createScopedWebElement(new Promise(function (resolve, reject) {

--- a/lib/api/web-element/waitUntil.js
+++ b/lib/api/web-element/waitUntil.js
@@ -1,0 +1,122 @@
+const until = require('selenium-webdriver/lib/until');
+const {AssertionRunner} = require('../../assertion');
+const Utils = require('../../utils');
+
+const mapToSeleniumFunction = {
+  'selected': until.elementIsSelected,
+  'not.selected': until.elementIsNotSelected,
+  'visible': until.elementIsVisible,
+  'not.visible': until.elementIsNotVisible,
+  'enabled': until.elementIsEnabled,
+  'not.enabled': until.elementIsDisabled,
+  'disabled': until.elementIsDisabled
+};
+
+
+
+class WaitUntil {
+  constructor(scopedElement, {action, timeout, retryInterval, message, nightwatchInstance, selector}) {
+    this.scopedElement = scopedElement;
+    this.conditionFn = mapToSeleniumFunction[action];
+    this.nightwatchInstance = nightwatchInstance;
+    this.action = action;
+    this.message = message;
+    this.selector = selector;
+    this.timeout = timeout || this.nightwatchInstance.settings.globals.waitForConditionTimeout;
+    this.retryInterval = retryInterval || this.nightwatchInstance.settings.globals.waitForConditionPollInterval;
+ 
+  }
+
+  createNode() {
+    const createAction = (actions, webElement) =>  function() {
+      if (!this.conditionFn) {
+        throw new Error(`Invalid action ${this.action} for WaitUntil Command. Possible actions: ${Object.keys(mapToSeleniumFunction).toString()}`);
+      }
+
+      return actions['wait'](this.conditionFn(webElement), this.timeout, this.retryInterval, this.message, ()=>{})
+        .then(result => {
+          const elapsedTime = new Date().getTime() - node.startTime;
+          if (result.error) {
+            const actual = result.error.name === 'NightwatchElementError' ? 'not found' : null;
+
+            return this.fail(result, actual, elapsedTime);
+          }
+
+          return this.pass(result, elapsedTime);
+        })
+        .then(result => node.deferred.resolve(result))
+        .catch(err=> node.deferred.resolve(err));
+    }.bind(this);
+    
+    const node = this.scopedElement.queueAction({name: 'waitUntil', createAction});
+
+    return node;
+  }
+
+
+  async wait() {
+    const assertApi = this.nightwatchInstance.api.assert;
+    try {
+      const node =  this.createNode();
+     
+      return this.scopedElement.waitFor(node.deferred.promise);
+    } catch (err) {
+      assertApi.ok(false, err.message);
+    }
+  }
+
+  formatMsg(message, timeMs) {
+    const defaultMsg = this.message || message;
+    
+    return Utils.format(defaultMsg, this.selector, timeMs);
+  }
+
+  assert({result, passed, err, message, elapsedTime}) {
+    const {reporter} = this.scopedElement;
+    
+    const runner = new AssertionRunner({abortOnFailure: true, passed, err, message, reporter, elapsedTime});
+
+    return runner.run(result);
+  }
+
+  pass(result, elapsedTime) {
+    const sliceAction = this.action.split('.');
+    const expected = sliceAction[0] === 'not' ? `not ${sliceAction[1]}` : this.action;
+
+    const message = this.formatMsg(`Element <%s> was ${expected} in %d milliseconds`, elapsedTime);
+
+    return this.assert({
+      result,
+      passed: true,
+      err: {
+        expected
+      },
+      elapsedTime,
+      message
+    });
+  }
+
+  fail(result, actual, elapsedTime) {
+
+    const sliceAction = this.action.split('.');
+    
+    actual = actual ? actual : sliceAction[0] === 'not' ? sliceAction[1] : `not ${this.action}`;
+    const expected = sliceAction[0] === 'not' ? `not ${sliceAction[1]}` : this.action;
+    const message = this.formatMsg(`Timed out while waiting for element <%s> to be ${expected} for %d milliseconds`, this.timeout);
+
+    return this.assert({
+      result,
+      passed: false,
+      message,
+      err: {
+        actual,
+        expected
+      },
+      elapsedTime
+    });
+  }
+
+
+}
+
+module.exports = WaitUntil;

--- a/lib/api/web-element/waitUntil.js
+++ b/lib/api/web-element/waitUntil.js
@@ -1,6 +1,6 @@
 const until = require('selenium-webdriver/lib/until');
 const {AssertionRunner} = require('../../assertion');
-const Utils = require('../../utils');
+const {isDefined, format} = require('../../utils');
 
 const mapToSeleniumFunction = {
   'selected': until.elementIsSelected,
@@ -15,7 +15,7 @@ const mapToSeleniumFunction = {
 
 
 class WaitUntil {
-  constructor(scopedElement, {action, timeout, retryInterval, message, nightwatchInstance, selector}) {
+  constructor(scopedElement, {action, timeout, retryInterval, message, nightwatchInstance, selector, abortOnFailure}) {
     this.scopedElement = scopedElement;
     this.conditionFn = mapToSeleniumFunction[action];
     this.nightwatchInstance = nightwatchInstance;
@@ -24,6 +24,7 @@ class WaitUntil {
     this.selector = selector;
     this.timeout = timeout || this.nightwatchInstance.settings.globals.waitForConditionTimeout;
     this.retryInterval = retryInterval || this.nightwatchInstance.settings.globals.waitForConditionPollInterval;
+    this.abortOnFailure = isDefined(abortOnFailure) ? abortOnFailure : this.nightwatchInstance.settings.globals.abortOnAssertionFailure;
  
   }
 
@@ -44,8 +45,12 @@ class WaitUntil {
 
           return this.pass(result, elapsedTime);
         })
-        .then(result => node.deferred.resolve(result))
-        .catch(err=> node.deferred.resolve(err));
+        .catch(err=> err)
+        .then(result => {
+          node.deferred.resolve(result);
+
+          return result;
+        });
     }.bind(this);
     
     const node = this.scopedElement.queueAction({name: 'waitUntil', createAction});
@@ -68,13 +73,13 @@ class WaitUntil {
   formatMsg(message, timeMs) {
     const defaultMsg = this.message || message;
     
-    return Utils.format(defaultMsg, this.selector, timeMs);
+    return format(defaultMsg, this.selector, timeMs);
   }
 
   assert({result, passed, err, message, elapsedTime}) {
     const {reporter} = this.scopedElement;
     
-    const runner = new AssertionRunner({abortOnFailure: true, passed, err, message, reporter, elapsedTime});
+    const runner = new AssertionRunner({abortOnFailure: this.abortOnFailure, passed, err, message, reporter, elapsedTime});
 
     return runner.run(result);
   }

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -1,4 +1,4 @@
-const {WebElement, WebDriver, Origin, By, until} = require('selenium-webdriver');
+const {WebElement, WebDriver, Origin, By, until, Condition} = require('selenium-webdriver');
 const {Locator} = require('../../element');
 const NightwatchLocator = require('../../element/locator-factory.js');
 const {isString} = require('../../utils');
@@ -1036,7 +1036,7 @@ module.exports = class MethodMappings {
         ///////////////////////////////////////////////////////////////////////////
         async wait(conditionFn, timeMs, message, retryInterval) {
           const driver = new WebDriver(Promise.resolve());
-          await driver.wait(conditionFn(), timeMs, message, retryInterval);
+          await driver.wait(conditionFn instanceof Condition ? conditionFn : conditionFn(), timeMs, message, retryInterval);
 
           return {
             value: null

--- a/test/apidemos/web-elements/waitUntilFailureTest.js
+++ b/test/apidemos/web-elements/waitUntilFailureTest.js
@@ -1,0 +1,5 @@
+describe('demo of failure of waitUntil element commands', function() {
+  it('waitUntil element is visible and but not selected', function({element}) {
+    element.find('#weblogin').waitUntil('visible').waitUntil('not.selected');
+  });
+});

--- a/test/apidemos/web-elements/waitUntilTest.js
+++ b/test/apidemos/web-elements/waitUntilTest.js
@@ -1,0 +1,14 @@
+describe('demo tests using waitUntil element APIs', function() {
+  it('wait until element is visible', function({element}) {
+    element('#weblogin').waitUntil('visible');
+  });
+
+  it('wait until element is selected', function({element, state}) {
+    element('#weblogin').waitUntil('selected');
+  });
+
+  it('wait until element is enabled', function({element}) {
+    element('#weblogin').waitUntil('enabled');
+  });
+});
+

--- a/test/lib/command-mocks.js
+++ b/test/lib/command-mocks.js
@@ -267,7 +267,27 @@ module.exports = {
         value
       })
     }, true);
-  }, 
+  },
+  
+  w3cSelected(elementId ='5cc459b8-36a8-3042-8b4a-258883ea642b', value = true) {
+    MockServer.addMock({
+      url: `/session/13521-10219-202/element/${elementId}/selected`,
+      method: 'GET',
+      response: JSON.stringify({
+        value
+      })
+    }, true);
+  },
+  
+  w3cEnabled(elementId ='5cc459b8-36a8-3042-8b4a-258883ea642b', value = true) {
+    MockServer.addMock({
+      url: `/session/13521-10219-202/element/${elementId}/enabled`,
+      method: 'GET',
+      response: JSON.stringify({
+        value
+      })
+    });
+  },
 
   findElements({using = 'css selector', value = '#container', response = null, times = 0}) {
     const mockOpts = {

--- a/test/src/apidemos/web-elements/testWaitUntil.js
+++ b/test/src/apidemos/web-elements/testWaitUntil.js
@@ -1,0 +1,86 @@
+const path = require('path');
+const assert = require('assert');
+
+const commandMocks = require('../../../lib/command-mocks');
+const common = require('../../../common.js');
+const {settings} = common;
+const NightwatchClient = common.require('index.js');
+
+describe('waitUntil element command', function() {
+  beforeEach(function(done) {
+    commandMocks.start(done);
+  });
+
+  afterEach(function(done) {
+    commandMocks.stop(done);
+  });
+
+  it('test waitUntil element command - passed', function() {
+    const testsPath = path.join(__dirname, '../../../apidemos/web-elements/waitUntilTest.js');
+    commandMocks.w3cSelected();
+    commandMocks.w3cVisible();
+    commandMocks.w3cEnabled();
+  
+
+    const globals = {
+      waitForConditionPollInterval: 50,
+      waitForConditionTimeout: 120,
+      retryAssertionTimeout: 100,
+
+      reporter(results) {
+        if (results.lastError) {
+          throw results.lastError;
+        }
+      }
+    };
+
+    return NightwatchClient.runTests(testsPath, settings({
+      selenium: {
+        port: null,
+        start_process: false
+      },
+      selenium_host: null,
+      webdriver: {
+        port: 10195,
+        start_process: false
+      },
+      output: false,
+      skip_testcases_on_fail: false,
+      globals
+    }));
+  });
+
+  it('test waitUntil element command - failed', function() {
+    const testsPath = path.join(__dirname, '../../../apidemos/web-elements/waitUntilFailureTest.js');
+    commandMocks.w3cSelected();
+    commandMocks.w3cVisible();
+  
+
+    const globals = {
+      waitForConditionPollInterval: 50,
+      waitForConditionTimeout: 120,
+      retryAssertionTimeout: 100,
+
+      reporter(results) {
+        if (!results.lastError) {
+          assert.fail('Should result into failure');
+        }
+      }
+    };
+
+    return NightwatchClient.runTests(testsPath, settings({
+      selenium: {
+        port: null,
+        start_process: false
+      },
+      selenium_host: null,
+      webdriver: {
+        port: 10195,
+        start_process: false
+      },
+      output: false,
+      skip_testcases_on_fail: false,
+      globals
+    }));
+  });
+});


### PR DESCRIPTION
## Changes
- added `waitUntil` module to element command

## Usage
```js
 element.find(<selector>).waitUntil(<action>).sendKeys('Nightwatch');
```
 **OR** 
```js
element.find(<selector>).waitUntil({action, timeout, retryInterval, abortOnFailure, message});
```


action could be: `enabled` `visible` `disabled` `selected` `not.selected` `not.visible` `not.enabled`