### PR TITLE
Fix issue with locating nth element in new element API.

### DIFF
--- a/lib/api/web-element/element-locator.js
+++ b/lib/api/web-element/element-locator.js
@@ -7,7 +7,7 @@ const NightwatchLocator = require('../../element/locator-factory');
 
 class ElementLocator {
   constructor(selector, options = {}) {
-    this.index = ElementLocator.getOrDefault(selector, '__index', 0);
+    this.index = ElementLocator.getOrDefault(selector, ['index', '__index'], 0);
     this.timeout = ElementLocator.getOrDefault(selector, 'timeout', options.waitForConditionTimeout);
     this.retryInterval = ElementLocator.getOrDefault(selector, 'retryInterval', options.waitForConditionPollInterval);
     this.locateStrategy = ElementLocator.getLocateStrategy(selector, options.locateStrategy);
@@ -24,11 +24,21 @@ class ElementLocator {
     });
   }
 
-  static getOrDefault(obj, prop, defaultValue) {
-    // eslint-disable-next-line no-prototype-builtins
-    const isDefined = Utils.isObject(obj) && obj.hasOwnProperty(prop) && Utils.isDefined(obj[prop]);
+  static getOrDefault(obj, props, defaultValue) {
+    if (!Utils.isObject(obj)) {
+      return defaultValue;
+    }
 
-    return isDefined ? obj[prop] : defaultValue;
+    const propArray = Array.isArray(props) ? props : [props];
+
+    for (const prop of propArray) {
+      // eslint-disable-next-line no-prototype-builtins
+      if ((prop in obj) && Utils.isDefined(obj[prop])) {
+        return obj[prop];
+      }
+    }
+
+    return defaultValue;
   }
 
   static getLocateStrategy(element, strategy) {

--- a/lib/api/web-element/element-locator.js
+++ b/lib/api/web-element/element-locator.js
@@ -33,7 +33,7 @@ class ElementLocator {
 
     for (const prop of propArray) {
       // eslint-disable-next-line no-prototype-builtins
-      if ((prop in obj) && Utils.isDefined(obj[prop])) {
+      if (obj.hasOwnProperty(prop) && Utils.isDefined(obj[prop])) {
         return obj[prop];
       }
     }


### PR DESCRIPTION
Right now, the following code doesn't work as expected (always returns the first element):

```js
const elem = await browser.element({selector: '.shelf-item', index: 12});
```

This is because the `.element()` command accepts an `index` property for mentioning the index of the element to return, but the code was only checking for `__index` property, which does not exist here.

But the `__index` property is also important to check because in case an instance of `Element` class is passed to `browser.element()` command, `obj.hasOwnProperty('index')` would fail for it because `index` is not a direct property of `Element` but only a getter for `__index` property. So, both are needed to be checked.


