### PR TITLE
Fix sync tests getting skipped in parallel mode.

### DIFF
--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -197,10 +197,6 @@ class Reporter extends SimplifiedReporter {
 
       // Use only necessary values
       if (result) {
-        if (result.constructor.name === 'NightwatchAPI') {
-          result = {};
-        }
-
         const {status, message, showDiff, name, abortOnFailure, stack, beautifiedStack} = result;
 
         commandResult = {

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -195,9 +195,14 @@ class Reporter extends SimplifiedReporter {
           result.status === -1
         );
 
-      // Use only necessary values 
+      // Use only necessary values
       if (result) {
+        if (result.constructor.name === 'NightwatchAPI') {
+          result = {};
+        }
+
         const {status, message, showDiff, name, abortOnFailure, stack, beautifiedStack} = result;
+
         commandResult ={
           status,
           message,

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -203,7 +203,7 @@ class Reporter extends SimplifiedReporter {
 
         const {status, message, showDiff, name, abortOnFailure, stack, beautifiedStack} = result;
 
-        commandResult ={
+        commandResult = {
           status,
           message,
           showDiff,

--- a/lib/runner/concurrency/task.js
+++ b/lib/runner/concurrency/task.js
@@ -1,5 +1,5 @@
 const Nightwatch = require('../../index');
-function runWorkerTask({argv, port1, settings}) {
+function runWorkerTask({argv, port1}) {
   const writeData = (data) => {
     data = data.toString().trim();
 
@@ -17,7 +17,7 @@ function runWorkerTask({argv, port1, settings}) {
   //send reports to main thread using message port
   process.port = port1;
   
-  return Nightwatch.runTests(argv, settings || {});
+  return Nightwatch.runTests(argv, {});
 }
 
 module.exports = runWorkerTask;

--- a/lib/runner/concurrency/task.js
+++ b/lib/runner/concurrency/task.js
@@ -1,5 +1,5 @@
 const Nightwatch = require('../../index');
-function runWorkerTask({argv, port1}) {
+function runWorkerTask({argv, port1, settings}) {
   const writeData = (data) => {
     data = data.toString().trim();
 
@@ -17,7 +17,7 @@ function runWorkerTask({argv, port1}) {
   //send reports to main thread using message port
   process.port = port1;
   
-  return Nightwatch.runTests(argv, {});
+  return Nightwatch.runTests(argv, settings || {});
 }
 
 module.exports = runWorkerTask;

--- a/lib/runner/concurrency/worker-task.js
+++ b/lib/runner/concurrency/worker-task.js
@@ -93,10 +93,7 @@ class WorkerTask extends EventEmitter {
     };
     port2.unref();
 
-    // remove all the functions from settings, otherwise piscina will fail.
-    const settings = JSON.parse(SafeJSON.stringify(this.settings));
-
-    return this.piscina.run({argv: this.argv, port1, settings}, {transferList: [port1]})
+    return this.piscina.run({argv: this.argv, port1}, {transferList: [port1]})
       .then(failures => {
         if (this.settings.disable_output_boxes){
           // eslint-disable-next-line no-console

--- a/lib/runner/concurrency/worker-task.js
+++ b/lib/runner/concurrency/worker-task.js
@@ -2,6 +2,7 @@ const boxen = require('boxen');
 const {MessageChannel} = require('worker_threads');
 const {Logger, symbols} = require('../../utils');
 const EventEmitter = require('events');
+const {SafeJSON, isString} = require('../../utils');
 
 let prevIndex = 0;
 
@@ -72,6 +73,13 @@ class WorkerTask extends EventEmitter {
     
     const {port1, port2} = new MessageChannel();
     port2.onmessage = ({data: result}) => {
+      if (isString(result)) {
+        try {
+          result = JSON.parse(result);
+          // eslint-disable-next-line no-empty
+        } catch (e) {}
+      }
+
       switch (result.type) {
         case 'testsuite_finished':
           result.itemKey = this.label,
@@ -86,7 +94,7 @@ class WorkerTask extends EventEmitter {
     port2.unref();
 
     // remove all the functions from settings, otherwise piscina will fail.
-    const settings = JSON.parse(JSON.stringify(this.settings));
+    const settings = JSON.parse(SafeJSON.stringify(this.settings));
 
     return this.piscina.run({argv: this.argv, port1, settings}, {transferList: [port1]})
       .then(failures => {

--- a/lib/runner/concurrency/worker-task.js
+++ b/lib/runner/concurrency/worker-task.js
@@ -85,7 +85,10 @@ class WorkerTask extends EventEmitter {
     };
     port2.unref();
 
-    return this.piscina.run({argv: this.argv, port1}, {transferList: [port1]})
+    // remove all the functions from settings, otherwise piscina will fail.
+    const settings = JSON.parse(JSON.stringify(this.settings));
+
+    return this.piscina.run({argv: this.argv, port1, settings}, {transferList: [port1]})
       .then(failures => {
         if (this.settings.disable_output_boxes){
           // eslint-disable-next-line no-console

--- a/lib/testsuite/index.js
+++ b/lib/testsuite/index.js
@@ -58,13 +58,13 @@ class TestSuite {
   }
 
   get skipTestcasesOnFail() {
-    let localDefinedValue = this.context.getSkipTestcasesOnFail();
+    const localDefinedValue = this.context.getSkipTestcasesOnFail();
 
     if (localDefinedValue !== undefined) {
       return localDefinedValue;
     }
 
-    let settingsValueUndefined = this.settings.skip_testcases_on_fail === undefined;
+    const settingsValueUndefined = this.settings.skip_testcases_on_fail === undefined;
     if (settingsValueUndefined && this.context.unitTestingMode) {
       // false by default when running unit tests
       return false;
@@ -75,7 +75,7 @@ class TestSuite {
   }
 
   get endSessionOnFail() {
-    let definedValue = this.context.getEndSessionOnFail();
+    const definedValue = this.context.getEndSessionOnFail();
 
     return definedValue === undefined ? this.settings.end_session_on_fail : definedValue;
   }
@@ -399,10 +399,10 @@ class TestSuite {
       return this;
     }
 
-    let capabilities = data.capabilities || {};
-    let browserName = (capabilities.browserName && capabilities.browserName.toUpperCase()) || '';
-    let browserVersion = capabilities.version || capabilities.browserVersion || '';
-    let platformVersion = capabilities.platform || capabilities.platformVersion || '';
+    const capabilities = data.capabilities || {};
+    const browserName = (capabilities.browserName && capabilities.browserName.toUpperCase()) || '';
+    const browserVersion = capabilities.version || capabilities.browserVersion || '';
+    const platformVersion = capabilities.platform || capabilities.platformVersion || '';
 
     if (!this.context.unitTestingMode) {
       this.settings.report_prefix = this.__reportPrefix = `${browserName}_${browserVersion}_${platformVersion}_`.replace(/ /g, '_');
@@ -637,7 +637,7 @@ class TestSuite {
           return this.retrySuite();
         }
 
-        let failures = errorOrFailures || failedResult || !this.reporter.allTestsPassed;
+        const failures = errorOrFailures || failedResult || !this.reporter.allTestsPassed;
 
         return this.stopSession(failures);
       });
@@ -668,11 +668,11 @@ class TestSuite {
         httpOutput: Logger.collectOutput()
       }));
     } else if (process.port && typeof process.port.postMessage === 'function') {
-      process.port.postMessage({
+      process.port.postMessage(SafeJSON.stringify({
         type: 'testsuite_finished',
         results: this.reporter.exportResults(),
         httpOutput: Logger.collectOutput()
-      });
+      }));
     }
   }
 

--- a/test/apidemos/custom-commands-parallel/testUsingES6AsyncCustomCommands.js
+++ b/test/apidemos/custom-commands-parallel/testUsingES6AsyncCustomCommands.js
@@ -1,0 +1,11 @@
+describe('Test Using Sync Custom Command returning NightwatchAPI', function() {
+  before(browser => {
+    browser.url('http://localhost');
+  });
+
+  it('sampleTest', browser => {
+    browser
+      .otherCommand()
+      .end();
+  });
+});

--- a/test/extra/commands/other/otherCommand.js
+++ b/test/extra/commands/other/otherCommand.js
@@ -1,5 +1,5 @@
-module.exports = {
-  command: function() {
-    return this;
+module.exports = class OtherCommand {
+  command() {
+    return this.api.pause(10);
   }
 };

--- a/test/extra/parallelism-customCommandsSync.json
+++ b/test/extra/parallelism-customCommandsSync.json
@@ -1,0 +1,20 @@
+{
+  "src_folders" : ["./test/apidemos/custom-commands-parallel"],
+  "test_workers": true,
+  "custom_commands_path": ["./test/extra/commands/other"],
+  "persist_globals": true,
+  "output_folder" : false,
+  "output" : false,
+  "silent": false,
+  "selenium" : {
+    "start_process" : false,
+    "port": 10195
+  },
+  "test_settings": {
+    "default" : {
+      "desiredCapabilities" : {
+        "browserName" : "firefox"
+      }
+    }
+  }
+}

--- a/test/src/apidemos/custom-commands/testCustomCommandSync.js
+++ b/test/src/apidemos/custom-commands/testCustomCommandSync.js
@@ -39,12 +39,10 @@ describe('sync custom commands', function() {
       }
     };
 
-    return NightwatchClient.runTests(testsPath, settings({
-      output: false,
-      silent: false,
-      selenium_host: null,
-      test_workers: true,
-      custom_commands_path: [path.join(__dirname, '../../../extra/commands/other')],
+    return NightwatchClient.runTests({
+      env: 'default',
+      config: 'test/extra/parallelism-customCommandsSync.json'
+    }, Object.assign({}, {
       globals
     }));
   });

--- a/test/src/apidemos/custom-commands/testCustomCommandSync.js
+++ b/test/src/apidemos/custom-commands/testCustomCommandSync.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const assert = require('assert');
+const MockServer = require('../../../lib/mockserver.js');
+const Mocks = require('../../../lib/command-mocks.js');
+const common = require('../../../common.js');
+const {settings} = common;
+const NightwatchClient = common.require('index.js');
+
+describe('sync custom commands', function() {
+  beforeEach(function(done) {
+    this.server = MockServer.init();
+    this.server.on('listening', () => {
+      done();
+    });
+  });
+
+  afterEach(function(done) {
+    this.server.close(function() {
+      done();
+    });
+  });
+
+  it('test sync custom command returning NightwatchAPI as result', function() {
+    const testsPath = path.join(__dirname, '../../../apidemos/custom-commands-parallel');
+    Mocks.createNewW3CSession({
+      testName: 'Test Sync Custom Commands returning NightwatchAPI'
+    });
+
+    const globals = {
+      waitForConditionPollInterval: 50,
+      waitForConditionTimeout: 120,
+      retryAssertionTimeout: 1000,
+
+      reporter(results) {
+        assert.strictEqual(Object.keys(results.modules).length, 1);
+        if (results.lastError) {
+          throw results.lastError;
+        }
+      }
+    };
+
+    return NightwatchClient.runTests(testsPath, settings({
+      output: false,
+      silent: false,
+      selenium_host: null,
+      test_workers: true,
+      custom_commands_path: [path.join(__dirname, '../../../extra/commands/other')],
+      globals
+    }));
+  });
+});


### PR DESCRIPTION
Fixes: #3786.

The issue here was that custom commands many times return an instance of `NightwatchAPI` instead of the actual command result. Due to this, when destructuring `status` from `result`, `status` was getting assigned the definition of `.status()` (a function) command instead of the status of the command run (a number).

Now, while being in parallel mode, reports from all test runs are sent to a common port (see [here](https://github.com/nightwatchjs/nightwatch/blob/90165d5393c7a74c0670ffcfd731b62e506ac9bb/lib/testsuite/index.js#L671-L674)), but the `postMessage` method does not work with functions, and so it was failing for tests containing custom commands.

Due to this, while the test with custom commands was running fine, it was not getting reported on the terminal as well as in the HTML report, hence it seemed like it was getting skipped.
