### PR TITLE
add GitHub Actions in the list of supporting colors

### DIFF
--- a/lib/settings/settings.js
+++ b/lib/settings/settings.js
@@ -485,8 +485,8 @@ class Settings {
   }
 
   setColorOutput() {
-    const {isCI, CIRCLE, JENKINS, NETLIFY, TRAVIS, GITLAB, BUILDKITE} = CI_Info;
-    const coloringSupport = CIRCLE || JENKINS || NETLIFY || TRAVIS || GITLAB || BUILDKITE;
+    const {isCI, CIRCLE, JENKINS, NETLIFY, TRAVIS, GITLAB, GITHUB_ACTIONS, BUILDKITE} = CI_Info;
+    const coloringSupport = CIRCLE || JENKINS || NETLIFY || TRAVIS || GITLAB || BUILDKITE || GITHUB_ACTIONS;
 
     if (isCI && !coloringSupport) {
       this.settings.disable_colors = true;


### PR DESCRIPTION
## Changes
- support `GITHUB_ACTIONS` for enabling colors in CLI

## Impact

- fixes #3601 