### PR TITLE
updated cucumber to v9.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "nightwatch": "bin/nightwatch"
       },
       "devDependencies": {
-        "@cucumber/cucumber": "^8.2.1",
+        "@cucumber/cucumber": "^9.3.0",
         "@swc/core": "^1.3.67",
         "@types/node": "^18.11.7",
         "copyfiles": "^2.4.1",
@@ -534,31 +534,31 @@
       }
     },
     "node_modules/@cucumber/ci-environment": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/ci-environment/-/ci-environment-9.1.0.tgz",
-      "integrity": "sha512-jdnF6APXP3GawMue8kdMxhu6TBhyRUO4KDRxTowf06NtclLjIw2Ybpo9IcIOMvE8kHukvJyM00uxWX+CfS7JgQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/ci-environment/-/ci-environment-9.2.0.tgz",
+      "integrity": "sha512-jLzRtVwdtNt+uAmTwvXwW9iGYLEOJFpDSmnx/dgoMGKXUWRx1UHT86Q696CLdgXO8kyTwsgJY0c6n5SW9VitAA==",
       "dev": true
     },
     "node_modules/@cucumber/cucumber": {
-      "version": "8.11.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-8.11.1.tgz",
-      "integrity": "sha512-C+wdypoSzHA48GCRorJCAZYuxXo1RSESukAmoz/JhGV7KB4pIlg9Y2aWeZKx6bJQkq8yq4+S4jg9f8FGCdc3jQ==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-9.3.0.tgz",
+      "integrity": "sha512-8QvcQVJzRra3pZpV0dITPcFuT2yYH0C1fEgzDlqe6+Zpz9k3z+ov9xUWEYgKp0VMx65JxNKAYYYWmG6cWOiYQQ==",
       "dev": true,
       "dependencies": {
-        "@cucumber/ci-environment": "9.1.0",
-        "@cucumber/cucumber-expressions": "16.1.1",
-        "@cucumber/gherkin": "26.0.3",
+        "@cucumber/ci-environment": "9.2.0",
+        "@cucumber/cucumber-expressions": "16.1.2",
+        "@cucumber/gherkin": "26.2.0",
         "@cucumber/gherkin-streams": "5.0.1",
         "@cucumber/gherkin-utils": "8.0.2",
-        "@cucumber/html-formatter": "20.2.1",
+        "@cucumber/html-formatter": "20.4.0",
         "@cucumber/message-streams": "4.0.1",
-        "@cucumber/messages": "21.0.1",
+        "@cucumber/messages": "22.0.0",
         "@cucumber/tag-expressions": "5.0.1",
         "assertion-error-formatter": "^3.0.0",
         "capital-case": "^1.0.4",
         "chalk": "^4.1.2",
         "cli-table3": "0.6.3",
-        "commander": "^9.0.0",
+        "commander": "^10.0.0",
         "debug": "^4.3.4",
         "error-stack-parser": "^2.1.4",
         "figures": "^3.2.0",
@@ -571,10 +571,11 @@
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "luxon": "3.2.1",
+        "mkdirp": "^2.1.5",
         "mz": "^2.7.0",
         "progress": "^2.0.3",
         "resolve-pkg": "^2.0.0",
-        "semver": "7.3.8",
+        "semver": "7.5.3",
         "string-argv": "^0.3.1",
         "strip-ansi": "6.0.1",
         "supports-color": "^8.1.1",
@@ -582,41 +583,71 @@
         "util-arity": "^1.1.0",
         "verror": "^1.10.0",
         "xmlbuilder": "^15.1.1",
-        "yaml": "1.10.2",
+        "yaml": "^2.2.2",
         "yup": "^0.32.11"
       },
       "bin": {
         "cucumber-js": "bin/cucumber.js"
       },
       "engines": {
-        "node": "12 || 14 || >=16"
+        "node": "14 || 16 || >=18"
       }
     },
     "node_modules/@cucumber/cucumber-expressions": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-16.1.1.tgz",
-      "integrity": "sha512-Ugsb9qxfgrgfUKsGvbx0awVk+69NIFjWfxNT+dnm62YrF2gdTHYxAOzOLuPgvE0yqYTh+3otrFLDDfkHGThM1g==",
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-16.1.2.tgz",
+      "integrity": "sha512-CfHEbxJ5FqBwF6mJyLLz4B353gyHkoi6cCL4J0lfDZ+GorpcWw4n2OUAdxJmP7ZlREANWoTFlp4FhmkLKrCfUA==",
       "dev": true,
       "dependencies": {
         "regexp-match-indices": "1.0.2"
       }
     },
     "node_modules/@cucumber/cucumber/node_modules/@cucumber/messages": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-21.0.1.tgz",
-      "integrity": "sha512-pGR7iURM4SF9Qp1IIpNiVQ77J9kfxMkPOEbyy+zRmGABnWWCsqMpJdfHeh9Mb3VskemVw85++e15JT0PYdcR3g==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-22.0.0.tgz",
+      "integrity": "sha512-EuaUtYte9ilkxcKmfqGF9pJsHRUU0jwie5ukuZ/1NPTuHS1LxHPsGEODK17RPRbZHOFhqybNzG2rHAwThxEymg==",
       "dev": true,
       "dependencies": {
-        "@types/uuid": "8.3.4",
+        "@types/uuid": "9.0.1",
         "class-transformer": "0.5.1",
         "reflect-metadata": "0.1.13",
         "uuid": "9.0.0"
       }
     },
+    "node_modules/@cucumber/cucumber/node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+      "dev": true
+    },
+    "node_modules/@cucumber/cucumber/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/mkdirp": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@cucumber/cucumber/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -652,22 +683,13 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@cucumber/cucumber/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@cucumber/gherkin": {
-      "version": "26.0.3",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-26.0.3.tgz",
-      "integrity": "sha512-xwJHi//bLFEU1drIyw2yswwUHnnVWO4XcyVBbCTDs6DkSh262GkogFI/IWwChZqJfOXnPglzLGxR1DibcZsILA==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-26.2.0.tgz",
+      "integrity": "sha512-iRSiK8YAIHAmLrn/mUfpAx7OXZ7LyNlh1zT89RoziSVCbqSVDxJS6ckEzW8loxs+EEXl0dKPQOXiDmbHV+C/fA==",
       "dev": true,
       "dependencies": {
-        "@cucumber/messages": "19.1.4 - 21"
+        "@cucumber/messages": ">=19.1.4 <=22"
       }
     },
     "node_modules/@cucumber/gherkin-streams": {
@@ -744,9 +766,9 @@
       }
     },
     "node_modules/@cucumber/html-formatter": {
-      "version": "20.2.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-20.2.1.tgz",
-      "integrity": "sha512-bwwyr1WjlOJ5dEFOLGbtYWbUprloB2eymqXBmmTC10s0xapZXkFn4VfHgMshaH91XiCIY/MoabWNAau3AeMHkQ==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-20.4.0.tgz",
+      "integrity": "sha512-TnLSXC5eJd8AXHENo69f5z+SixEVtQIf7Q2dZuTpT/Y8AOkilGpGl1MQR1Vp59JIw+fF3EQSUKdf+DAThCxUNg==",
       "dev": true,
       "peerDependencies": {
         "@cucumber/messages": ">=18"
@@ -9786,31 +9808,31 @@
       }
     },
     "@cucumber/ci-environment": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/ci-environment/-/ci-environment-9.1.0.tgz",
-      "integrity": "sha512-jdnF6APXP3GawMue8kdMxhu6TBhyRUO4KDRxTowf06NtclLjIw2Ybpo9IcIOMvE8kHukvJyM00uxWX+CfS7JgQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/ci-environment/-/ci-environment-9.2.0.tgz",
+      "integrity": "sha512-jLzRtVwdtNt+uAmTwvXwW9iGYLEOJFpDSmnx/dgoMGKXUWRx1UHT86Q696CLdgXO8kyTwsgJY0c6n5SW9VitAA==",
       "dev": true
     },
     "@cucumber/cucumber": {
-      "version": "8.11.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-8.11.1.tgz",
-      "integrity": "sha512-C+wdypoSzHA48GCRorJCAZYuxXo1RSESukAmoz/JhGV7KB4pIlg9Y2aWeZKx6bJQkq8yq4+S4jg9f8FGCdc3jQ==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-9.3.0.tgz",
+      "integrity": "sha512-8QvcQVJzRra3pZpV0dITPcFuT2yYH0C1fEgzDlqe6+Zpz9k3z+ov9xUWEYgKp0VMx65JxNKAYYYWmG6cWOiYQQ==",
       "dev": true,
       "requires": {
-        "@cucumber/ci-environment": "9.1.0",
-        "@cucumber/cucumber-expressions": "16.1.1",
-        "@cucumber/gherkin": "26.0.3",
+        "@cucumber/ci-environment": "9.2.0",
+        "@cucumber/cucumber-expressions": "16.1.2",
+        "@cucumber/gherkin": "26.2.0",
         "@cucumber/gherkin-streams": "5.0.1",
         "@cucumber/gherkin-utils": "8.0.2",
-        "@cucumber/html-formatter": "20.2.1",
+        "@cucumber/html-formatter": "20.4.0",
         "@cucumber/message-streams": "4.0.1",
-        "@cucumber/messages": "21.0.1",
+        "@cucumber/messages": "22.0.0",
         "@cucumber/tag-expressions": "5.0.1",
         "assertion-error-formatter": "^3.0.0",
         "capital-case": "^1.0.4",
         "chalk": "^4.1.2",
         "cli-table3": "0.6.3",
-        "commander": "^9.0.0",
+        "commander": "^10.0.0",
         "debug": "^4.3.4",
         "error-stack-parser": "^2.1.4",
         "figures": "^3.2.0",
@@ -9823,10 +9845,11 @@
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "luxon": "3.2.1",
+        "mkdirp": "^2.1.5",
         "mz": "^2.7.0",
         "progress": "^2.0.3",
         "resolve-pkg": "^2.0.0",
-        "semver": "7.3.8",
+        "semver": "7.5.3",
         "string-argv": "^0.3.1",
         "strip-ansi": "6.0.1",
         "supports-color": "^8.1.1",
@@ -9834,26 +9857,44 @@
         "util-arity": "^1.1.0",
         "verror": "^1.10.0",
         "xmlbuilder": "^15.1.1",
-        "yaml": "1.10.2",
+        "yaml": "^2.2.2",
         "yup": "^0.32.11"
       },
       "dependencies": {
         "@cucumber/messages": {
-          "version": "21.0.1",
-          "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-21.0.1.tgz",
-          "integrity": "sha512-pGR7iURM4SF9Qp1IIpNiVQ77J9kfxMkPOEbyy+zRmGABnWWCsqMpJdfHeh9Mb3VskemVw85++e15JT0PYdcR3g==",
+          "version": "22.0.0",
+          "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-22.0.0.tgz",
+          "integrity": "sha512-EuaUtYte9ilkxcKmfqGF9pJsHRUU0jwie5ukuZ/1NPTuHS1LxHPsGEODK17RPRbZHOFhqybNzG2rHAwThxEymg==",
           "dev": true,
           "requires": {
-            "@types/uuid": "8.3.4",
+            "@types/uuid": "9.0.1",
             "class-transformer": "0.5.1",
             "reflect-metadata": "0.1.13",
             "uuid": "9.0.0"
           }
         },
+        "@types/uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+          "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+          "dev": true
+        },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -9873,31 +9914,25 @@
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
           "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
           "dev": true
-        },
-        "yaml": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-          "dev": true
         }
       }
     },
     "@cucumber/cucumber-expressions": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-16.1.1.tgz",
-      "integrity": "sha512-Ugsb9qxfgrgfUKsGvbx0awVk+69NIFjWfxNT+dnm62YrF2gdTHYxAOzOLuPgvE0yqYTh+3otrFLDDfkHGThM1g==",
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-16.1.2.tgz",
+      "integrity": "sha512-CfHEbxJ5FqBwF6mJyLLz4B353gyHkoi6cCL4J0lfDZ+GorpcWw4n2OUAdxJmP7ZlREANWoTFlp4FhmkLKrCfUA==",
       "dev": true,
       "requires": {
         "regexp-match-indices": "1.0.2"
       }
     },
     "@cucumber/gherkin": {
-      "version": "26.0.3",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-26.0.3.tgz",
-      "integrity": "sha512-xwJHi//bLFEU1drIyw2yswwUHnnVWO4XcyVBbCTDs6DkSh262GkogFI/IWwChZqJfOXnPglzLGxR1DibcZsILA==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-26.2.0.tgz",
+      "integrity": "sha512-iRSiK8YAIHAmLrn/mUfpAx7OXZ7LyNlh1zT89RoziSVCbqSVDxJS6ckEzW8loxs+EEXl0dKPQOXiDmbHV+C/fA==",
       "dev": true,
       "requires": {
-        "@cucumber/messages": "19.1.4 - 21"
+        "@cucumber/messages": ">=19.1.4 <=22"
       },
       "dependencies": {
         "@cucumber/messages": {
@@ -9963,9 +9998,9 @@
       }
     },
     "@cucumber/html-formatter": {
-      "version": "20.2.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-20.2.1.tgz",
-      "integrity": "sha512-bwwyr1WjlOJ5dEFOLGbtYWbUprloB2eymqXBmmTC10s0xapZXkFn4VfHgMshaH91XiCIY/MoabWNAau3AeMHkQ==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-20.4.0.tgz",
+      "integrity": "sha512-TnLSXC5eJd8AXHENo69f5z+SixEVtQIf7Q2dZuTpT/Y8AOkilGpGl1MQR1Vp59JIw+fF3EQSUKdf+DAThCxUNg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^8.2.1",
+    "@cucumber/cucumber": "^9.3.0",
     "@swc/core": "^1.3.67",
     "@types/node": "^18.11.7",
     "copyfiles": "^2.4.1",


### PR DESCRIPTION
Cucumber v8.2.1 was leading to a `semver` dependency vulnerability. Cucumber v9.3.0 was required to fix the vulnerability.

Regarding updating @cucumber/cucumber, I read the change log and have observed 3 breaking changes so far:

1. Remove support for Node.js versions 12 and 17
2. Remove "generator" snippet interface
3. Change hashes type from any to Record<string, string> in DataTable

I read some of its documentation part and saw the implementation in nightwatch code base. It is used in quite a lot of files so I can't be sure but I didn't exactly observe generator snippet interface used anywhere. I am not sure about point 3. Can I proceed to update or does any of this will lead to any problem in the codebase?