### PR TITLE
Fix 'duckDuckGo.js' example test.

### DIFF
--- a/examples/tests/duckDuckGo.js
+++ b/examples/tests/duckDuckGo.js
@@ -5,10 +5,11 @@ describe('duckduckgo example', function() {
   it('Search Nightwatch.js and check results', function(browser) {
     browser
       .navigateTo('https://duckduckgo.com')
-      .waitForElementVisible('#search_form_input_homepage')
-      .sendKeys('#search_form_input_homepage', ['Nightwatch.js'])
-      .click('#search_button_homepage')
-      .assert.visible('.results--main')
-      .assert.textContains('.results--main', 'Nightwatch.js');
+      .waitForElementVisible('body')
+      .assert.visible('input[name="q"]')
+      .sendKeys('input[name="q"]', ['Nightwatch.js'])
+      .assert.visible('button[type=submit]')
+      .click('button[type=submit]')
+      .assert.textContains('.react-results--main', 'Nightwatch.js');
   }); 
 });


### PR DESCRIPTION
'duckDuckGo.js' test was not working earlier. 
I have used better selector to run the example test so it doesn't fail whenever changes happen in the 'DuckDuckGo' website.  
