### PR TITLE
Fixes/3102 handle parallelism in cucumber

### DIFF
--- a/lib/runner/folder-walk.js
+++ b/lib/runner/folder-walk.js
@@ -39,6 +39,7 @@ class Walker {
     this.settings = lodashClone(settings, true);
     this.argv = argv;
     this.usingMocha = this.settings.test_runner && this.settings.test_runner.type === 'mocha';
+    this.usingCucumber =  this.settings.test_runner && this.settings.test_runner.type === 'cucumber';
 
     this.registerMatchers();
 
@@ -174,6 +175,11 @@ class Walker {
       .then(fullPath => {
         if (fullPath && Utils.isString(fullPath)) {
           fullPath = [fullPath];
+        }
+
+        // cucumber-runner manages it's own set of filters
+        if (this.usingCucumber) {
+          return resolve(fullPath);
         }
 
         if (Array.isArray(fullPath)) {

--- a/lib/runner/folder-walk.js
+++ b/lib/runner/folder-walk.js
@@ -39,7 +39,7 @@ class Walker {
     this.settings = lodashClone(settings, true);
     this.argv = argv;
     this.usingMocha = this.settings.test_runner && this.settings.test_runner.type === 'mocha';
-    this.usingCucumber =  this.settings.test_runner && this.settings.test_runner.type === 'cucumber';
+    this.usingCucumber = this.settings.test_runner?.type === 'cucumber';
 
     this.registerMatchers();
 

--- a/lib/runner/test-runners/cucumber.js
+++ b/lib/runner/test-runners/cucumber.js
@@ -206,7 +206,7 @@ class CucumberSuite extends TestSuite {
 
 class CucumberRunnner extends Runner {
   get supportsConcurrency() {
-    return true;
+    return false;
   }
 
   get type() {

--- a/test/cucumber-integration-tests/sample_cucumber_tests/parallelWithMultipleDefinition/testExpect.js
+++ b/test/cucumber-integration-tests/sample_cucumber_tests/parallelWithMultipleDefinition/testExpect.js
@@ -1,0 +1,8 @@
+const {Then} = require('@cucumber/cucumber');
+
+
+Then('I check if webdriver is present and contains text', async function() {
+  browser.globals.test_calls++;
+
+  await browser.expect.element('#webdriver').text.to.contain('xx');
+});

--- a/test/cucumber-integration-tests/sample_cucumber_tests/parallelWithMultipleDefinition/testSample.js
+++ b/test/cucumber-integration-tests/sample_cucumber_tests/parallelWithMultipleDefinition/testSample.js
@@ -1,0 +1,12 @@
+const {Given, Then} = require('@cucumber/cucumber');
+
+Given('I navigate to localhost', function() {
+
+  return browser.navigateTo('http://localhost');
+});
+
+Then('I check if webdriver is present', function() {
+
+  return browser.assert.elementPresent('#webdriver');
+});
+

--- a/test/cucumber-integration-tests/testCucumberTestsInParallel.js
+++ b/test/cucumber-integration-tests/testCucumberTestsInParallel.js
@@ -71,8 +71,4 @@ describe('Cucumber integration - parallel running single formatter', function() 
         assert.strictEqual(errorOrFailed, false);
       });
   });
-
-
-
-
 });

--- a/test/cucumber-integration-tests/testCucumberTestsInParallel.js
+++ b/test/cucumber-integration-tests/testCucumberTestsInParallel.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const assert = require('assert');
 const Globals = require('../lib/globals/commands.js');
+const commandMocks = require('../lib/command-mocks.js');
 const common = require('../common.js');
 const MockServer = require('../lib/mockserver.js');
 
@@ -39,4 +40,39 @@ describe('Cucumber integration - parallel running single formatter', function() 
         assert.strictEqual(errorOrFailed, true);
       });
   });
+
+  it('testCucumberSampleTests in parallel with multiple step definition files', function() {
+
+    commandMocks.elementText('5cc459b8-36a8-3042-8b4a-258883ea642b', 'xx');
+
+    const source = [
+      path.join(__dirname, './sample_cucumber_tests/parallelWithMultipleDefinition')
+    ];
+
+    const {runTests} = common.require('index.js');
+
+    return runTests({
+      source,
+      parallel: true,
+      verbose: true,
+      timeout: 10,
+      silent: false,
+      tags: ['not @fail'],
+      format: 'progress',
+      config: path.join(__dirname, '../extra/cucumber-config-parallel.js'),
+      'format-options': '',
+      ['retry-interval']: 5,
+      ['persist-globals']: true,
+      ['webdriver-host']: 'localhost',
+      ['start-process']: false,
+      ['webdriver-port']: 10190
+    }, {})
+      .then(errorOrFailed => {
+        assert.strictEqual(errorOrFailed, false);
+      });
+  });
+
+
+
+
 });


### PR DESCRIPTION
## Changes

- Set `supportForConcurrency` in cucumber as false
  - This will allow Nightwatch to treat it as a serial run and not split the step definition files from cucumber and let cucumber runner handle the parallelism
-  remove all the filters from the test module filters for cucumber runner. Cucumber manages it's own set of filters.

## Impacts
- fixes #3102 
