### PR TITLE
Add types for modified non-element API.

### DIFF
--- a/types/assertions.d.ts
+++ b/types/assertions.d.ts
@@ -1,5 +1,6 @@
 import {NightwatchCustomAssertions} from './custom-assertion';
-import {Awaitable, Definition, ElementResult, JSON_WEB_OBJECT, NightwatchAPI} from './index';
+import {Awaitable, Definition, ElementResult, JSON_WEB_OBJECT} from './index';
+import { IfUnknown } from './utils';
 
 export interface NightwatchAssertionsError {
 	name: string;
@@ -8,7 +9,7 @@ export interface NightwatchAssertionsError {
 	stack: string;
 }
 
-export interface NightwatchCommonAssertions {
+export interface NightwatchCommonAssertions<ReturnType> {
 	/**
 	 * Checks if the given attribute of an element contains the expected value.
 	 *
@@ -23,7 +24,7 @@ export interface NightwatchCommonAssertions {
 		attribute: string,
 		expected: string,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the given attribute of an element has the expected value.
@@ -39,7 +40,7 @@ export interface NightwatchCommonAssertions {
 		attribute: string,
 		expected: string,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Check if an element's attribute value matches a regular expression.
@@ -58,7 +59,7 @@ export interface NightwatchCommonAssertions {
 		attribute: string,
 		regex: string | RegExp,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the specified css property of a given element has the expected value.
@@ -74,7 +75,7 @@ export interface NightwatchCommonAssertions {
 		cssProperty: string,
 		expected: string,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the specified DOM property of a given element has the expected value.
@@ -86,7 +87,7 @@ export interface NightwatchCommonAssertions {
 		domProperty: string,
 		expected: string | number,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<any>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<any>>;
 
 	/**
 	 * Checks if the specified DOM property of a given element has the expected value.
@@ -98,7 +99,7 @@ export interface NightwatchCommonAssertions {
 		domProperty: string,
 		expected: string | number,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<any>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<any>>;
 
 	/**
 	 * Check if specified DOM property value of a given element matches a regex.
@@ -109,7 +110,7 @@ export interface NightwatchCommonAssertions {
 		domProperty: string,
 		expected: string | RegExp,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<any>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<any>>;
 
 	/**
 	 * Checks if the number of elements specified by a selector is equal to a given value.
@@ -127,7 +128,7 @@ export interface NightwatchCommonAssertions {
 		count: number,
 		msg?: string
 	): Awaitable<
-		NightwatchAPI,
+		IfUnknown<ReturnType, this>,
 		NightwatchAssertionsResult<JSON_WEB_OBJECT[]> & {
 			WebdriverElementId: string;
 		}
@@ -146,7 +147,7 @@ export interface NightwatchCommonAssertions {
 		selector: Definition,
 		msg?: string
 	): Awaitable<
-		NightwatchAPI,
+		IfUnknown<ReturnType, this>,
 		NightwatchAssertionsResult<ElementResult[]>
 	>;
 
@@ -166,7 +167,7 @@ export interface NightwatchCommonAssertions {
 		selector: Definition,
 		msg?: string
 	): Awaitable<
-		NightwatchAPI,
+		IfUnknown<ReturnType, this>,
 		NightwatchAssertionsResult<ElementResult[]>
 	>;
 
@@ -185,7 +186,7 @@ export interface NightwatchCommonAssertions {
 		selector: Definition,
 		className: string,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the given element has the specified CSS class.
@@ -202,7 +203,7 @@ export interface NightwatchCommonAssertions {
 		selector: Definition,
 		className: string,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the given element has the specified CSS class.
@@ -223,7 +224,7 @@ export interface NightwatchCommonAssertions {
 		selector: Definition,
 		className: string | string[],
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the given element contains the specified DOM attribute.
@@ -243,7 +244,7 @@ export interface NightwatchCommonAssertions {
 		selector: Definition,
 		expectedAttribute: string,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string[]>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string[]>>;
 
 	/**
 	 * Checks if the given element is enabled (as indicated by the 'disabled' attribute).
@@ -258,7 +259,7 @@ export interface NightwatchCommonAssertions {
 	enabled(
 		selector: Definition,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<boolean>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<boolean>>;
 
 	/**
 	 * Checks if the given element is selected.
@@ -273,7 +274,7 @@ export interface NightwatchCommonAssertions {
 	selected(
 		selector: Definition,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<boolean>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<boolean>>;
 
 	/**
 	 * Checks if the given element contains the specified text.
@@ -290,7 +291,7 @@ export interface NightwatchCommonAssertions {
 		selector: Definition,
 		expectedText: string,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the given element contains the specified text.
@@ -307,7 +308,7 @@ export interface NightwatchCommonAssertions {
 		selector: Definition,
 		expectedText: string,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Check if an element's inner text equals the expected text.
@@ -325,7 +326,7 @@ export interface NightwatchCommonAssertions {
 		selector: Definition,
 		expectedText: string,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Check if an elements inner text matches a regular expression.
@@ -343,7 +344,7 @@ export interface NightwatchCommonAssertions {
 		selector: Definition,
 		regex: string | RegExp,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the page title equals the given value.
@@ -359,7 +360,7 @@ export interface NightwatchCommonAssertions {
 	title(
 		expected: string,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the page title equals the given value.
@@ -373,7 +374,7 @@ export interface NightwatchCommonAssertions {
 	titleContains(
 		expected: string,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the page title equals the given value.
@@ -387,7 +388,7 @@ export interface NightwatchCommonAssertions {
 	titleEquals(
 		expected: string,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the current title matches a regular expression.
@@ -404,7 +405,7 @@ export interface NightwatchCommonAssertions {
 	titleMatches(
 		regex: string | RegExp,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the current URL contains the given value.
@@ -418,7 +419,7 @@ export interface NightwatchCommonAssertions {
 	urlContains(
 		expectedText: string,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the current url equals the given value.
@@ -432,7 +433,7 @@ export interface NightwatchCommonAssertions {
 	urlEquals(
 		expected: string,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the current url matches a regular expression.
@@ -448,7 +449,7 @@ export interface NightwatchCommonAssertions {
 	urlMatches(
 		regex: string | RegExp,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the given form element's value equals the expected value.
@@ -465,7 +466,7 @@ export interface NightwatchCommonAssertions {
 		selector: Definition,
 		expectedText: string,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the given form element's value contains the expected value.
@@ -480,7 +481,7 @@ export interface NightwatchCommonAssertions {
 		selector: Definition,
 		expectedText: string,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the given form element's value equals the expected value.
@@ -499,7 +500,7 @@ export interface NightwatchCommonAssertions {
 		selector: Definition,
 		expected: string,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<string>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<string>>;
 
 	/**
 	 * Checks if the given element is not visible on the page.
@@ -516,7 +517,7 @@ export interface NightwatchCommonAssertions {
 	hidden(
 		selector: Definition,
 		msg?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<boolean>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<boolean>>;
 
 	/**
 	 * Checks if the given element is visible on the page.
@@ -530,7 +531,7 @@ export interface NightwatchCommonAssertions {
 	visible(
 		selector: Definition,
 		message?: string
-	): Awaitable<NightwatchAPI, NightwatchAssertionsResult<boolean>>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchAssertionsResult<boolean>>;
 
 	NightwatchAssertionsError: NightwatchAssertionsError;
 }
@@ -540,109 +541,109 @@ export interface NightwatchNodeAssertionsResult {
 	returned: 1;
 }
 
-export interface NightwatchNodeAssertions {
+export interface NightwatchNodeAssertions<ReturnType> {
 	// The following definitions are taken from @types/assert
 
 	fail(
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 	fail(
 		actual: any,
 		expected: any,
 		message?: string | Error,
 		operator?: string
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 
 	ok(
 		value: any,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 
 	equal(
 		actual: any,
 		expected: any,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 	notEqual(
 		actual: any,
 		expected: any,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 
 	deepEqual(
 		actual: any,
 		expected: any,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 	notDeepEqual(
 		actual: any,
 		expected: any,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 
 	strictEqual(
 		actual: any,
 		expected: any,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 	notStrictEqual(
 		actual: any,
 		expected: any,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 
 	deepStrictEqual(
 		actual: any,
 		expected: any,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 	notDeepStrictEqual(
 		actual: any,
 		expected: any,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 
 	throws(
 		block: () => any,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 	doesNotThrow(
 		block: () => any,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 
 	ifError(
 		value: any
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 
 	rejects(
 		block: (() => Promise<any>) | Promise<any>,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 	doesNotReject(
 		block: (() => Promise<any>) | Promise<any>,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 
 	match(
 		value: string,
 		regExp: RegExp,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 	doesNotMatch(
 		value: string,
 		regExp: RegExp,
 		message?: string | Error
-	): Awaitable<NightwatchAPI, NightwatchNodeAssertionsResult | Error>;
+	): Awaitable<IfUnknown<ReturnType, this>, NightwatchNodeAssertionsResult | Error>;
 }
 
-export interface NightwatchAssertions
-	extends NightwatchCommonAssertions,
-	NightwatchCustomAssertions {
+export interface NightwatchAssertions<ReturnType>
+	extends NightwatchCommonAssertions<ReturnType>,
+	NightwatchCustomAssertions<ReturnType> {
 	/**
 	 * Negates any of assertions following in the chain.
 	 */
-	not: Omit<NightwatchAssertions, 'not'>;
+	not: Omit<NightwatchAssertions<ReturnType>, 'not'>;
 }
 
 export interface NightwatchAssertionsResult<T> {
@@ -652,7 +653,9 @@ export interface NightwatchAssertionsResult<T> {
 	passed: true;
 }
 
-export interface Assert extends NightwatchAssertions, NightwatchNodeAssertions { }
+export interface Assert<ReturnType = unknown>
+	extends NightwatchAssertions<ReturnType>,
+	NightwatchNodeAssertions<ReturnType> { }
 
 // TODO: Check where the following type is being used.
 /**

--- a/types/custom-assertion.d.ts
+++ b/types/custom-assertion.d.ts
@@ -149,4 +149,4 @@ export interface NightwatchAssertion<T> {
 /**
  * @see https://nightwatchjs.org/guide/extending-nightwatch/adding-custom-assertions.html
  */
-export interface NightwatchCustomAssertions {}
+export interface NightwatchCustomAssertions<ReturnType> {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -527,6 +527,7 @@ export interface NightwatchAPI
   verify: Assert;
 
   appium: AppiumCommands;
+  cookies: CookiesNsCommands;
 
   page: NightwatchPage & NightwatchCustomPageObjects;
 
@@ -955,17 +956,6 @@ export type NightwatchLogTypes =
   | 'browser'
   | 'server'
   | 'performance';
-
-export interface Cookie {
-  name: string;
-  value: string;
-  path?: string;
-  domain?: string;
-  secure?: boolean;
-  expiry?: Date | number;
-  httpOnly?: boolean;
-  sameSite?: string;
-}
 
 export interface SharedCommands extends ClientCommands, ElementCommands { }
 
@@ -1398,6 +1388,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    * }
    *
    * @see https://nightwatchjs.org/api/deleteCookie.html
+   *
+   * @deprecated In favour of `.cookies.delete()`.
    */
   deleteCookie(
     cookieName: string,
@@ -1418,6 +1410,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    * }
    *
    * @see https://nightwatchjs.org/api/deleteCookies.html
+   *
+   * @deprecated In favour of `.cookies.deleteAll()`.
    */
   deleteCookies(
     callback?: (
@@ -1458,6 +1452,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    * }
    *
    * @see https://nightwatchjs.org/api/getCookie.html
+   *
+   * @deprecated In favour of `.cookies.get()`.
    */
   getCookie(
     name: string,
@@ -1482,6 +1478,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    * }
    *
    * @see https://nightwatchjs.org/api/getCookies.html
+   *
+   * @deprecated In favour of `.cookies.getAll()`.
    */
   getCookies(
     callback?: (
@@ -1899,6 +1897,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    * }
    *
    * @see https://nightwatchjs.org/api/setCookie.html
+   *
+   * @deprecated In favour of `.cookies.set()`.
    */
   setCookie(
     cookie: Cookie,
@@ -4618,6 +4618,149 @@ export interface AppiumCommands {
   ): Awaitable<NightwatchAPI, boolean>;
 }
 
+export interface Cookie {
+  name: string;
+  value: string;
+  path?: string;
+  domain?: string;
+  secure?: boolean;
+  httpOnly?: boolean;
+  expiry?: number;
+  sameSite?: 'Lax' | 'Strict' | 'None';
+}
+
+export interface CookiesNsCommands {
+  /**
+   * Retrieve a single cookie visible to the current page.
+   *
+   * The cookie is returned as a cookie JSON object, with properties as defined [here](https://www.w3.org/TR/webdriver/#dfn-table-for-cookie-conversion).
+   *
+   * @example
+   * module.exports = {
+   *   'get a cookie': function (browser) {
+   *     browser
+   *       .cookies.get('test_cookie', function (result) {
+   *         const cookie = result.value;
+   *         this.assert.equal(cookie.name, 'test_cookie');
+   *         this.assert.equal(cookie.value, '123456');
+   *       });
+   *   },
+   *
+   *   'get a cookie with ES6 async/await': async function (browser) {
+   *     const cookie = await browser.cookies.get('test_cookie');
+   *     browser.assert.equal(cookie.name, 'test_cookie');
+   *     browser.assert.equal(cookie.value, '123456');
+   *   }
+   * };
+   */
+  get(
+      name: string,
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<Cookie | null>) => void,
+  ): Awaitable<NightwatchAPI, Cookie | null>;
+
+  /**
+   * Retrieve all cookies visible to the current page.
+   *
+   * The cookies are returned as an array of cookie JSON object, with properties as defined [here](https://www.w3.org/TR/webdriver/#dfn-table-for-cookie-conversion).
+   *
+   * @example
+   * module.exports = {
+   *   'get all cookies': function (browser) {
+   *     browser
+   *       .cookies.getAll(function (result) {
+   *         this.assert.equal(result.value.length, 1);
+   *         this.assert.equal(result.value[0].name, 'test_cookie');
+   *       });
+   *   },
+   *
+   *   'get all cookies with ES6 async/await': async function (browser) {
+   *     const cookies = await browser.cookies.getAll();
+   *     browser.assert.equal(cookies.length, 1);
+   *     browser.assert.equal(cookies[0].name, 'test_cookie');
+   *   }
+   * };
+   */
+  getAll(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<Cookie[]>) => void,
+  ): Awaitable<NightwatchAPI, Cookie[]>;
+
+  /**
+   * Set a cookie, specified as a cookie JSON object, with properties as defined [here](https://www.w3.org/TR/webdriver/#dfn-table-for-cookie-conversion).
+   *
+   * @example
+   * module.exports = {
+   *   'set a cookie': function (browser) {
+   *     browser
+   *       .cookies.set({
+   *         name: "test_cookie",
+   *         value: "test_value",
+   *         path: "/", // (Optional)
+   *         domain: "example.org", // (Optional)
+   *         secure: false, // (Optional)
+   *         httpOnly: false, // (Optional)
+   *         expiry: 1395002765 // (Optional) time in seconds since midnight, January 1, 1970 UTC
+   *       });
+   *   },
+   *
+   *   'set a cookie with ES6 async/await': async function (browser) {
+   *     await browser.cookies.set({
+   *       name: 'test_cookie',
+   *       value: 'test_value',
+   *       domain: 'example.org', // (Optional)
+   *       sameSite: 'Lax' // (Optional)
+   *     });
+   *   }
+   * };
+   */
+  set(
+      cookie: Cookie,
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Delete the cookie with the given name. This command is a no-op if there is no such cookie visible to the current page.
+   *
+   * @example
+   * module.exports = {
+   *   'delete a cookie': function (browser) {
+   *     browser
+   *       .cookies.delete('test_cookie', function () {
+   *         console.log('cookie deleted successfully');
+   *       });
+   *   },
+   *
+   *   'delete a cookie with ES6 async/await': async function (browser) {
+   *     await browser.cookies.delete('test_cookie');
+   *   }
+   * };
+   */
+  delete(
+      cookieName: string,
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Delete all cookies visible to the current page.
+   *
+   * @example
+   * module.exports = {
+   *   'delete all cookies': function (browser) {
+   *     browser
+   *       .cookies.deleteAll(function() {
+   *         console.log('all cookies deleted successfully');
+   *       });
+   *   },
+   *
+   *   'delete all cookies with ES6 async/await': async function (browser) {
+   *     await browser.cookies.deleteAll();
+   *   }
+   * };
+   */
+  deleteAll(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+}
+
 export interface WebDriverProtocol
   extends WebDriverProtocolSessions,
   WebDriverProtocolNavigation,
@@ -5880,6 +6023,8 @@ export interface WebDriverProtocolCookies {
    * @see setCookie
    * @see deleteCookie
    * @see deleteCookies
+   *
+   * @deprecated
    */
   cookie(
     method: "GET" | "DELETE",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -530,6 +530,7 @@ export interface NightwatchAPI
   cookies: CookiesNsCommands;
   alerts: AlertsNsCommands;
   document: DocumentNsCommands;
+  window: WindowNsCommands;
 
   page: NightwatchPage & NightwatchCustomPageObjects;
 
@@ -1286,6 +1287,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    *   });
    * });
    * @see https://nightwatchjs.org/api/closeWindow.html
+   *
+   * @deprecated In favour of `.window.close()`.
    */
   closeWindow(
     callback?: (
@@ -1311,6 +1314,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    *   }
    * }
    * @see https://nightwatchjs.org/api/fullscreenWindow.html
+   *
+   * @deprecated In favour of `.window.fullscreen()`.
    */
   fullscreenWindow(
     callback?: (
@@ -1337,6 +1342,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    *   }
    * }
    * @see https://nightwatchjs.org/api/minimizeWindow.html
+   *
+   * @deprecated In favour of `.window.minimize()`.
    */
   minimizeWindow(
     callback?: (
@@ -1370,6 +1377,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    *   }
    * }
    * @see https://nightwatchjs.org/api/openNewWindow.html
+   *
+   * @deprecated In favour of `.window.open()`.
    */
   openNewWindow(
     type?: WindowType,
@@ -1710,6 +1719,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    *  };
    *
    * @see https://nightwatchjs.org/api/maximizeWindow.html
+   *
+   * @deprecated In favour of `.window.maximize()`.
    */
   maximizeWindow(
     callback?: (
@@ -1861,6 +1872,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    *  };
    *
    * @see https://nightwatchjs.org/api/resizeWindow.html
+   *
+   * @deprecated In favour of `.window.resize()`.
    */
   resizeWindow(
     width: number,
@@ -1928,6 +1941,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    *  };
    *
    * @see https://nightwatchjs.org/api/setWindowPosition.html
+   *
+   * @deprecated In favour of `.window.setPosition()`.
    */
   setWindowPosition(
     offsetX: number,
@@ -1976,6 +1991,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    * }
    *
    * @see https://nightwatchjs.org/api/setWindowRect.html
+   *
+   * @deprecated In favour of `.window.setRect()`.
    */
   setWindowRect(
     options: WindowSizeAndPosition,
@@ -1995,6 +2012,7 @@ export interface ClientCommands extends ChromiumClientCommands {
    *
    * @see https://nightwatchjs.org/api/setWindowSize.html
    *
+   * @deprecated In favour of `.window.setSize()`.
    */
   setWindowSize(
     width: number,
@@ -2027,6 +2045,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    * @alias switchToWindow
    *
    * @see https://nightwatchjs.org/api/switchWindow.html
+   *
+   * @deprecated In favour of `.window.switch()`.
    */
   switchWindow(
     handleOrName: string,
@@ -2056,6 +2076,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    *  };
    *
    * @see https://nightwatchjs.org/api/switchToWindow.html
+   *
+   * @deprecated In favour of `.window.switchTo()`.
    */
   switchToWindow(
     handleOrName: string,
@@ -2092,7 +2114,9 @@ export interface ClientCommands extends ChromiumClientCommands {
    *   }
    * }
    *
-   *  @see https://nightwatchjs.org/api/getWindowRect.html
+   * @see https://nightwatchjs.org/api/getWindowRect.html
+   *
+   * @deprecated In favour of `.window.getRect()`.
    */
   getWindowRect(
     callback?: (
@@ -2124,6 +2148,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    * }
    *
    * @see https://nightwatchjs.org/api/getWindowSize.html
+   *
+   * @deprecated In favour of `.window.getRect()`.
    */
   getWindowSize(
     callback?: (
@@ -2155,6 +2181,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    * }
    *
    * @see https://nightwatchjs.org/api/getWindowPosition.html
+   *
+   * @deprecated In favour of `.window.getPosition()`.
    */
   getWindowPosition(
     callback?: (
@@ -4909,7 +4937,7 @@ export interface DocumentNsCommands {
    *   }
    * };
    *
-   * @alias pageSource
+   * @alias document.pageSource
    */
   source(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<string>) => void,
@@ -4932,11 +4960,474 @@ export interface DocumentNsCommands {
    *   }
    * };
    *
-   * @alias source
+   * @alias document.source
    */
   pageSource(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<string>) => void,
   ): Awaitable<NightwatchAPI, string>;
+}
+
+export interface WindowNsCommands {
+  /**
+   * Close the current window or tab. This can be useful when you're working with multiple windows/tabs open (e.g. an OAuth login).
+   *
+   * After closing a window or tab, you must switch back to a valid window handle (using `.window.switchTo()` command) in order to continue execution.
+   *
+   * @example
+   * module.exports = {
+   *  'close current window/tab': function (browser) {
+   *     browser.window.close(function (result) {
+   *       console.log('current window/tab closed successfully');
+   *     });
+   *   },
+   *
+   *   'close current window/tab with ES6 async/await': async function (browser) {
+   *     await browser.window.close();
+   *   }
+   * };
+   */
+  close(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Opens a new tab (default) or a separate new window, and changes focus to the newly opened tab/window.
+   *
+   * This command is only available for W3C Webdriver compatible browsers.
+   *
+   * @example
+   * module.exports = {
+   *  'open a new tab/window': function (browser) {
+   *     // open a new tab (default)
+   *     browser.window.open(function () {
+   *       console.log('new tab opened successfully');
+   *     });
+   *
+   *     // open a new window
+   *     browser.window.open('window', function () {
+   *       console.log('new window opened successfully');
+   *     });
+   *   },
+   *
+   *   'open a new tab/window ES6 async demo Test': async function (browser) {
+   *     // open a new tab (default)
+   *     await browser.window.open();
+   *
+   *     // open a new window
+   *     await browser.window.open('window');
+   *   }
+   * };
+   *
+   * @alias window.openNew
+   */
+  open(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+  open(
+      type: "window" | "tab",
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Opens a new tab (default) or a separate new window, and changes focus to the newly opened tab/window.
+   *
+   * This command is only available for W3C Webdriver compatible browsers.
+   *
+   * @example
+   * module.exports = {
+   *  'open a new tab/window': function (browser) {
+   *     // open a new tab (default)
+   *     browser.window.openNew(function () {
+   *       console.log('new tab opened successfully');
+   *     });
+   *
+   *     // open a new window
+   *     browser.window.openNew('window', function () {
+   *       console.log('new window opened successfully');
+   *     });
+   *   },
+   *
+   *   'open a new tab/window ES6 async demo Test': async function (browser) {
+   *     // open a new tab (default)
+   *     await browser.window.openNew();
+   *
+   *     // open a new window
+   *     await browser.window.openNew('window');
+   *   }
+   * };
+   *
+   * @alias window.open
+   */
+  openNew(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+  openNew(
+      type: "window" | "tab",
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Retrieve the current window handle.
+   *
+   * WebDriver does not make the distinction between windows and tabs. So, if your site opens a new tab or window, you can work with it using a window handle.
+   *
+   * @example
+   * module.exports = {
+   *  'get current window handle': function (browser) {
+   *     browser.window.getHandle(function (result) {
+   *       console.log('current window handle is:', result.value);
+   *     });
+   *   },
+   *
+   *   'get current window handle with ES6 async/await': async function (browser) {
+   *     const windowHandle = await browser.window.getHandle();
+   *     console.log('current window handle is:', windowHandle);
+   *   }
+   * };
+   */
+  getHandle(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<string>) => void,
+  ): Awaitable<NightwatchAPI, string>;
+
+  /**
+   * Retrieve the list of all window handles available to the session.
+   *
+   * @example
+   * module.exports = {
+   *  'get all window handles': function (browser) {
+   *     browser.window.getAllHandles(function (result) {
+   *       console.log('available window handles are:', result.value);
+   *     });
+   *   },
+   *
+   *   'get all window handles with ES6 async/await': async function (browser) {
+   *     const windowHandles = await browser.window.getAllHandles();
+   *     console.log('available window handles are:', windowHandles);
+   *   }
+   * };
+   */
+  getAllHandles(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<string[]>) => void,
+  ): Awaitable<NightwatchAPI, string[]>;
+
+  /**
+   * Change focus to another window.
+   *
+   * The window to change focus to must be specified by its server assigned window handle. To find out the window handle, use `window.getAllHandles()` command.
+   *
+   * @example
+   * module.exports = {
+   *  'switch to another window': function (browser) {
+   *     browser
+   *       .navigateTo('https://nightwatchjs.org/__e2e/window/')
+   *       .click('#openWindowBttn')
+   *       .waitUntil(function () {
+   *         // wait until window handle for the new window is available
+   *         return new Promise((resolve) => {
+   *           browser.window.getAllHandles(function (result) {
+   *             resolve(result.value.length === 2);
+   *           });
+   *         });
+   *       })
+   *       .perform(async function () {
+   *         const originalWindow = await browser.window.getHandle();
+   *         const allWindows = await browser.window.getAllHandles();
+   *
+   *         // loop through to find the new window handle
+   *         for (const windowHandle of allWindows) {
+   *           if (windowHandle !== originalWindow) {
+   *             await browser.window.switchTo(windowHandle);
+   *             break;
+   *           }
+   *         }
+   *
+   *         const currentWindow = await browser.window.getHandle();
+   *         browser.assert.notEqual(currentWindow, originalWindow);
+   *       });
+   *   },
+   *
+   *   'switch to another window with ES6 async/await': async function (browser) {
+   *     await browser.navigateTo('https://nightwatchjs.org/__e2e/window/');
+   *     await browser.click('#openWindowBttn');
+   *
+   *     // wait until window handle for the new window is available
+   *     await browser.waitUntil(async function () {
+   *       const windowHandles = await browser.window.getAllHandles();
+   *
+   *       return windowHandles.length === 2;
+   *     });
+   *
+   *     const originalWindow = await browser.window.getHandle();
+   *     const allWindows = await browser.window.getAllHandles();
+   *
+   *     // loop through available windows to find the new window handle
+   *     for (const windowHandle of allWindows) {
+   *       if (windowHandle !== originalWindow) {
+   *         await browser.window.switchTo(windowHandle);
+   *         break;
+   *       }
+   *     }
+   *
+   *     const currentWindow = await browser.window.getHandle();
+   *     await browser.assert.notEqual(currentWindow, originalWindow);
+   *   }
+   * };
+   *
+   * @alias window.switch
+   */
+  switchTo(
+      windowHandle: string,
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+  switch(
+      windowHandle: string,
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Increases the window to the maximum available size without going full-screen.
+   *
+   * @example
+   * module.exports = {
+   *  'maximize current window': function (browser) {
+   *     browser.window.maximize(function () {
+   *       console.log('window maximized successfully');
+   *     });
+   *   },
+   *
+   *   'maximize current window using ES6 async/await': async function (browser) {
+   *     await browser.window.maximize();
+   *   }
+   * };
+   */
+  maximize(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Hides the window in the system tray. If the window happens to be in fullscreen mode,
+   * it is restored the normal state then it will be "iconified" - minimize or hide the window from the visible screen.
+   *
+   * @example
+   * module.exports = {
+   *  'minimize current window': function (browser) {
+   *     browser.window.minimize(function () {
+   *       console.log('window minimized successfully');
+   *     });
+   *   },
+   *
+   *   'minimize current window using ES6 async/await': async function (browser) {
+   *     await browser.window.minimize();
+   *   }
+   * };
+   */
+  minimize(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Set the current window state to fullscreen, similar to pressing F11 in most browsers.
+   *
+   * @example
+   * module.exports = {
+   *  'make current window fullscreen': function (browser) {
+   *     browser.window.fullscreen(function () {
+   *       console.log('window in fullscreen mode');
+   *     });
+   *   },
+   *
+   *   'make current window fullscreen with ES6 async/await': async function (browser) {
+   *     await browser.window.fullscreen();
+   *   }
+   * };
+   */
+  fullscreen(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Get the coordinates of the top left corner of the current window.
+   *
+   * @example
+   * module.exports = {
+   *   'get current window position': function (browser) {
+   *      browser.window.getPosition(function (result) {
+   *        console.log('Position of current window:', result.value.x, result.value.y);
+   *      });
+   *   },
+   *
+   *   'get current window position using ES6 async/await': async function (browser) {
+   *      const {x, y} = await browser.window.getPosition();
+   *      console.log('Position of current window:', x, y);
+   *   }
+   * };
+   */
+  getPosition(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<WindowPosition>) => void,
+  ): Awaitable<NightwatchAPI, WindowPosition>;
+
+  /**
+   * Get the size of the current window in pixels.
+   *
+   * @example
+   * module.exports = {
+   *   'get current window size': function (browser) {
+   *      browser.window.getSize(function (result) {
+   *        console.log('Size of current window:', result.value.width, result.value.height);
+   *      });
+   *   },
+   *
+   *   'get current window size using ES6 async/await': async function (browser) {
+   *      const {width, height} = await browser.window.getSize();
+   *      console.log('Size of current window:', width, height);
+   *   }
+   * };
+   */
+  getSize(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<WindowSize>) => void,
+  ): Awaitable<NightwatchAPI, WindowSize>;
+
+  /**
+   * Fetches the [window rect](https://w3c.github.io/webdriver/#dfn-window-rect) - size and position of the current window.
+   *
+   * Its JSON representation is the following:
+   * - `x` - window's screenX attribute;
+   * - `y` - window's screenY attribute;
+   * - `width` - outerWidth attribute;
+   * - `height` - outerHeight attribute.
+   *
+   * All attributes are in CSS pixels.
+   *
+   * @example
+   * module.exports = {
+   *   'get current window rect': function (browser) {
+   *      browser.window.getRect(function (result) {
+   *        console.log('Size of current window:', result.value.width, result.value.height);
+   *        console.log('Position of current window:', result.value.x, result.value.y);
+   *      });
+   *   },
+   *
+   *   'get current window rect using ES6 async/await': async function (browser) {
+   *      const {width, height, x, y} = await browser.window.getRect();
+   *      console.log('Size of current window:', width, height);
+   *      console.log('Position of current window:', x, y);
+   *   }
+   * };
+   */
+  getRect(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<WindowSizeAndPosition>) => void,
+  ): Awaitable<NightwatchAPI, WindowSizeAndPosition>;
+
+  /**
+   * Set the position of the current window - move the window to the chosen position.
+   *
+   * @example
+   * module.exports = {
+   *   'set current window position': function (browser) {
+   *      // Move the window to the top left of the primary monitor
+   *      browser.window.setPosition(0, 0, function (result) {
+   *        console.log('window moved successfully');
+   *      });
+   *   },
+   *
+   *   'set current window position using ES6 async/await': async function (browser) {
+   *      // Move the window to the top left of the primary monitor
+   *      await browser.window.setPosition(0, 0);
+   *   }
+   * };
+   */
+  setPosition(
+      x: number,
+      y: number,
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Set the size of the current window in CSS pixels.
+   *
+   * @example
+   * module.exports = {
+   *   'set current window size': function (browser) {
+   *      browser.window.setSize(1024, 768, function (result) {
+   *        console.log('window resized successfully');
+   *      });
+   *   },
+   *
+   *   'set current window size using ES6 async/await': async function (browser) {
+   *      await browser.window.setSize(1024, 768);
+   *   }
+   * };
+   *
+   * @alias window.resize
+   */
+  setSize(
+      width: number,
+      height: number,
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Set the size of the current window in CSS pixels.
+   *
+   * @example
+   * module.exports = {
+   *   'set current window size': function (browser) {
+   *      browser.window.setSize(1024, 768, function (result) {
+   *        console.log('window resized successfully');
+   *      });
+   *   },
+   *
+   *   'set current window size using ES6 async/await': async function (browser) {
+   *      await browser.window.setSize(1024, 768);
+   *   }
+   * };
+   *
+   * @alias window.setSize
+   */
+  resize(
+      width: number,
+      height: number,
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Change the [window rect](https://w3c.github.io/webdriver/#dfn-window-rect) - size and position of the current window.
+   *
+   * Its JSON representation is the following:
+   * - `x` - window's screenX attribute;
+   * - `y` - window's screenY attribute;
+   * - `width` - outerWidth attribute;
+   * - `height` - outerHeight attribute.
+   *
+   * All attributes are in CSS pixels.
+   *
+   * To change the window rect, you can either specify `width` and `height` together, `x` and `y` together, or all properties together.
+   *
+   * @example
+   * module.exports = {
+   *   'set current window rect': function (browser) {
+   *      // Change the screenX and screenY attributes of the window rect.
+   *      browser.window.setRect({x: 500, y: 500});
+   *
+   *      // Change the outerWidth and outerHeight attributes of the window rect.
+   *      browser.window.setRect({width: 600, height: 300});
+   *   },
+   *
+   *   'set current window rect using ES6 async/await': async function (browser) {
+   *      // Change all attributes of the window rect at once.
+   *      await browser.window.setRect({
+   *        width: 600,
+   *        height: 300,
+   *        x: 100,
+   *        y: 100
+   *      });
+   *   }
+   * };
+   */
+  setRect(
+      options: WindowSize | WindowPosition | WindowSizeAndPosition,
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
 }
 
 export interface WebDriverProtocol
@@ -5264,23 +5755,6 @@ export interface WebDriverProtocolNavigation {
 
 export interface WebDriverProtocolCommandContexts {
   /**
-   * Change focus to another window or close the current window.
-   * Shouldn't normally be used directly, instead `.switchWindow()` and `.closeWindow()` should be used.
-   *
-   * @see https://nightwatchjs.org/api/window.html
-   *
-   * @deprecated Use `.switchWindow()` and `.closeWindow()` instead.
-   */
-  window(
-    method: "post" | "delete" | "POST" | "DELETE",
-    handleOrName?: string,
-    callback?: (
-      this: NightwatchAPI,
-      result: NightwatchCallbackResult<null>
-    ) => void
-  ): Awaitable<this, null>;
-
-  /**
    * Retrieve the current window handle.
    *
    * @example
@@ -5291,6 +5765,8 @@ export interface WebDriverProtocolCommandContexts {
    *  }
    *
    * @see https://nightwatchjs.org/api/windowHandle.html
+   *
+   * @deprecated In favour of `.window.getHandle()`.
    */
   windowHandle(
     callback?: (
@@ -5311,6 +5787,8 @@ export interface WebDriverProtocolCommandContexts {
    *  }
    *
    * @see https://nightwatchjs.org/api/windowHandles.html
+   *
+   * @deprecated In favour of `.window.getAllHandles()`.
    */
   windowHandles(
     callback?: (
@@ -5330,6 +5808,8 @@ export interface WebDriverProtocolCommandContexts {
    *  }
    *
    * @see https://nightwatchjs.org/api/windowMaximize.html
+   *
+   * @deprecated In favour of `.window.maximize()`.
    */
   windowMaximize(
     handleOrName?: string,
@@ -5360,6 +5840,8 @@ export interface WebDriverProtocolCommandContexts {
    *  }
    *
    * @see https://nightwatchjs.org/api/windowPosition.html
+   *
+   * @deprecated In favour of `.window.getPosition()` and `.window.setPosition()`.
    */
   windowPosition(
     windowHandle: string,
@@ -5397,6 +5879,8 @@ export interface WebDriverProtocolCommandContexts {
    *  }
    *
    * @see https://nightwatchjs.org/api/windowSize.html
+   *
+   * @deprecated In favour of `.window.getSize()` and `.window.setSize()`.
    */
   windowSize(
     windowHandle: string,
@@ -5450,6 +5934,8 @@ export interface WebDriverProtocolCommandContexts {
    * }
    *
    * @see https://nightwatchjs.org/api/windowRect.html
+   *
+   * @deprecated In favour of `.window.getRect()` and `.window.setRect()`.
    */
   windowRect(
     options: { width?: number; height?: number; x?: number; y?: number },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -529,6 +529,7 @@ export interface NightwatchAPI
   appium: AppiumCommands;
   cookies: CookiesNsCommands;
   alerts: AlertsNsCommands;
+  document: DocumentNsCommands;
 
   page: NightwatchPage & NightwatchCustomPageObjects;
 
@@ -1664,15 +1665,24 @@ export interface ClientCommands extends ChromiumClientCommands {
    * };
    *
    * @see https://nightwatchjs.org/api/injectScript.html
+   *
+   * @deprecated In favour of `.document.injectScript()`.
    */
   injectScript(
     scriptUrl: string,
-    id?: string,
     callback?: (
       this: NightwatchAPI,
-      result: NightwatchCallbackResult<HTMLScriptElement>
-    ) => void
-  ): Awaitable<this, HTMLScriptElement>;
+      result: NightwatchCallbackResult<WebElement>
+    ) => void,
+  ): Awaitable<this, WebElement>;
+  injectScript(
+    scriptUrl: string,
+    id: string,
+    callback?: (
+      this: NightwatchAPI,
+      result: NightwatchCallbackResult<WebElement>
+    ) => void,
+  ): Awaitable<this, WebElement>;
 
   /**
    * Utility command to test if the log type is available.
@@ -2164,6 +2174,8 @@ export interface ClientCommands extends ChromiumClientCommands {
    *  };
    *
    * @see https://nightwatchjs.org/api/pageSource.html
+   *
+   * @deprecated In favour of `.document.pageSource()`.
    */
   pageSource(
     callback?: (
@@ -4853,6 +4865,80 @@ export interface AlertsNsCommands {
   ): Awaitable<NightwatchAPI, null>;
 }
 
+export interface DocumentNsCommands {
+  /**
+   * Utility command to load an external script into the page specified by url.
+   *
+   * @example
+   * module.exports = {
+   *   'inject external script': function (browser) {
+   *      browser.document.injectScript('<script-url>', function () {
+   *        console.log('script injected successfully');
+   *      });
+   *   },
+   *
+   *   'inject external script using ES6 async/await': async function (browser) {
+   *      await browser.document.injectScript('<script-url>', 'injected-script');
+   *   }
+   * };
+   */
+  injectScript(
+      scriptUrl: string,
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<WebElement>) => void,
+  ): Awaitable<NightwatchAPI, WebElement>;
+  injectScript(
+      scriptUrl: string,
+      id: string,
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<WebElement>) => void,
+  ): Awaitable<NightwatchAPI, WebElement>;
+
+  /**
+   * Get the string serialized source of the current page.
+   *
+   * @example
+   * module.exports = {
+   *   'get page source': function (browser) {
+   *      browser.document.source(function (result) {
+   *        console.log('current page source:', result.value);
+   *      });
+   *   },
+   *
+   *   'get page source using ES6 async/await': async function (browser) {
+   *      const pageSource = await browser.document.source();
+   *      console.log('current page source:', pageSource);
+   *   }
+   * };
+   *
+   * @alias pageSource
+   */
+  source(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<string>) => void,
+  ): Awaitable<NightwatchAPI, string>;
+
+  /**
+   * Get the string serialized source of the current page.
+   *
+   * @example
+   * module.exports = {
+   *   'get page source': function (browser) {
+   *      browser.document.pageSource(function (result) {
+   *        console.log('current page source:', result.value);
+   *      });
+   *   },
+   *
+   *   'get page source using ES6 async/await': async function (browser) {
+   *      const pageSource = await browser.document.pageSource();
+   *      console.log('current page source:', pageSource);
+   *   }
+   * };
+   *
+   * @alias source
+   */
+  pageSource(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<string>) => void,
+  ): Awaitable<NightwatchAPI, string>;
+}
+
 export interface WebDriverProtocol
   extends WebDriverProtocolSessions,
   WebDriverProtocolNavigation,
@@ -5913,7 +5999,9 @@ export interface WebDriverProtocolDocumentHandling {
    * @example
    * browser.source();
    *
-   * @see https://nightwatchjs.org/api/source.html#apimethod-container
+   * @see https://nightwatchjs.org/api/source.html
+   *
+   * @deprecated In favour of `.document.source()`.
    */
   source(
     callback?: (

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -528,6 +528,7 @@ export interface NightwatchAPI
 
   appium: AppiumCommands;
   cookies: CookiesNsCommands;
+  alerts: AlertsNsCommands;
 
   page: NightwatchPage & NightwatchCustomPageObjects;
 
@@ -4761,6 +4762,97 @@ export interface CookiesNsCommands {
   ): Awaitable<NightwatchAPI, null>;
 }
 
+export interface AlertsNsCommands {
+  /**
+   * Accepts the currently displayed alert dialog. Usually, this is equivalent to clicking on the 'OK' button in the dialog.
+   *
+   * @example
+   * module.exports = {
+   *   'accept open alert': function (browser) {
+   *     browser
+   *       .alerts.accept(function () {
+   *         console.log('alert accepted successfully');
+   *       });
+   *   },
+   *
+   *   'accept open alert with ES6 async/await': async function (browser) {
+   *     await browser.alerts.accept();
+   *   }
+   * };
+   */
+  accept(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Dismisses the currently displayed alert dialog.
+   *
+   * For confirm() and prompt() dialogs, this is equivalent to clicking the 'Cancel' button.
+   * For alert() dialogs, this is equivalent to clicking the 'OK' button.
+   *
+   * @example
+   * module.exports = {
+   *   'dismiss open alert': function (browser) {
+   *     browser
+   *       .alerts.dismiss(function () {
+   *         console.log('alert dismissed successfully');
+   *       });
+   *   },
+   *
+   *   'dismiss open alert with ES6 async/await': async function (browser) {
+   *     await browser.alerts.dismiss();
+   *   }
+   * };
+   */
+  dismiss(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+
+  /**
+   * Get the text of the currently displayed JavaScript alert(), confirm(), or prompt() dialog.
+   *
+   * @example
+   * module.exports = {
+   *   'get open alert text': function (browser) {
+   *     browser
+   *       .alerts.getText(function (result) {
+   *         console.log('text on open alert:', result.value);
+   *       });
+   *   },
+   *
+   *   'get open alert text with ES6 async/await': async function (browser) {
+   *     const alertText = await browser.alerts.getText();
+   *     console.log('text on open alert:', alertText);
+   *   }
+   * };
+   */
+  getText(
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<string>) => void,
+  ): Awaitable<NightwatchAPI, string>;
+
+  /**
+   * Send keystrokes to a JavaScript prompt() dialog.
+   *
+   * @example
+   * module.exports = {
+   *   'set text on JS prompt': function (browser) {
+   *     browser
+   *       .alerts.setText('some text', function () {
+   *         console.log('text sent to JS prompt successfully');
+   *       });
+   *   },
+   *
+   *   'set text on JS prompt with ES6 async/await': async function (browser) {
+   *     await browser.alerts.setText('some text');
+   *   }
+   * };
+   */
+  setText(
+      value: string,
+      callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
+  ): Awaitable<NightwatchAPI, null>;
+}
+
 export interface WebDriverProtocol
   extends WebDriverProtocolSessions,
   WebDriverProtocolNavigation,
@@ -6310,7 +6402,9 @@ export interface WebDriverProtocolUserPrompts {
    * @example
    * browser.acceptAlert()
    *
-   * @see https://nightwatchjs.org/api/acceptAlert.html#apimethod-container
+   * @see https://nightwatchjs.org/api/acceptAlert.html
+   *
+   * @deprecated In favour of `.alerts.accept()`.
    */
   acceptAlert(
     callback?: (
@@ -6327,7 +6421,9 @@ export interface WebDriverProtocolUserPrompts {
    * @example
    * browser.dismissAlert();
    *
-   * @see https://nightwatchjs.org/api/dismissAlert.html#apimethod-container
+   * @see https://nightwatchjs.org/api/dismissAlert.html
+   *
+   * @deprecated In favour of `.alerts.dismiss()`.
    */
   dismissAlert(
     callback?: (
@@ -6342,7 +6438,9 @@ export interface WebDriverProtocolUserPrompts {
    * @example
    * browser.getAlertText();
    *
-   * @see https://nightwatchjs.org/api/getAlertText.html#apimethod-container
+   * @see https://nightwatchjs.org/api/getAlertText.html
+   *
+   * @deprecated In favour of `.alerts.getText()`.
    */
   getAlertText(
     callback?: (
@@ -6357,7 +6455,9 @@ export interface WebDriverProtocolUserPrompts {
    * @example
    * browser.setAlertText('randomalert');
    *
-   * @see https://nightwatchjs.org/api/setAlertText.html#apimethod-container
+   * @see https://nightwatchjs.org/api/setAlertText.html
+   *
+   * @deprecated In favour of `.alerts.setText()`.
    */
   setAlertText(
     value: string,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,6 +34,7 @@ import { NightwatchGlobals } from './globals';
 import { EnhancedPageObject } from './page-object';
 import { NightwatchCustomCommands } from './custom-command';
 import { NightwatchDesiredCapabilities, NightwatchOptions, NightwatchTestOptions } from './nightwatch-options';
+import { IfUnknown } from './utils';
 
 export * from './globals';
 export * from './expect';
@@ -492,6 +493,18 @@ export type NightwatchPage = {
   [name: string]: NightwatchPage;
 };
 
+export interface NamespacedApi<ReturnType = unknown> {
+  appium: AppiumCommands<ReturnType>;
+  cookies: CookiesNsCommands<ReturnType>;
+  alerts: AlertsNsCommands<ReturnType>;
+  document: DocumentNsCommands<ReturnType>;
+  window: WindowNsCommands<ReturnType>;
+
+  assert: Assert<ReturnType>;
+  verify: Assert<ReturnType>;
+  expect: Expect;
+}
+
 export interface NightwatchApiCommands {
   readonly WEBDRIVER_ELEMENT_ID: string;
   readonly browserName: string;
@@ -518,19 +531,11 @@ export interface NightwatchAPI
   extends SharedCommands,
   WebDriverProtocol,
   NightwatchCustomCommands,
-  NightwatchApiCommands {
+  NightwatchApiCommands,
+  NamespacedApi<NightwatchAPI> {
   baseUrl: string;
-  assert: Assert;
   actions(options?: { async?: boolean; bridge?: boolean }): Actions;
-  expect: Expect;
   ensure: Ensure;
-  verify: Assert;
-
-  appium: AppiumCommands;
-  cookies: CookiesNsCommands;
-  alerts: AlertsNsCommands;
-  document: DocumentNsCommands;
-  window: WindowNsCommands;
 
   page: NightwatchPage & NightwatchCustomPageObjects;
 
@@ -912,6 +917,7 @@ export interface CreateClientParams {
   config?: string;
 }
 
+// TODO: add namespaced api to `Nightwatch` interface only after fixing EnhancedPageObject.
 export interface Nightwatch {
   cli(callback: any): this;
   client(settings: NightwatchOptions, reporter?: any, argv?: {}): this;
@@ -936,9 +942,9 @@ export interface Nightwatch {
   runner(argv?: {}, done?: () => void, settings?: {}): this;
   runTests(testSource: string | string[], settings?: any, ...args: any[]): any;
   api: NightwatchAPI;
-  assert: Assert;
+  assert: Assert<NightwatchAPI>;
   expect: Expect;
-  verify: Assert;
+  verify: Assert<NightwatchAPI>;
   updateCapabilities(...args: any): this;
   launchBrowser(): NightwatchAPI | Promise<NightwatchAPI>;
 }
@@ -4267,7 +4273,7 @@ export interface ElementCommands {
   ): Awaitable<this, string>;
 }
 
-export interface AppiumCommands {
+export interface AppiumCommands<ReturnType = unknown> {
   /**
    * Get the current device orientation.
    *
@@ -4291,7 +4297,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<'LANDSCAPE' | 'PORTRAIT'>
     ) => void
-  ): Awaitable<NightwatchAPI, 'LANDSCAPE' | 'PORTRAIT'>;
+  ): Awaitable<IfUnknown<ReturnType, this>, 'LANDSCAPE' | 'PORTRAIT'>;
 
   /**
    * Set the current device orientation.
@@ -4310,7 +4316,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<'LANDSCAPE' | 'PORTRAIT'>
     ) => void
-  ): Awaitable<NightwatchAPI, 'LANDSCAPE' | 'PORTRAIT'>;
+  ): Awaitable<IfUnknown<ReturnType, this>, 'LANDSCAPE' | 'PORTRAIT'>;
 
   /**
    * Get a list of the available contexts. Used when testing hybrid mobile apps using Appium.
@@ -4337,7 +4343,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<string[]>
     ) => void
-  ): Awaitable<NightwatchAPI, string[]>;
+  ): Awaitable<IfUnknown<ReturnType, this>, string[]>;
 
   /**
    * Get the current context in which Appium is running. Used when testing hybrid mobile apps using Appium.
@@ -4364,7 +4370,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<string | null>
     ) => void
-  ): Awaitable<NightwatchAPI, string | null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, string | null>;
 
   /**
    * Set the context to be automated. Used when testing hybrid mobile apps using Appium.
@@ -4400,7 +4406,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<null>
     ) => void
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Start an Android activity by providing package name, activity name and other optional parameters.
@@ -4443,7 +4449,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<null>
     ) => void
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Get the name of the current Android activity.
@@ -4468,7 +4474,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<string>
     ) => void
-  ): Awaitable<NightwatchAPI, string>;
+  ): Awaitable<IfUnknown<ReturnType, this>, string>;
 
   /**
    * Get the name of the current Android package.
@@ -4493,7 +4499,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<string>
     ) => void
-  ): Awaitable<NightwatchAPI, string>;
+  ): Awaitable<IfUnknown<ReturnType, this>, string>;
 
   /**
    * Get the current geolocation of the mobile device.
@@ -4518,7 +4524,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<AppiumGeolocation>
     ) => void
-  ): Awaitable<NightwatchAPI, AppiumGeolocation>;
+  ): Awaitable<IfUnknown<ReturnType, this>, AppiumGeolocation>;
 
   /**
    * Set the current geolocation of the mobile device.
@@ -4541,7 +4547,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<AppiumGeolocation>
     ) => void
-  ): Awaitable<NightwatchAPI, AppiumGeolocation>;
+  ): Awaitable<IfUnknown<ReturnType, this>, AppiumGeolocation>;
 
   /**
    * Press a particular key on an Android Device.
@@ -4566,7 +4572,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<null>
     ) => void
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
   pressKeyCode(
     keycode: number,
     metastate?: number,
@@ -4575,7 +4581,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<null>
     ) => void
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Press and hold a particular key on an Android Device.
@@ -4600,7 +4606,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<null>
     ) => void
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
   longPressKeyCode(
     keycode: number,
     metastate?: number,
@@ -4609,7 +4615,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<null>
     ) => void
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Hide soft keyboard.
@@ -4631,7 +4637,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<boolean>
     ) => void
-  ): Awaitable<NightwatchAPI, boolean>;
+  ): Awaitable<IfUnknown<ReturnType, this>, boolean>;
 
   /**
    * Whether or not the soft keyboard is shown.
@@ -4656,7 +4662,7 @@ export interface AppiumCommands {
       this: NightwatchAPI,
       result: NightwatchCallbackResult<boolean>
     ) => void
-  ): Awaitable<NightwatchAPI, boolean>;
+  ): Awaitable<IfUnknown<ReturnType, this>, boolean>;
 }
 
 export interface Cookie {
@@ -4670,7 +4676,7 @@ export interface Cookie {
   sameSite?: 'Lax' | 'Strict' | 'None';
 }
 
-export interface CookiesNsCommands {
+export interface CookiesNsCommands<ReturnType = unknown> {
   /**
    * Retrieve a single cookie visible to the current page.
    *
@@ -4697,7 +4703,7 @@ export interface CookiesNsCommands {
   get(
       name: string,
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<Cookie | null>) => void,
-  ): Awaitable<NightwatchAPI, Cookie | null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, Cookie | null>;
 
   /**
    * Retrieve all cookies visible to the current page.
@@ -4723,7 +4729,7 @@ export interface CookiesNsCommands {
    */
   getAll(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<Cookie[]>) => void,
-  ): Awaitable<NightwatchAPI, Cookie[]>;
+  ): Awaitable<IfUnknown<ReturnType, this>, Cookie[]>;
 
   /**
    * Set a cookie, specified as a cookie JSON object, with properties as defined [here](https://www.w3.org/TR/webdriver/#dfn-table-for-cookie-conversion).
@@ -4756,7 +4762,7 @@ export interface CookiesNsCommands {
   set(
       cookie: Cookie,
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Delete the cookie with the given name. This command is a no-op if there is no such cookie visible to the current page.
@@ -4778,7 +4784,7 @@ export interface CookiesNsCommands {
   delete(
       cookieName: string,
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Delete all cookies visible to the current page.
@@ -4799,10 +4805,10 @@ export interface CookiesNsCommands {
    */
   deleteAll(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 }
 
-export interface AlertsNsCommands {
+export interface AlertsNsCommands<ReturnType = unknown> {
   /**
    * Accepts the currently displayed alert dialog. Usually, this is equivalent to clicking on the 'OK' button in the dialog.
    *
@@ -4822,7 +4828,7 @@ export interface AlertsNsCommands {
    */
   accept(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Dismisses the currently displayed alert dialog.
@@ -4846,7 +4852,7 @@ export interface AlertsNsCommands {
    */
   dismiss(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Get the text of the currently displayed JavaScript alert(), confirm(), or prompt() dialog.
@@ -4868,7 +4874,7 @@ export interface AlertsNsCommands {
    */
   getText(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<string>) => void,
-  ): Awaitable<NightwatchAPI, string>;
+  ): Awaitable<IfUnknown<ReturnType, this>, string>;
 
   /**
    * Send keystrokes to a JavaScript prompt() dialog.
@@ -4890,10 +4896,10 @@ export interface AlertsNsCommands {
   setText(
       value: string,
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 }
 
-export interface DocumentNsCommands {
+export interface DocumentNsCommands<ReturnType = unknown> {
   /**
    * Utility command to load an external script into the page specified by url.
    *
@@ -4913,12 +4919,12 @@ export interface DocumentNsCommands {
   injectScript(
       scriptUrl: string,
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<WebElement>) => void,
-  ): Awaitable<NightwatchAPI, WebElement>;
+  ): Awaitable<IfUnknown<ReturnType, this>, WebElement>;
   injectScript(
       scriptUrl: string,
       id: string,
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<WebElement>) => void,
-  ): Awaitable<NightwatchAPI, WebElement>;
+  ): Awaitable<IfUnknown<ReturnType, this>, WebElement>;
 
   /**
    * Get the string serialized source of the current page.
@@ -4941,7 +4947,7 @@ export interface DocumentNsCommands {
    */
   source(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<string>) => void,
-  ): Awaitable<NightwatchAPI, string>;
+  ): Awaitable<IfUnknown<ReturnType, this>, string>;
 
   /**
    * Get the string serialized source of the current page.
@@ -4964,10 +4970,10 @@ export interface DocumentNsCommands {
    */
   pageSource(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<string>) => void,
-  ): Awaitable<NightwatchAPI, string>;
+  ): Awaitable<IfUnknown<ReturnType, this>, string>;
 }
 
-export interface WindowNsCommands {
+export interface WindowNsCommands<ReturnType = unknown> {
   /**
    * Close the current window or tab. This can be useful when you're working with multiple windows/tabs open (e.g. an OAuth login).
    *
@@ -4988,7 +4994,7 @@ export interface WindowNsCommands {
    */
   close(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Opens a new tab (default) or a separate new window, and changes focus to the newly opened tab/window.
@@ -5022,11 +5028,11 @@ export interface WindowNsCommands {
    */
   open(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
   open(
       type: "window" | "tab",
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Opens a new tab (default) or a separate new window, and changes focus to the newly opened tab/window.
@@ -5060,11 +5066,11 @@ export interface WindowNsCommands {
    */
   openNew(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
   openNew(
       type: "window" | "tab",
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Retrieve the current window handle.
@@ -5087,7 +5093,7 @@ export interface WindowNsCommands {
    */
   getHandle(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<string>) => void,
-  ): Awaitable<NightwatchAPI, string>;
+  ): Awaitable<IfUnknown<ReturnType, this>, string>;
 
   /**
    * Retrieve the list of all window handles available to the session.
@@ -5108,7 +5114,7 @@ export interface WindowNsCommands {
    */
   getAllHandles(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<string[]>) => void,
-  ): Awaitable<NightwatchAPI, string[]>;
+  ): Awaitable<IfUnknown<ReturnType, this>, string[]>;
 
   /**
    * Change focus to another window.
@@ -5178,11 +5184,11 @@ export interface WindowNsCommands {
   switchTo(
       windowHandle: string,
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
   switch(
       windowHandle: string,
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Increases the window to the maximum available size without going full-screen.
@@ -5202,7 +5208,7 @@ export interface WindowNsCommands {
    */
   maximize(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Hides the window in the system tray. If the window happens to be in fullscreen mode,
@@ -5223,7 +5229,7 @@ export interface WindowNsCommands {
    */
   minimize(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Set the current window state to fullscreen, similar to pressing F11 in most browsers.
@@ -5243,7 +5249,7 @@ export interface WindowNsCommands {
    */
   fullscreen(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Get the coordinates of the top left corner of the current window.
@@ -5264,7 +5270,7 @@ export interface WindowNsCommands {
    */
   getPosition(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<WindowPosition>) => void,
-  ): Awaitable<NightwatchAPI, WindowPosition>;
+  ): Awaitable<IfUnknown<ReturnType, this>, WindowPosition>;
 
   /**
    * Get the size of the current window in pixels.
@@ -5285,7 +5291,7 @@ export interface WindowNsCommands {
    */
   getSize(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<WindowSize>) => void,
-  ): Awaitable<NightwatchAPI, WindowSize>;
+  ): Awaitable<IfUnknown<ReturnType, this>, WindowSize>;
 
   /**
    * Fetches the [window rect](https://w3c.github.io/webdriver/#dfn-window-rect) - size and position of the current window.
@@ -5316,7 +5322,7 @@ export interface WindowNsCommands {
    */
   getRect(
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<WindowSizeAndPosition>) => void,
-  ): Awaitable<NightwatchAPI, WindowSizeAndPosition>;
+  ): Awaitable<IfUnknown<ReturnType, this>, WindowSizeAndPosition>;
 
   /**
    * Set the position of the current window - move the window to the chosen position.
@@ -5340,7 +5346,7 @@ export interface WindowNsCommands {
       x: number,
       y: number,
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Set the size of the current window in CSS pixels.
@@ -5364,7 +5370,7 @@ export interface WindowNsCommands {
       width: number,
       height: number,
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Set the size of the current window in CSS pixels.
@@ -5388,7 +5394,7 @@ export interface WindowNsCommands {
       width: number,
       height: number,
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 
   /**
    * Change the [window rect](https://w3c.github.io/webdriver/#dfn-window-rect) - size and position of the current window.
@@ -5427,7 +5433,7 @@ export interface WindowNsCommands {
   setRect(
       options: WindowSize | WindowPosition | WindowSizeAndPosition,
       callback?: (this: NightwatchAPI, result: NightwatchCallbackResult<null>) => void,
-  ): Awaitable<NightwatchAPI, null>;
+  ): Awaitable<IfUnknown<ReturnType, this>, null>;
 }
 
 export interface WebDriverProtocol
@@ -7149,6 +7155,20 @@ export interface WebDriverProtocolMobileRelated {
     ) => void
   ): Awaitable<this, null>;
 }
+
+// namespaced api
+export const browser: NightwatchAPI;
+export const app: NightwatchAPI;
+
+export const appium: AppiumCommands;
+export const cookies: CookiesNsCommands;
+export const alerts: AlertsNsCommands;
+export const document: DocumentNsCommands;
+export const window: WindowNsCommands;
+
+export const assert: Assert;
+export const verify: Assert;
+export const expect: Expect;
 
 declare const _default: Nightwatch;
 export default _default;

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -13,3 +13,10 @@ export type MergeObjectsArray<T> = T extends Array<infer U>
       [K in keyof U]: U[K];
     }
   : T;
+
+/**
+ * If the first type is of type `unknown`, change it to the second type.
+ */
+export type IfUnknown<T, X> = unknown extends T ? X : T;
+
+


### PR DESCRIPTION
This PR adds types for the modified non-element API and new namespaced API.

Because the return type of all the namespaced commands will differ based on whether they are called as `browser.namespace.commandName()`, or directly as `namespace.commandName()` by importing the namespace from `'nightwatch'` first, a `ReturnType` generic is used to decide that return type.
* In normal cases (when commands are called as `browser.namespace.commandName()`), `ReturnType` is set to `NightwatchAPI` so that the commands continue to work as before.
* In cases where the namespace is imported from 'nightwatch', `ReturnType` will be `unknown` (its default type) and hence the commands will return `this` (the namespace itself).