### PR TITLE
Fixed the issue regarding error if a folder defined in `src_folders` is empty when using tags

### DIFF
--- a/lib/runner/folder-walk.js
+++ b/lib/runner/folder-walk.js
@@ -130,7 +130,7 @@ class Walker {
 
   async applyTagFilter(list) {
     if (!Array.isArray(list)) {
-      return;
+      return [];
     }
     if (!this.tags.anyTagsDefined() || this.usingCucumber) {
       return list;

--- a/lib/runner/folder-walk.js
+++ b/lib/runner/folder-walk.js
@@ -130,8 +130,9 @@ class Walker {
 
   async applyTagFilter(list) {
     if (!Array.isArray(list)) {
-      return [];
+      return undefined;
     }
+    
     if (!this.tags.anyTagsDefined() || this.usingCucumber) {
       return list;
     }

--- a/lib/runner/folder-walk.js
+++ b/lib/runner/folder-walk.js
@@ -68,12 +68,12 @@ class Walker {
       err.showTrace = false;
 
       if (Array.isArray(this.settings.src_folders) && this.settings.src_folders.length > 0) {
-        let srcFolders = this.settings.src_folders.map(item => `"${item}"`).join(', ');
+        const srcFolders = this.settings.src_folders.map(item => `"${item}"`).join(', ');
         err.message += `; src_folders: ${srcFolders}`;
       }
 
       if (this.argv.group) {
-        let groups = this.argv.group.map(item => `"${item}"`).join(', ');
+        const groups = this.argv.group.map(item => `"${item}"`).join(', ');
         err.message += `; group(s): ${groups}`;
       }
 
@@ -118,7 +118,7 @@ class Walker {
         matched = false;
       }
 
-      let filename = filePath.split(path.sep).slice(-1)[0];
+      const filename = filePath.split(path.sep).slice(-1)[0];
 
       if (this.settings.filename_filter) {
         matched = matched && minimatch(filename, this.settings.filename_filter);
@@ -129,25 +129,27 @@ class Walker {
   }
 
   async applyTagFilter(list) {
-    if (!this.tags.anyTagsDefined() || this.usingCucumber) {
-      return list;
-    }
-
-    const matches = await Promise.all(list.map(filePath => {
-      return this.tags.loadModule(filePath);
-    }));
-
-    return matches.filter(context => {
-      if (!context) {
-        return false;
+    if (Array.isArray(list)) {
+      if (!this.tags.anyTagsDefined() || this.usingCucumber) {
+        return list;
       }
-
-      return this.tags.checkModuleTags(context);
-    }).map(context => context.modulePath);
+    
+      const matches = await Promise.all(list.map(filePath => {
+        return this.tags.loadModule(filePath);
+      }));
+    
+      return matches.filter(context => {
+        if (!context) {
+          return false;
+        }
+      
+        return this.tags.checkModuleTags(context);
+      }).map(context => context.modulePath);
+    }
   }
 
   promiseFn(resolve, reject) {
-    let sourcePath = this.modulePathsCopy.shift();
+    const sourcePath = this.modulePathsCopy.shift();
     let fullPath = path.resolve(sourcePath);
 
     Utils.checkPath(fullPath)

--- a/lib/runner/folder-walk.js
+++ b/lib/runner/folder-walk.js
@@ -129,23 +129,24 @@ class Walker {
   }
 
   async applyTagFilter(list) {
-    if (Array.isArray(list)) {
-      if (!this.tags.anyTagsDefined() || this.usingCucumber) {
-        return list;
+    if (!Array.isArray(list)) {
+      return;
+    }
+    if (!this.tags.anyTagsDefined() || this.usingCucumber) {
+      return list;
+    }
+  
+    const matches = await Promise.all(list.map(filePath => {
+      return this.tags.loadModule(filePath);
+    }));
+  
+    return matches.filter(context => {
+      if (!context) {
+        return false;
       }
     
-      const matches = await Promise.all(list.map(filePath => {
-        return this.tags.loadModule(filePath);
-      }));
-    
-      return matches.filter(context => {
-        if (!context) {
-          return false;
-        }
-      
-        return this.tags.checkModuleTags(context);
-      }).map(context => context.modulePath);
-    }
+      return this.tags.checkModuleTags(context);
+    }).map(context => context.modulePath);
   }
 
   promiseFn(resolve, reject) {

--- a/lib/runner/folder-walk.js
+++ b/lib/runner/folder-walk.js
@@ -130,7 +130,7 @@ class Walker {
 
   async applyTagFilter(list) {
     if (!Array.isArray(list)) {
-      return undefined;
+      return;
     }
     
     if (!this.tags.anyTagsDefined() || this.usingCucumber) {

--- a/lib/runner/folder-walk.js
+++ b/lib/runner/folder-walk.js
@@ -132,20 +132,20 @@ class Walker {
     if (!Array.isArray(list)) {
       return;
     }
-    
+
     if (!this.tags.anyTagsDefined() || this.usingCucumber) {
       return list;
     }
-  
+
     const matches = await Promise.all(list.map(filePath => {
       return this.tags.loadModule(filePath);
     }));
-  
+
     return matches.filter(context => {
       if (!context) {
         return false;
       }
-    
+
       return this.tags.checkModuleTags(context);
     }).map(context => context.modulePath);
   }


### PR DESCRIPTION
![image](https://github.com/nightwatchjs/nightwatch/assets/88396544/82141ee0-2bea-44bb-b3d5-fed14f2687a1)


The error originates in the function `applyTagFilter` which lies in `folder-walk.js`
The cause of the error is that when any folder that is defined in `src_folders` in the file `nightwatch.conf.js`, is empty, the `list` parameter of the function `applyTagFilter` goes undefined. When the function executes, it uses the Array property `.map()` on `list` parameter which is undefined and hence the error.

To fix this, an if condition is added to the top of the function body which returns the function if the parameter `list` doesn't qualify as an array.

Fixes: #3823