### PR TITLE
Feature/disable process listener for programattic api

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,7 @@ module.exports.createClient = function({
   debug = false,
   enable_global_apis = false,
   config = './nightwatch.json',
+  disable_process_listener = false,
   test_settings
 } = {}) {
   if (browserName && !env) {
@@ -73,7 +74,8 @@ module.exports.createClient = function({
     timeout,
     devtools,
     debug,
-    parallel
+    parallel,
+    disable_process_listener
   });
 
   const settings = arguments[0] || {};
@@ -279,7 +281,7 @@ Nightwatch.runTests = async function(testSource, settings) {
 Nightwatch.CliRunner = function(argv = {}) {
   const CliRunner = require('./runner/cli/cli.js');
 
-  return new CliRunner(argv, true);
+  return new CliRunner(argv);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -279,7 +279,7 @@ Nightwatch.runTests = async function(testSource, settings) {
 Nightwatch.CliRunner = function(argv = {}) {
   const CliRunner = require('./runner/cli/cli.js');
 
-  return new CliRunner(argv);
+  return new CliRunner(argv, true);
 };
 
 /**

--- a/lib/runner/cli/cli.js
+++ b/lib/runner/cli/cli.js
@@ -83,7 +83,7 @@ class CliRunner {
     }
   }
 
-  constructor(argv = {}) {
+  constructor(argv = {}, isProgrammatic = false) {
     if (argv.source && !argv._source) {
       argv._source = argv.source;
       delete argv.source;
@@ -109,7 +109,10 @@ class CliRunner {
     this.globals = null;
     this.testEnv = null;
     this.testEnvArray = [];
-    this.processListener = new ProcessListener();
+    this.isProgrammatic = isProgrammatic;
+    if (!isProgrammatic) {
+      this.processListener = new ProcessListener();
+    }
   }
 
   initTestSettings(userSettings = {}, baseSettings = null, argv = null, testEnv = '', asyncLoading) {
@@ -452,7 +455,9 @@ class CliRunner {
       globalsInstance: this.globals
     });
 
-    this.processListener.setTestRunner(this.testRunner);
+    if (!this.isProgrammatic) {
+      this.processListener.setTestRunner(this.testRunner);
+    }
 
     return this;
   }

--- a/lib/runner/cli/cli.js
+++ b/lib/runner/cli/cli.js
@@ -83,7 +83,7 @@ class CliRunner {
     }
   }
 
-  constructor(argv = {}, isProgrammatic = false) {
+  constructor(argv = {}) {
     if (argv.source && !argv._source) {
       argv._source = argv.source;
       delete argv.source;
@@ -109,8 +109,8 @@ class CliRunner {
     this.globals = null;
     this.testEnv = null;
     this.testEnvArray = [];
-    this.isProgrammatic = isProgrammatic;
-    if (!isProgrammatic) {
+
+    if (!argv.disable_process_listener) {
       this.processListener = new ProcessListener();
     }
   }
@@ -455,7 +455,7 @@ class CliRunner {
       globalsInstance: this.globals
     });
 
-    if (!this.isProgrammatic) {
+    if (this.processListener) {
       this.processListener.setTestRunner(this.testRunner);
     }
 

--- a/test/src/index/testProgrammaticApis.js
+++ b/test/src/index/testProgrammaticApis.js
@@ -570,4 +570,74 @@ describe('test programmatic apis', function () {
     CliRunner.createDefaultConfig = createDefaultConfig;
     CliRunner.prototype.loadConfig = loadConfig;
   });
+
+  it('test if process listener get disabled', async function() {
+    let processListenerCalled = false;
+    mockery.enable({useCleanCache: true, warnOnUnregistered: false});
+    mockery.registerMock('../process-listener.js', class {
+      constructor() {
+        processListenerCalled = true;
+      }
+
+      setTestRunner() {}
+    });
+
+    const CliRunner = common.require('runner/cli/cli.js');
+    const Nightwatch = common.require('index.js');
+
+    const createDefaultConfig = CliRunner.createDefaultConfig;
+    const loadConfig = CliRunner.prototype.loadConfig;
+    const defaultConfig = {
+      test_settings: {
+        default: {
+          launchUrl: 'http://localhost'
+        }
+      },
+      selenium: {
+        port: 10195,
+        start_process: false
+      },
+      selenium_host: 'localhost'
+    };
+
+    CliRunner.createDefaultConfig = function(destFileName) {
+      return defaultConfig;
+    };
+
+    CliRunner.prototype.loadConfig = function () {
+      return defaultConfig;
+    };
+
+    const clientWithoutListner = Nightwatch.createClient({
+      timeout: 500,
+      useAsync: false,
+      output: false,
+      silent: false,
+      headless: true,
+      output_folder: 'output',
+      globals: {
+        testGlobal: 'one'
+      },
+      disable_process_listener: true
+    });
+
+    assert.ok(!processListenerCalled);
+
+    const client = Nightwatch.createClient({
+      timeout: 500,
+      useAsync: false,
+      output: false,
+      silent: false,
+      headless: true,
+      output_folder: 'output',
+      globals: {
+        testGlobal: 'one'
+      }
+    });
+
+    assert.ok(processListenerCalled);
+
+    CliRunner.createDefaultConfig = createDefaultConfig;
+    CliRunner.prototype.loadConfig = loadConfig;
+  });
 });


### PR DESCRIPTION
Adds flag to disable `process-listener` while using programatic api. 
Required when users want to have control over error reporting.

#### Usage
```javascript 
const clientWithoutListner = Nightwatch.createClient({
    timeout: 500,
    useAsync: false,
    output: false,
    silent: false,
    headless: true,
    output_folder: 'output',
    globals: {
        testGlobal: 'one'
    },
    disable_process_listener: true
})
```