### PR TITLE
Allow users to disable chromedriver logs in Nightwatch.

### DIFF
--- a/lib/transport/selenium-webdriver/service-builders/chrome.js
+++ b/lib/transport/selenium-webdriver/service-builders/chrome.js
@@ -34,15 +34,26 @@ class ChromeServiceBuilder extends BaseService {
     const {server_path} = this.settings.webdriver;
     this.service = new chrome.ServiceBuilder(server_path);
 
+    let enableVerboseLogging = true;
+
     if (Array.isArray(this.cliArgs) && this.cliArgs.length > 0) {
       this.service.addArguments(...this.cliArgs);
+
+      for (const arg of this.cliArgs) {
+        if (arg === '--silent' || arg.startsWith('--log-level=')) {
+          enableVerboseLogging = false;
+          break;
+        }
+      }
     }
-    
-    this.service.enableVerboseLogging();
+
+    if (enableVerboseLogging) {
+      this.service.enableVerboseLogging();
+    }
 
     if (process.platform !== 'win32') {
       this.service.enableChromeLogging();
-    } 
+    }
 
     return super.createService();
   }

--- a/test/src/utils/testStackTrace.js
+++ b/test/src/utils/testStackTrace.js
@@ -121,9 +121,8 @@ describe('test stackTrace parse', function() {
     const errorMessage = Logger.getErrorContent(error);
     assert.ok(!errorMessage.includes('\t'));
 
-    assert.strictEqual(errorMessage, ` [1;31m→ TypeError[0m
-
-    [0;31mUnknown method[0m
+    assert.strictEqual(errorMessage, ` ✖ [1;31mTypeError[0m
+   [0;31mUnknown method[0m
 [0;33m
     Error location:[0m
     ${errorFilePath}:


### PR DESCRIPTION
Earlier, we were making it mandatory for chromedriver to always emit logs in `--verbose` mode, so passing `--silent` or `--log-level=OFF` cli_args did not work and threw the following error:
```
Only one of --log-level, --verbose, or --silent is allowed.
Unable to initialize logging. Exiting...
```