### PR TITLE
Add missing aposthropes from default configuration.

### DIFF
--- a/lib/runner/cli/nightwatch.conf.ejs
+++ b/lib/runner/cli/nightwatch.conf.ejs
@@ -117,7 +117,7 @@ module.exports = {
         start_process: true,
         server_path: '',
         cli_args: [
-          // --verbose
+          // '--verbose'
         ]
       }
     },
@@ -140,7 +140,7 @@ module.exports = {
         //  and set the location below:
         server_path: '',
         cli_args: [
-          // --verbose
+          // '--verbose'
         ]
       }
     },

--- a/test/src/index/transport/testMobileWebSupport.js
+++ b/test/src/index/transport/testMobileWebSupport.js
@@ -60,7 +60,7 @@ describe('MobileSupport', function () {
         start_process: true,
         server_path: '',
         cli_args: [
-          // --verbose
+          // '--verbose'
         ]
       }
     })).catch(err => {
@@ -122,7 +122,7 @@ describe('MobileSupport', function () {
         start_process: true,
         server_path: '',
         cli_args: [
-          // --verbose
+          // '--verbose'
         ]
       }
     }))
@@ -157,7 +157,7 @@ describe('MobileSupport', function () {
         start_process: true,
         server_path: '',
         cli_args: [
-          // --verbose
+          // '--verbose'
         ]
       }
     }));
@@ -233,7 +233,7 @@ describe('MobileSupport', function () {
         start_process: true,
         server_path: '',
         cli_args: [
-          // --verbose
+          // '--verbose'
         ]
       }
     }))


### PR DESCRIPTION
webdriver/cli_args has commented out setting --verbose, which is missing aposthropes. Uncommenting will lead to failure.