### PR TITLE
Migrating `lib/api/client-commands/_base-command.js` to typescript

### DIFF
--- a/lib/api/client-commands/_base-command.ts
+++ b/lib/api/client-commands/_base-command.ts
@@ -1,5 +1,22 @@
-module.exports = class ClientCommand {
-  static get isTraceable() {
+interface ResultObject {
+  status: number;
+  code: any;
+  name: any;
+  value: {
+    message: any;
+  };
+  error: any;
+}
+
+interface MakePromiseOptions {
+  performAction: (callback : (result : ResultObject) => void) => void;
+  userSuppliedCallback?: (param : any) => any;
+  fullResultObject?: boolean;
+  fullPromiseResolve?: boolean;
+}
+
+export default class ClientCommand {
+  static get isTraceable() : boolean {
     return false;
   }
 
@@ -11,9 +28,14 @@ module.exports = class ClientCommand {
    * @param {boolean} fullPromiseResolve Weather to resolve the promise with the full result object or just the "value" property
    * @return {Promise}
    */
-  static makePromise({performAction, userSuppliedCallback = function() {}, fullResultObject = true, fullPromiseResolve = true}) {
-    return new Promise(function(resolve, reject) {
-      performAction(function(result) {
+  static makePromise({
+      performAction, 
+      userSuppliedCallback = function() {}, 
+      fullResultObject = true, 
+      fullPromiseResolve = true
+    } : MakePromiseOptions) : Promise<any> {
+    return new Promise((resolve, reject) => {
+      performAction((result) => {
         try {
           if (result instanceof Error) {
             const {name, message, code} = result;
@@ -44,19 +66,19 @@ module.exports = class ClientCommand {
     });
   }
 
-  get returnsFullResultObject() {
+  get returnsFullResultObject() : boolean {
     return true;
   }
 
-  get resolvesWithFullResultObject() {
+  get resolvesWithFullResultObject() : boolean {
     return true;
   }
 
-  reportProtocolErrors(result) {
+  reportProtocolErrors(result : any) : boolean {
     return true;
   }
 
-  command(userSuppliedCallback) {
+  command(userSuppliedCallback : (param : any) => void) {
     const {performAction} = this;
 
     return ClientCommand.makePromise({
@@ -76,7 +98,7 @@ module.exports = class ClientCommand {
    * @param {function} callback
    * @private
    */
-  executeScriptHandler(method, script, args, callback) {
+  executeScriptHandler(method : string, script : string | Function, args : any[], callback : (param : any) => void) {
     let fn;
 
     if (script.originalTarget) {

--- a/lib/api/client-commands/_base-command.ts
+++ b/lib/api/client-commands/_base-command.ts
@@ -28,6 +28,7 @@ export default class ClientCommand {
    * @param {boolean} fullPromiseResolve Weather to resolve the promise with the full result object or just the "value" property
    * @return {Promise}
    */
+  
   static makePromise({
       performAction, 
       userSuppliedCallback = function() {}, 
@@ -58,7 +59,7 @@ export default class ClientCommand {
           }
 
           const resolveValue = fullPromiseResolve ? result : result.value;
-          promise.then(_ => resolve(resolveValue)).catch(err => reject(err));
+          promise.then((_ : any) => resolve(resolveValue)).catch((err : Error) => reject(err));
         } catch (e) {
           reject(e);
         }
@@ -77,6 +78,8 @@ export default class ClientCommand {
   reportProtocolErrors(result : any) : boolean {
     return true;
   }
+
+  performAction () {}
 
   command(userSuppliedCallback : (param : any) => void) {
     const {performAction} = this;
@@ -98,11 +101,14 @@ export default class ClientCommand {
    * @param {function} callback
    * @private
    */
+
+  transportActions : any = {}
+
   executeScriptHandler(method : string, script : string | Function, args : any[], callback : (param : any) => void) {
     let fn;
 
-    if (script.originalTarget) {
-      script = script.originalTarget;
+    if ((script as any).originalTarget) {
+      script = (script as any).originalTarget;
     }
 
     if (typeof script === 'function') {


### PR DESCRIPTION
I made changes to change the code from javascript to typescript but there are some typescript errors I am facing regarding which I need some guidance.

Line 61: Parameter '_' implicitly has an 'any' type.ts(7006)
Line 61: Parameter 'err' implicitly has an 'any' type.ts(7006)
Line 82: Property 'performAction' does not exist on type 'ClientCommand'.ts(2339)
Line 104, 105: Property 'originalTarget' does not exist on type 'string | Function'.
  Property 'originalTarget' does not exist on type 'string'.ts(2339)
Line 115: Property 'transportActions' does not exist on type 'ClientCommand'.ts(2339)