### PR TITLE
Add support for namespaced aliases.

### DIFF
--- a/lib/api/_loaders/_base-loader.js
+++ b/lib/api/_loaders/_base-loader.js
@@ -317,29 +317,12 @@ class BaseLoader extends EventEmitter {
     return [];
   }
 
-  isRestrictedNamespace(parent, namespace) {
-    if (!parent) {
-      return false;
-    }
-
-    // do not load these namespaces on parent (page objects and within-context).
-    const restrictedNamespaces = ['client'];
-
-    return Boolean(namespace && restrictedNamespaces.some(
-      (ns) => namespace.toString().startsWith(ns)
-    ));
-  }
-
   define(parent = null) {
     if (!this.commandFn) {
       return this;
     }
 
-    if (this.isRestrictedNamespace(parent, this.namespace)) {
-      return this;
-    }
-
-    const {commandName, nightwatchInstance} = this;
+    const {commandName, namespace, nightwatchInstance} = this;
 
     this.validateMethod(parent);
     const args = this.defineArgs(parent);
@@ -355,20 +338,17 @@ class BaseLoader extends EventEmitter {
 
     // check for namespaced aliases
     const nsAliases = this.getNamespacedAliases();
-
-    const origNamespace = this.namespace;    
     nsAliases.forEach((ns) => {
       this.commandName = ns.pop();
       this.setNamespace(ns);
 
       this.validateMethod(parent);
       const args = this.defineArgs(parent);
-
       nightwatchInstance.setApiMethod(this.commandName, ...args);
     });
 
     this.commandName = commandName;
-    this.setNamespace(origNamespace);
+    this.setNamespace(namespace);
 
     return this.defineNamespacedApi(parent, namespacedApi);
   }
@@ -380,7 +360,7 @@ class BaseLoader extends EventEmitter {
       return this;
     }
 
-    const {commandName, nightwatchInstance} = this;
+    const {commandName, namespace, nightwatchInstance} = this;
 
     if (this.namespace && this.namespace.length) {
       const args = this.defineArgs(parent, namespacedApi);
@@ -394,7 +374,21 @@ class BaseLoader extends EventEmitter {
       }
     }
 
+    // check for namespaced aliases
+    const nsAliases = this.getNamespacedAliases();
+    nsAliases.forEach((ns) => {
+      this.commandName = ns.pop();
+
+      if (ns.length) {
+        this.setNamespace(ns);
+
+        const args = this.defineArgs(parent, namespacedApi);
+        nightwatchInstance.setNamespacedApiMethod(this.commandName, ...args);
+      }
+    });
+
     this.commandName = commandName;
+    this.setNamespace(namespace);
 
     return this;
   }

--- a/lib/api/_loaders/_base-loader.js
+++ b/lib/api/_loaders/_base-loader.js
@@ -301,6 +301,22 @@ class BaseLoader extends EventEmitter {
     return args;
   }
 
+  getNamespacedAliases() {
+    const nsAliases = this.module.namespacedAliases;
+
+    if (nsAliases && Utils.isString(nsAliases)) {
+      return [nsAliases.split('.')];
+    }
+
+    if (Array.isArray(nsAliases)) {
+      return nsAliases
+        .filter((nsAlias) => nsAlias && Utils.isString(nsAlias))
+        .map((nsAlias) => nsAlias.split('.'));
+    }
+
+    return [];
+  }
+
   isRestrictedNamespace(parent, namespace) {
     if (!parent) {
       return false;
@@ -337,7 +353,22 @@ class BaseLoader extends EventEmitter {
       nightwatchInstance.setApiMethod(this.commandName, ...args);
     }
 
+    // check for namespaced aliases
+    const nsAliases = this.getNamespacedAliases();
+
+    const origNamespace = this.namespace;    
+    nsAliases.forEach((ns) => {
+      this.commandName = ns.pop();
+      this.setNamespace(ns);
+
+      this.validateMethod(parent);
+      const args = this.defineArgs(parent);
+
+      nightwatchInstance.setApiMethod(this.commandName, ...args);
+    });
+
     this.commandName = commandName;
+    this.setNamespace(origNamespace);
 
     return this.defineNamespacedApi(parent, namespacedApi);
   }

--- a/lib/api/_loaders/_base-loader.js
+++ b/lib/api/_loaders/_base-loader.js
@@ -302,7 +302,7 @@ class BaseLoader extends EventEmitter {
   }
 
   getNamespacedAliases() {
-    const nsAliases = this.module.namespacedAliases;
+    const nsAliases = this.module && this.module.namespacedAliases;
 
     if (nsAliases && Utils.isString(nsAliases)) {
       return [nsAliases.split('.')];
@@ -327,14 +327,6 @@ class BaseLoader extends EventEmitter {
     this.validateMethod(parent);
     const args = this.defineArgs(parent);
     nightwatchInstance.setApiMethod(commandName, ...args);
-
-    if (this.module && this.module.AliasName) {
-      this.commandName = this.module.AliasName;
-
-      this.validateMethod(parent);
-      const args = this.defineArgs(parent);
-      nightwatchInstance.setApiMethod(this.commandName, ...args);
-    }
 
     // check for namespaced aliases
     const nsAliases = this.getNamespacedAliases();
@@ -365,13 +357,6 @@ class BaseLoader extends EventEmitter {
     if (this.namespace && this.namespace.length) {
       const args = this.defineArgs(parent, namespacedApi);
       nightwatchInstance.setNamespacedApiMethod(commandName, ...args);
-
-      if (this.module && this.module.AliasName) {
-        this.commandName = this.module.AliasName;
-
-        const args = this.defineArgs(parent, namespacedApi);
-        nightwatchInstance.setNamespacedApiMethod(this.commandName, ...args);
-      }
     }
 
     // check for namespaced aliases

--- a/lib/api/client-commands/document/source.js
+++ b/lib/api/client-commands/document/source.js
@@ -25,8 +25,8 @@ const ClientCommand = require('../_base-command.js');
  * @api protocol.document
  */
 class Source extends ClientCommand {
-  static get AliasName() {
-    return 'pageSource';
+  static get namespacedAliases() {
+    return 'document.pageSource';
   }
 
   performAction(callback) {

--- a/lib/api/client-commands/window/open.js
+++ b/lib/api/client-commands/window/open.js
@@ -43,8 +43,8 @@ class OpenNewWindow extends ClientCommand {
     return true;
   }
 
-  static get AliasName() {
-    return 'openNew';
+  static get namespacedAliases() {
+    return 'window.openNew';
   }
 
   performAction(callback) {

--- a/lib/api/client-commands/window/setSize.js
+++ b/lib/api/client-commands/window/setSize.js
@@ -26,8 +26,8 @@ const ClientCommand = require('../_base-command.js');
  * @api protocol.window
  */
 class SetWindowSize extends ClientCommand {
-  static get AliasName() {
-    return 'resize';
+  static get namespacedAliases() {
+    return 'window.resize';
   }
 
   performAction(callback) {

--- a/lib/api/client-commands/window/switchTo.js
+++ b/lib/api/client-commands/window/switchTo.js
@@ -77,8 +77,8 @@ class SwitchToWindow extends ClientCommand {
     return true;
   }
 
-  static get AliasName() {
-    return 'switch';
+  static get namespacedAliases() {
+    return 'window.switch';
   }
 
   performAction(callback) {

--- a/lib/api/element-commands/getAttribute.js
+++ b/lib/api/element-commands/getAttribute.js
@@ -44,7 +44,7 @@ const BaseElementCommand = require('./_baseElementCommand.js');
  * @link /#dfn-get-element-attribute
  */
 class GetAttribute extends BaseElementCommand {
-  static get AliasName() {
+  static get namespacedAliases() {
     return 'getElementAttribute';
   }
 

--- a/lib/api/element-commands/setPassword.js
+++ b/lib/api/element-commands/setPassword.js
@@ -30,7 +30,7 @@ const BaseElementCommand = require('./_baseElementCommand.js');
  * @api protocol.elementinteraction
  */
 class SetPassword extends BaseElementCommand {
-  static get AliasName() {
+  static get namespacedAliases() {
     return 'sendKeysRedacted';
   }
 

--- a/lib/api/protocol/execute.js
+++ b/lib/api/protocol/execute.js
@@ -28,7 +28,7 @@ const ProtocolAction = require('./_base-action.js');
  * @returns {*} The script result.
  */
 module.exports = class Session extends ProtocolAction {
-  static get AliasName() {
+  static get namespacedAliases() {
     return 'executeScript';
   }
 

--- a/lib/api/protocol/executeAsyncScript.js
+++ b/lib/api/protocol/executeAsyncScript.js
@@ -35,7 +35,7 @@ const ProtocolAction = require('./_base-action.js');
  * @returns {*} The script result.
  */
 module.exports = class Session extends ProtocolAction {
-  static get AliasName() {
+  static get namespacedAliases() {
     return 'executeAsync';
   }
 

--- a/lib/api/protocol/switchToWindow.js
+++ b/lib/api/protocol/switchToWindow.js
@@ -28,7 +28,7 @@ const ProtocolAction = require('./_base-action.js');
  * @deprecated In favour of `.window.switchTo()`.
  */
 module.exports = class Action extends ProtocolAction {
-  static get AliasName() {
+  static get namespacedAliases() {
     return 'switchWindow';
   }
 

--- a/test/apidemos/custom-commands/testNamespacedAliases.js
+++ b/test/apidemos/custom-commands/testNamespacedAliases.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+
+describe('custom command using namespaced aliases', function () {
+  it('test aliases are available on requested namespace', async function() {
+    assert.strictEqual(typeof browser.customPauseWithNamespacedAlias, 'function');
+    assert.strictEqual(typeof browser.newPause, 'function');
+    assert.strictEqual(typeof browser.sampleNamespace.amazingPause, 'function');
+    assert.strictEqual(typeof browser.fantasticNamespace.subNamespace.fantasticPause, 'function');
+  });
+
+  it('test custom command with a failure', async function() {
+    browser.sampleNamespace.amazingPause('200');
+  });
+});

--- a/test/apidemos/namespaced-api/namespacedApiTest.js
+++ b/test/apidemos/namespaced-api/namespacedApiTest.js
@@ -1,5 +1,5 @@
 const common = require('../../common.js');
-const {browser, appium, assert, expect, firefox} = common.require('index.js');
+const {browser, appium, assert, expect, firefox, document} = common.require('index.js');
 
 describe('namespaced api test', function() {
   it('browser.navigateTo', function () {
@@ -26,6 +26,15 @@ describe('namespaced api test', function() {
       .strictEqual(typeof result.navigateTo, 'undefined')
       .strictEqual(typeof result.debug, 'undefined')
       .strictEqual(typeof result.hideKeyboard, 'function')
+      .strictEqual(typeof result.sessionId, 'undefined');
+  });
+
+  it('document.customExecute (namespaced alias loaded on namespaced api)', function () {
+    const result = document.customExecute('acme');
+    assert
+      .strictEqual(typeof result.navigateTo, 'undefined')
+      .strictEqual(typeof result.debug, 'undefined')
+      .strictEqual(typeof result.injectScript, 'function')
       .strictEqual(typeof result.sessionId, 'undefined');
   });
 

--- a/test/extra/commands/customExecute.js
+++ b/test/extra/commands/customExecute.js
@@ -1,3 +1,7 @@
-exports.command = function(data, callback = function() {}) {
-  this.execute(function(data) {return data}, [data], callback);
+module.exports = {
+  namespacedAliases: ['document.customExecute'],
+
+  command: function(data, callback = function() {}) {
+    this.execute(function(data) {return data}, [data], callback);
+  }
 };

--- a/test/extra/commands/customPauseWithNamespacedAlias.js
+++ b/test/extra/commands/customPauseWithNamespacedAlias.js
@@ -1,0 +1,13 @@
+module.exports = class CustomPause {
+  static get namespacedAliases() {
+    return ['newPause', 'sampleNamespace.amazingPause', 'fantasticNamespace.subNamespace.fantasticPause'];
+  }
+
+  command(timeout) {
+    if (typeof timeout !== 'number') {
+      throw new Error('First argument should be a number.');
+    }
+
+    this.pause(200);
+  }
+};

--- a/test/src/apidemos/custom-commands/testCustomPauseWithNamespacedAlias.js
+++ b/test/src/apidemos/custom-commands/testCustomPauseWithNamespacedAlias.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+const path = require('path');
+const common = require('../../../common.js');
+const {settings} = common;
+const MockServer = require('../../../lib/mockserver.js');
+const Mocks = require('../../../lib/command-mocks.js');
+const NightwatchClient = common.require('index.js');
+
+describe('custom command with namespaced alias', function () {
+  beforeEach(function (done) {
+    this.server = MockServer.init();
+    this.server.on('listening', () => {
+      done();
+    });
+  });
+
+  afterEach(function (done) {
+    this.server.close(function () {
+      done();
+    });
+  });
+
+  it('test namespaced aliases by running a custom-command', function () {
+    const testsPath = path.join(__dirname, '../../../apidemos/custom-commands/testNamespacedAliases.js');
+    Mocks.createNewW3CSession({
+      testName: 'Test Using Namespaced Aliases'
+    });
+
+    const globals = {
+      waitForConditionPollInterval: 50,
+
+      reporter(results) {
+        if (results.lastError && !results.lastError.message.includes('First argument should be a number')) {
+          throw results.lastError;
+        }
+
+        assert.ok(results.lastError instanceof Error);
+        assert.strictEqual(
+          results.lastError.message,
+          'Error while running "sampleNamespace.amazingPause" command: First argument should be a number.'
+        );
+      }
+    };
+
+    return NightwatchClient.runTests(testsPath, settings({
+      output: false,
+      silent: true,
+      selenium_host: null,
+      custom_commands_path: [path.join(__dirname, '../../../extra/commands')],
+      globals
+    }));
+  });
+});

--- a/test/src/apidemos/namespaced-api/testNamespacedApi.js
+++ b/test/src/apidemos/namespaced-api/testNamespacedApi.js
@@ -21,23 +21,31 @@ describe('namespaced api tests', function() {
   it('run basic test with namespaced api', function() {
     const testsPath = path.join(__dirname, '../../../apidemos/namespaced-api/namespacedApiTest.js');
 
-    MockServer.addMock({
-      url: '/wd/hub/session/1352110219202/orientation',
-      statusCode: 200,
-      response: JSON.stringify({
-        value: null
-      }),
-      times: 4
-    });
-
-    MockServer.addMock({
-      url: '/wd/hub/session/1352110219202/title',
-      method: 'GET',
-      response: JSON.stringify({
-        value: 'Localhost'
-      }),
-      times: 7
-    });
+    MockServer
+      .addMock({
+        url: '/wd/hub/session/1352110219202/orientation',
+        statusCode: 200,
+        response: JSON.stringify({
+          value: null
+        }),
+        times: 4
+      })
+      .addMock({
+        url: '/wd/hub/session/1352110219202/execute/sync',
+        method: 'POST',
+        statusCode: 200,
+        response: JSON.stringify({
+          value: null
+        })
+      }, true)
+      .addMock({
+        url: '/wd/hub/session/1352110219202/title',
+        method: 'GET',
+        response: JSON.stringify({
+          value: 'Localhost'
+        }),
+        times: 7
+      });
 
     const globals = {
       waitForConditionPollInterval: 50,
@@ -51,7 +59,8 @@ describe('namespaced api tests', function() {
 
     return NightwatchClient.runTests(testsPath, settings({
       skip_testcases_on_fail: false,
-      output: true,
+      output: false,
+      custom_commands_path: [path.join(__dirname, '../../../extra/commands')],
       globals
     }));
   });


### PR DESCRIPTION
This PR adds support for adding namespaced aliases to Nightwatch commands. This would allow us to make a particular command available on multiple namespaces without the need to duplicate the file at multiple places.

This can be achieved by adding a `namespacedAliases` static get method to any command file. The aliases returned by the method should be absolute (how it will be used on the main `browser` object) and should end with the command name).

Having the aliases as absolute is necessary so that we can make a command having a namespace already, be available on the main `browser` object. For example, making `browser.appium.hideKeyboard()` command available as `browser.hideAppiumKeyboard()` as well, instead of the other way around.

### Example Usage

Inside `lib/api/protocol/navigateTo.js` command, add the following method:
```js
static get namespacedAliases() {
  return 'client.navigateTo'; // or return ['client.navigateTo']
}
```
Now, the `browser.navigateTo()` command can also be used as `browser.client.navigateTo()`.

Similarly, inside `lib/api/protocol/appium/hideKeyboard.js` command, add the following method:
```js
static get namespacedAliases() {
  return 'hideAppiumKeyboard'; // or return ['hideAppiumKeyboard']
}
```
Now, the `browser.appium.hideKeyboard()` command can also be used as `browser.hideAppiumKeyboard()`.