### PR TITLE
Add manually triggered Nightly release workflow.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,42 @@
+name: Nightly
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Nightly version
+        required: false
+        type: string
+        default: ''
+      ref:
+        description: Branch, tag, or SHA to release
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - name: Install dependencies
+        run: npm install
+      - name: Build Nightwatch
+        run: npm run build
+      - name: Create publishable package 📦
+        run: npm pack
+      - name: Release Nightly
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "nightly-${{ inputs.version }}"
+          title: "Nightly ${{ inputs.version }}"
+          prerelease: true
+          files: '*.tgz'


### PR DESCRIPTION
This would allow us to release a certain branch or commit in Nightwatch as a pre-release so that users can try it out before it goes into the main release.

It can be triggered manually, where it asks for the Nightly version name/number and the Git ref to release, and creates a pre-release based on the inputs.

![image](https://github.com/nightwatchjs/nightwatch/assets/39924567/41de5028-3590-4ccb-8332-d54616e9556e)

Sample run: https://github.com/garg3133/nightwatch/actions/runs/5411304762/jobs/9833867052
Sample release: https://github.com/garg3133/nightwatch/releases