### PR TITLE
add error handling for worker threads

### DIFF
--- a/lib/runner/concurrency/index.js
+++ b/lib/runner/concurrency/index.js
@@ -216,8 +216,14 @@ class Concurrency extends EventEmitter {
       });
     });
 
-    return Promise.all(workerPool.tasks);
+    return new Promise((resolve, reject) => {
+      Promise.allSettled(workerPool.tasks)
+        .then(values => {
+          values.some(({status}) =>  status === 'rejected') ? reject() : resolve();
+        }); 
+    });
   }
+
   /**
   *
   * @param {Array} modules

--- a/lib/runner/concurrency/index.js
+++ b/lib/runner/concurrency/index.js
@@ -185,7 +185,7 @@ class Concurrency extends EventEmitter {
       if (this.isSafariEnvPresent) {
         extraArgs.push('--serial');
       }
-      let childProcess = this.createChildProcess(environment, args, extraArgs, index);
+      const childProcess = this.createChildProcess(environment, args, extraArgs, index);
 
       return this.runChildProcess(childProcess, environment + ' environment', availColors, 'envs');
     }));
@@ -296,7 +296,12 @@ class Concurrency extends EventEmitter {
     });
 
    
-    return Promise.all(workerPool.tasks);
+    return new Promise((resolve, reject) => {
+      Promise.allSettled(workerPool.tasks)
+        .then(values => {
+          values.some(({status}) =>  status === 'rejected') ? reject() : resolve();
+        }); 
+    });
   }
 
 

--- a/lib/runner/concurrency/worker-task.js
+++ b/lib/runner/concurrency/worker-task.js
@@ -94,6 +94,7 @@ class WorkerTask extends EventEmitter {
     port2.unref();
 
     return this.piscina.run({argv: this.argv, port1}, {transferList: [port1]})
+      .catch(err => err)
       .then(failures => {
         if (this.settings.disable_output_boxes){
           // eslint-disable-next-line no-console
@@ -101,6 +102,11 @@ class WorkerTask extends EventEmitter {
         } else {
           // eslint-disable-next-line no-console
           console.log(boxen(this.task_output.join('\n'), {title: `────────────────── ${failures ? symbols.fail : symbols.ok} ${this.task_label}`, padding: 1, borderColor: 'cyan'}));
+        }
+
+        //throw error to mark exit-code of the process
+        if (failures) {
+          throw new Error();
         }
       });
   }

--- a/test/src/runner/cli/testCliRunnerParallel.js
+++ b/test/src/runner/cli/testCliRunnerParallel.js
@@ -3,6 +3,7 @@ const path = require('path');
 const mockery = require('mockery');
 const common = require('../../../common.js');
 const NightwatchClient = common.require('index.js');
+const {settings} = common;
 
 describe('Test CLI Runner in Parallel', function () {
   const ChildProcess = common.require('runner/concurrency/child-process.js');
@@ -103,6 +104,51 @@ describe('Test CLI Runner in Parallel', function () {
       output: false,
       output_folder: false
     });
+  });
+
+  it('run error test file with concurrency - worker threads', function() {
+    let numberOfTasks = 0;
+    class RunnerBaseMock extends RunnerBase {
+      static readTestSource(settings, argv) {
+        assert.strictEqual(settings.testWorkersEnabled, true);
+
+        return [
+          'test_file_1.js',
+          'test_file_2.js'
+        ];
+      }
+    }
+
+    class WorkerProcessMock extends WorkerProcess {
+      addTask({colors}) {
+
+        this.__tasks.push(new Promise((resolve, reject) => {
+          setTimeout(()=>{
+            numberOfTasks++;
+            reject(new Error('Nigtwatch custom error'));
+          }, 10*(numberOfTasks+1));
+        }));
+
+        return Promise.resolve(0);
+      }
+    }
+    mockery.registerMock('./worker-process.js', WorkerProcessMock);
+    mockery.registerMock('../runner.js', RunnerBaseMock);
+
+    return NightwatchClient.runTests({
+      env: 'default',
+      config: path.join(__dirname, '../../../extra/withgeckodriver-concurrent.json')
+    }, settings({
+      globals: {
+        reporter() {
+          assert.strictEqual(numberOfTasks, 2); 
+        }
+      },
+      use_child_process: false,
+      silent: false,
+      output: false,
+      output_folder: false
+    }));
   });
 
   it('start single test run with geckodriver and test workers enabled', function () {


### PR DESCRIPTION
## Changes
- add error handling to worker threads (non-test execution error)
- return the correct exit code on execution failure

## Impacts
- fixes https://github.com/nightwatchjs/nightwatch/issues/3787
- fixes https://github.com/nightwatchjs/nightwatch/issues/3804
- fixes #3833 