### PR TITLE
Fix types for page objects.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -489,11 +489,10 @@ export interface NightwatchKeys {
 }
 
 /**
- * Keeping for backward compatibility.
+ * Kept for backward compatibility.
  *
- * If `NightwatchPage` type is removed, users would need to do extra work after
- * migrating to v3 to fix the types for page objects, which we don't want. So,
- * users can keep using these default types for page objects, but if they want
+ * NightwatchPage provides some basic types for page objects. 
+ * Users can keep using these default types for page objects, but if they want
  * to be strict, they can define their own page object types by extending
  * `NightwatchCustomPageObjects` interface.
  *

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -488,6 +488,34 @@ export interface NightwatchKeys {
   COMMAND: string;
 }
 
+/**
+ * Keeping for backward compatibility.
+ *
+ * If `NightwatchPage` type is removed, users would need to do extra work after
+ * migrating to v3 to fix the types for page objects, which we don't want. So,
+ * users can keep using these default types for page objects, but if they want
+ * to be strict, they can define their own page object types by extending
+ * `NightwatchCustomPageObjects` interface.
+ *
+ * @example
+ * // using default types
+ * const googlePage = browser.page.google();
+ * 
+ * // defining types by extending NightwatchCustomPageObjects interface
+ * interface GooglePage
+ *   extends EnhancedPageObject<
+ *     typeof googleCommands,
+ *     typeof googlePage.elements
+ *   > {}
+ *
+ * declare module 'nightwatch' {
+ *   interface NightwatchCustomPageObjects {
+ *     google(): GooglePage;
+ *   }
+ * }
+ *
+ * const googlePage = browser.page.google(); // type automatically inferred as GooglePage
+ */
 export type NightwatchPage = {
   [name: string]: () => EnhancedPageObject<any, any, any>;
 } & {

--- a/types/page-object.d.ts
+++ b/types/page-object.d.ts
@@ -92,10 +92,10 @@ export interface SectionProperties {
 
 export type EnhancedSectionInstance<
   Commands = {},
-  Props = {},
   Elements = {},
-  Sections extends Record<string, PageObjectSection> = {}
-> = EnhancedPageObjectSections<Commands, Props, Elements, Sections> &
+  Sections extends Record<string, PageObjectSection> = {},
+  Props = {}
+> = EnhancedPageObjectSections<Commands, Elements, Sections, Props> &
   Commands &
   ElementCommands &
   ChromiumClientCommands &
@@ -151,15 +151,14 @@ interface PageObjectSection {
 
 export interface EnhancedPageObjectSections<
   Commands = {},
-  Props = {},
   Elements = {},
-  Sections extends Record<string, PageObjectSection> = {}
+  Sections extends Record<string, PageObjectSection> = {},
+  Props = {}
 > extends EnhancedPageObjectSharedFields<
-  {},
   Commands,
-  Props,
   Elements,
-  Sections
+  Sections,
+  Props
 > {
   /**
    * The element selector name
@@ -195,9 +194,9 @@ interface EnhancedPageObjectSharedFields<
   section: {
     [Key in keyof Sections]: EnhancedSectionInstance<
       Required<MergeObjectsArray<Sections[Key]['commands']>>,
-      Sections[Key]['props'],
       Sections[Key]['elements'],
-      Sections[Key]['sections']
+      Sections[Key]['sections'],
+      Sections[Key]['props']
     >;
   };
 

--- a/types/page-object.d.ts
+++ b/types/page-object.d.ts
@@ -87,7 +87,23 @@ export interface SectionProperties {
    *   }
    * }
    */
-  commands?: Record<string, () => unknown>[];
+  commands?: Partial<Record<string, (...args: any) => unknown>>[]
+
+  /**
+   * An object or a function returning an object representing a container for user variables.
+   * Props objects are copied directly into the props property of the page object instance.
+   *
+   * @example
+   * sections: {
+   *   apps: {
+   *     selector: 'div.gb_pc',
+   *     props: {
+   *       myVar: "some info"
+   *     }
+   *   }
+   * }
+   */
+  props?: Record<string, unknown> | (() => Record<string, unknown>);
 }
 
 export type EnhancedSectionInstance<
@@ -143,10 +159,10 @@ export type EnhancedSectionInstance<
   Pick<Nightwatch, 'client' | 'api' | 'assert' | 'verify' | 'expect'>;
 
 interface PageObjectSection {
-  commands: Record<string, unknown>;
-  props: Record<string, unknown>;
-  elements: Record<string, unknown>;
-  sections: Record<string, PageObjectSection>;
+  commands?: Record<string, unknown>[];
+  props?: Record<string, unknown>;
+  elements?: Record<string, unknown>;
+  sections?: any;
 }
 
 export interface EnhancedPageObjectSections<
@@ -194,9 +210,9 @@ interface EnhancedPageObjectSharedFields<
   section: {
     [Key in keyof Sections]: EnhancedSectionInstance<
       Required<MergeObjectsArray<Sections[Key]['commands']>>,
-      Sections[Key]['elements'],
-      Sections[Key]['sections'],
-      Sections[Key]['props']
+      Required<Sections[Key]['elements']>,
+      Required<Sections[Key]['sections']>,
+      Required<Sections[Key]['props']>
     >;
   };
 

--- a/types/page-object.d.ts
+++ b/types/page-object.d.ts
@@ -171,11 +171,11 @@ export interface EnhancedPageObjectSections<
 }
 
 interface EnhancedPageObjectSharedFields<
-  URL = string,
   Commands = {},
-  Props = {},
   Elements = {},
-  Sections extends Record<string, PageObjectSection> = {}
+  Sections extends Record<string, PageObjectSection> = {},
+  Props = {},
+  URL = string
 > {
   /**
    * A map of Element objects
@@ -184,7 +184,7 @@ interface EnhancedPageObjectSharedFields<
    */
   elements: {
     [key in keyof Elements]: EnhancedElementInstance<
-      EnhancedPageObject<URL, Commands, Props, Elements, Sections>
+      EnhancedPageObject<Commands, Elements, Sections, Props, URL>
     >;
   };
 
@@ -406,20 +406,20 @@ export interface PageObjectModel {
  * Every time a factory function like MyPage above is called, a new instance of the page object is instantiated.
  */
 export type EnhancedPageObject<
-  URL = string,
   Commands = {},
-  Props = {},
   Elements = {},
-  Sections extends Record<string, PageObjectSection> = {}
+  Sections extends Record<string, PageObjectSection> = {},
+  Props = {},
+  URL = string
 > = Nightwatch &
   SharedCommands &
   NightwatchCustomCommands &
   EnhancedPageObjectSharedFields<
-    URL,
     Required<MergeObjectsArray<Commands>>,
-    Props,
     Required<MergeObjectsArray<Elements>>,
-    Sections
+    Sections,
+    Props,
+    URL
   > &
   Required<MergeObjectsArray<Commands>> & {
     /**
@@ -446,5 +446,5 @@ export type EnhancedPageObject<
     navigate(
       url?: string,
       callback?: () => void
-    ): EnhancedPageObject<URL, Commands, Props, Elements, Sections>;
+    ): EnhancedPageObject<Commands, Elements, Sections, Props, URL>;
   };

--- a/types/page-object.d.ts
+++ b/types/page-object.d.ts
@@ -97,8 +97,18 @@ export interface SectionProperties {
    * sections: {
    *   apps: {
    *     selector: 'div.gb_pc',
+   *     // object version
    *     props: {
    *       myVar: "some info"
+   *     }
+   *   },
+   *   menu: {
+   *     selector: '#gb',
+   *     // function version
+   *     props: function () {
+   *       return {
+   *         myOtherVar: "some other info"
+   *       };
    *     }
    *   }
    * }
@@ -162,6 +172,7 @@ interface PageObjectSection {
   commands?: Record<string, unknown>[];
   props?: Record<string, unknown>;
   elements?: Record<string, unknown>;
+  // TODO: make sections type more strict.
   sections?: any;
 }
 

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -8,9 +8,9 @@
  * // if object
  * {} => {}
  */
-export type MergeObjectsArray<T> = T extends Array<infer U>
+export type MergeObjectsArray<T> = T extends Array<unknown>
   ? {
-      [K in keyof U]: U[K];
+      [K in keyof T[number]]: T[number][K];
     }
   : T;
 


### PR DESCRIPTION
The issue with the types of page objects was that some new generics were added in `EnhancedPageObjects` interface in between the generics that were already present, due to which the interface was no longer backwards compatible. This PR fixes the issue by moving the newly added generics to the end of the interface.

### How to use page object types

* First, create a page object, along with an interface for the created page:
  ```ts
  // nightwatch/page-objects/googlePage.ts
  import { EnhancedPageObject, PageObjectModel } from 'nightwatch';
  
  const googleCommands = {
    clickSearch(this: GooglePage) {
      return this.waitForElementVisible('@submit', 10000)
        .click('@submit')
        .waitForElementNotPresent('@submit');
    },
  };
  
  const googlePage: PageObjectModel = {
    url: 'http://www.google.com',
    commands: [googleCommands],
    elements: {
      searchBar: {
        selector: 'input[type=text]',
      },
      submit: {
        selector: 'input[name=btnK]',
      },
    },
  };
  
  export default googlePage;
  
  export interface GooglePage
    extends EnhancedPageObject<
      typeof googleCommands,
      typeof googlePage.elements
    > {}
  ```
* Next, in the root folder of the project, create a `types/nightwatch.d.ts` or `types/page-objects.d.ts` file (depending on whether you want to put all the custom types in `nightwatch.d.ts` only, or have separate files for custom commands, page objects, etc.) and add the following:
  ```ts
  // types/page-objects.d.ts
  import { NightwatchCustomPageObjects } from "nightwatch";
  import { GooglePage } from "../nightwatch/page-objects/googlePage";

  declare module 'nightwatch' {
    interface NightwatchCustomPageObjects {
      googlePage(): GooglePage;
    }
  }
  ```
* In the `tsconfig.json` and `nightwatch/tsconfig.json` file's `include` property, add the path to the folder where your custom types are present (`types` in this case):
  ```json
  "compilerOptions": {
    ...
  },
  "include": ["test", "types"]
  ```
* Finally, create a test file (at `test/google.ts`) that uses the page object. Also, add the path to the source folder where your tests are located in the `include` property of `tsconfig.json` like done above (for the `test` folder).
  ```ts
  // test/google.ts
  import { NightwatchTests, NightwatchBrowser } from 'nightwatch';
  
  const googleTest: NightwatchTests = {
    'Google search test': (browser: NightwatchBrowser) => {
      let google = browser.page.googlePage();  // type automatically inferred as `GooglePage`
  
      google
        .navigate()
        .assert.titleEquals('Google')
        .assert.visible('@searchBar')
        .setValue('@searchBar', 'nightwatch');
  
      google
        .clickSearch()
        .expect.element('body')
        .text.to.contain(
          'Nightwatch.js | Node.js powered End-to-End testing framework'
        );
  
      browser.end();
    },
  };
  
  export default googleTest;
  ```
