### PR TITLE
remove upper bound for number of worker threads

### DIFF
--- a/lib/runner/concurrency/index.js
+++ b/lib/runner/concurrency/index.js
@@ -362,12 +362,7 @@ class Concurrency extends EventEmitter {
     let workers = require('os').cpus().length;
 
     if (isObject(test_workers) && isNumber(test_workers.workers)) {
-      if (workers < test_workers.workers) {
-        // eslint-disable-next-line no-console
-        Logger.warn(`Number of max workers is set to ${test_workers.workers} while the number of cpu cores is ${workers}. This can cause performance issues...\n`);
-      } else {
-        workers = test_workers.workers;
-      }
+      workers = test_workers.workers;
     }
 
     return workers;

--- a/test/src/cli/testParallelExecution.js
+++ b/test/src/cli/testParallelExecution.js
@@ -12,6 +12,7 @@ describe('test Parallel Execution', function() {
   const allOpts = [];
 
   this.timeout(10000);
+  let workerCount;
 
   beforeEach(function() {
     mockery.enable({useCleanCache: true, warnOnUnregistered: false});
@@ -48,7 +49,7 @@ describe('test Parallel Execution', function() {
 
         this.tasks = [];
         this.index = 0;
-
+        workerCount = maxWorkerCount;
         workerPoolArgv.push(args);
       }
 
@@ -628,4 +629,20 @@ describe('test Parallel Execution', function() {
     assert.equal(client2.transport.settings.webdriver.port, 9999);
   });
 
+  it('test number of work threads for parallel execution', function() {
+
+    const CliRunner = common.require('runner/cli/cli.js');
+    const runner = new CliRunner({
+      reporter: 'junit',
+      config: path.join(__dirname, '../../extra/parallelism-count.json'),
+      env: 'default',
+      headless: true
+    });
+
+    runner.setup({});
+
+    return runner.runTests().then(_ => {
+      assert.strictEqual(workerCount, 4);
+    }); 
+  });
 });


### PR DESCRIPTION
## Changes
-  remove the upper bound for a number of worker threads.

## Impact
- fixes #3928 