### PR TITLE
Bump patch Version for ejs from 3.1.8 to 3.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "devtools-protocol": "^0.0.1140464",
     "didyoumean": "1.2.2",
     "dotenv": "10.0.0",
-    "ejs": "3.1.8",
+    "ejs": "3.1.9",
     "envinfo": "7.8.1",
     "fs-extra": "^10.1.0",
     "glob": "^7.2.3",


### PR DESCRIPTION
Bump patch Version for ejs from 3.1.8 to 3.1.9 as ejs v 3.1.8 has some security vulnerabilities