### PR TITLE
Allow access of nested globals properties.

### DIFF
--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -10,7 +10,7 @@ export interface NightwatchGlobals {
    * @example
    * myGlobalVar: "some value"
    */
-  [key: string]: unknown;
+  [key: string]: any;
 
   /**
    * This controls whether to abort the test execution when an assertion failed and skip the rest


### PR DESCRIPTION
Fixes #3757.

Changing `unknown` to `any` would allow users to access nested properties in Nightwatch globals without having to do too much work.

#### Impact:
* The only downside of this approach is that now users could access `browser.globals.levelOne.levelTwo.someVariable` in TS even if that variable does not exist. But it's the only easy way to allow users to access nested variables, all other approaches (some of which are listed below) would be too much work.
* It should be noted that `browser.globals.someVariable` would not give error for both `unknown` and `any` if `someVariable` does not exist. So, the only change is with the nested variables.

### Alternative solution:
* One (and only correct) alternative solution for this is to extend `NightwatchGlobals` interface to include all the custom-defined global properties by either importing those properties (if those are defined in a separate file), or by manually writing the types for those properties (if those are defined in Nightwatch conf file) as follows:
  ```ts
  // types/nightwatch.conf.ts
  import customGlobals from './globals';

  interface NightwatchGlobals extends customGlobals {
    // custom globals defined in nightwatch conf file
    customVarX: string;
    customVarY: {
      a: string;
      b: number;
    }
  }
  ```
  The above approach can also be combined be the approach used in this PR to get IntelliSense for custom-defined globals, but going with **only** this approach would require users to define the types for all the globals beforehand, either by importing the globals file or manually defining the types, which could be a lot of work and will be non-backwards compatible (show error at a lot of places upon migrating to v3).

* Another approach would be to typecase the global variable when using it, which is not ideal at all:
  ```ts
  const topic = (browser.globals.messageHub as {topicName: string}).topicName;
  ```

