### PR TITLE
Add types for Firefox namespace commands

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5205,6 +5205,13 @@ export interface CookiesNsCommands<ReturnType = unknown> {
   ): Awaitable<IfUnknown<ReturnType, this>, null>;
 }
 
+export interface FirefoxNsCommands<ReturnType = unknown> {
+  getContext(): Awaitable<IfUnknown<ReturnType, this>, 'content' | 'chrome'>;
+  setContext(ctx: Promise<string>): Awaitable<IfUnknown<ReturnType, this>, void>;
+  installAddon(path:string, temporary?: boolean): Awaitable<IfUnknown<string, this>, Promise<string>>;
+  uninstallAddon(id: string | Promise<string>): Awaitable<IfUnknown<ReturnType, this>, void>;
+} 
+
 export interface AlertsNsCommands<ReturnType = unknown> {
   /**
    * Accepts the currently displayed alert dialog. Usually, this is equivalent to clicking on the 'OK' button in the dialog.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5206,9 +5206,10 @@ export interface CookiesNsCommands<ReturnType = unknown> {
   ): Awaitable<IfUnknown<ReturnType, this>, null>;
 }
 
+type FirefoxContext = 'content' | 'chrome';
 export interface FirefoxNsCommands<ReturnType = unknown> {
-  getContext(): Awaitable<IfUnknown<ReturnType, this>, 'content' | 'chrome'>;
-  setContext(ctx: 'content' | 'chrome' | PromiseLike<'content' | 'chrome'>): Awaitable<IfUnknown<ReturnType, this>, null>;
+  getContext(): Awaitable<IfUnknown<ReturnType, this>, FirefoxContext>;
+  setContext(ctx: FirefoxContext | PromiseLike<FirefoxContext>): Awaitable<IfUnknown<ReturnType, this>, null>;
   installAddon(path:string, temporary?: boolean): Awaitable<IfUnknown<ReturnType, this>, string>;
   uninstallAddon(addonId: string | PromiseLike<string>): Awaitable<IfUnknown<ReturnType, this>, null>;
 } 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -515,6 +515,7 @@ export interface NamespacedApi<ReturnType = unknown> {
   alerts: AlertsNsCommands<ReturnType>;
   document: DocumentNsCommands<ReturnType>;
   window: WindowNsCommands<ReturnType>;
+  firefox: FirefoxNsCommands<ReturnType>;
 
   assert: Assert<ReturnType>;
   verify: Assert<ReturnType>;
@@ -5207,9 +5208,9 @@ export interface CookiesNsCommands<ReturnType = unknown> {
 
 export interface FirefoxNsCommands<ReturnType = unknown> {
   getContext(): Awaitable<IfUnknown<ReturnType, this>, 'content' | 'chrome'>;
-  setContext(ctx: Promise<string>): Awaitable<IfUnknown<ReturnType, this>, void>;
-  installAddon(path:string, temporary?: boolean): Awaitable<IfUnknown<string, this>, Promise<string>>;
-  uninstallAddon(id: string | Promise<string>): Awaitable<IfUnknown<ReturnType, this>, void>;
+  setContext(ctx: 'content' | 'chrome' | PromiseLike<'content' | 'chrome'>): Awaitable<IfUnknown<ReturnType, this>, null>;
+  installAddon(path:string, temporary?: boolean): Awaitable<IfUnknown<ReturnType, this>, string>;
+  uninstallAddon(addonId: string | PromiseLike<string>): Awaitable<IfUnknown<ReturnType, this>, null>;
 } 
 
 export interface AlertsNsCommands<ReturnType = unknown> {
@@ -7566,6 +7567,7 @@ export const cookies: CookiesNsCommands;
 export const alerts: AlertsNsCommands;
 export const document: DocumentNsCommands;
 export const window: WindowNsCommands;
+export const firefox: FirefoxNsCommands;
 
 export const assert: Assert;
 export const verify: Assert;


### PR DESCRIPTION
Added Firefox namespace commands:
1. `getContext()`
2. `setContext()`
3. `installAddon()`
4. `uninstallAddon()`