### PR TITLE
updated semver to v7.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "ora": "5.4.1",
         "piscina": "^3.2.0",
         "selenium-webdriver": "~4.10.0",
-        "semver": "7.3.5",
+        "semver": "7.5.2",
         "stacktrace-parser": "0.1.10",
         "strip-ansi": "6.0.1",
         "untildify": "^4.0.0",
@@ -7567,9 +7567,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -14721,9 +14721,9 @@
       }
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ora": "5.4.1",
     "piscina": "^3.2.0",
     "selenium-webdriver": "~4.10.0",
-    "semver": "7.3.5",
+    "semver": "7.5.2",
     "stacktrace-parser": "0.1.10",
     "strip-ansi": "6.0.1",
     "untildify": "^4.0.0",


### PR DESCRIPTION
Affected version of semver 7.3.5, which was creating a vulnerability, is updated to the patched version 7.5.2

Fixes: #3827
