### PR TITLE
New element api should return ScopedElement on await.

### DIFF
--- a/lib/api/web-element/commands/getWebElement.js
+++ b/lib/api/web-element/commands/getWebElement.js
@@ -1,0 +1,27 @@
+/**
+ * Returns an instance of [Selenium WebElement](https://www.selenium.dev/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebElement.html) for the element.
+ *
+ * @example
+ * export default {
+ *   async demoTest(browser: NightwatchAPI): Promise<void> {
+ *     const webElement = await browser.element('#login input[type=text]').getWebElement();
+ *
+ *     // check whether element is visible
+ *     const webElementVisible = await webElement.isDisplayed();
+ *     if (webElementVisible) {
+ *       // do something
+ *     }
+ *   }
+ * }
+ *
+ * @since 3.0.0
+ * @method element.getWebElement
+ * @syntax browser.element(selector).getWebElement()
+ * @memberof ScopedWebElement
+ * @instance
+ * @see https://www.selenium.dev/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebElement.html
+ * @returns {WebElement}
+ */
+module.exports.command = function () {
+  return this.webElement;
+};

--- a/lib/api/web-element/factory.js
+++ b/lib/api/web-element/factory.js
@@ -67,9 +67,18 @@ const createScopedWebElement = function(selector, parentElement, nightwatchInsta
     
   });
 
+  // 'then' property is not called on await if
+  // `selector` => `exported` is itself a promise.
   Object.defineProperty(exported, 'then', {
     value(onFulfilled, onRejected) {
-      return instance.then(onFulfilled, onRejected);
+      // return `exported` but after the previous commands
+      // have completed their execution.
+      const exportedCopy = Object.assign({}, exported);
+      // avoid infinite loop on await
+      delete exportedCopy.then;
+
+      instance.webElement
+        .then(_ => onFulfilled(exportedCopy), onRejected);
     },
     enumerable: true,
     configurable: true
@@ -158,7 +167,7 @@ const createScopedWebElements = function(commandName, selector, parentElement, n
 
   Object.defineProperty(exported, 'then', {
     value(onFulfilled, onRejected) {
-      return instance.then(onFulfilled, onRejected);
+      return node.deferred.promise.then(onFulfilled, onRejected);
     },
     enumerable: false,
     configurable: true
@@ -190,7 +199,7 @@ const createScopedWebElements = function(commandName, selector, parentElement, n
 
           resolve(elements[index]);
         });
-      }.bind(instance)), parentElement, nightwatchInstance);
+      }.bind(node.deferred.promise)), parentElement, nightwatchInstance);
     },
     enumerable: true,
     configurable: true

--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -205,6 +205,11 @@ class ScopedWebElement {
         return resolve(null);
       }
 
+      // for findAll().nth() command
+      if (selector.webElement instanceof WebElementPromise) {
+        selector = await selector.webElement;
+      }
+
       if (selector instanceof WebElement) {
         return resolve(selector);
       }


### PR DESCRIPTION
Currently, the `element()` and `element.find()` command returns different things with/without await, which is causing confusion. So, this PR proposes for the commands to return the same thing with/without await to maintain consistency, and the only use of `await` would be to execute all the commands till now and give result after that.

How APIs work currently:

```js
const inputElement = await browser.element.find('input[name=q]');
const inputValue = await inputElement.getValue(); // won't work, as inputElement is an instance of WebElement and `.getValue` is not present on `WebElement`.
```

which is really confusing as in when to use await and when not to.

So, this PR changes the current behaviour to always return `ScopedElement` (which is a superset of WebElement with more functionalities) with or without `await`.

And if the users want a `WebElement` instance specifically (to pass to User Actions API for example), they can do so using the newly added `.getWebElement()` command.
