### PR TITLE
fix abortOnAssertionFailure issue with waitFor commands

### DIFF
--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -47,10 +47,6 @@ class AsyncTree extends EventEmitter{
     if (childNode) {
       const result = await this.runChildNode(childNode);
 
-      if (result instanceof Error && result.namespace === 'verify') {
-        return null;
-      }
-
       return result;
     }
 

--- a/lib/testsuite/index.js
+++ b/lib/testsuite/index.js
@@ -13,7 +13,7 @@ const SuiteRetries = require('./retries.js');
 const NightwatchClient = require('../core/client.js');
 const Concurrency = require('../runner/concurrency');
 const ElementGlobal = require('../api/_loaders/element-global.js');
-const {Logger, Screenshots, Snapshots, alwaysDisplayError, isString, isFunction, SafeJSON} = require('../utils');
+const {Logger, Screenshots, Snapshots, alwaysDisplayError, isString, isFunction, SafeJSON, isDefined} = require('../utils');
 const NightwatchInspectorServer = require('./nightwatch-inspector');
 const {DEFAULT_RUNNER_EVENTS, NightwatchEventHub} = require('../runner/eventHub');
 const {GlobalHook, TestSuiteHook} = DEFAULT_RUNNER_EVENTS;
@@ -863,7 +863,8 @@ class TestSuite {
           return this.retryCurrentTestCase();
         }
 
-        if ((possibleError instanceof Error) && this.shouldSkipTestsOnFail()) {
+        const abortOnFailure = isDefined(possibleError.abortOnFailure) ? possibleError.abortOnFailure :  true;
+        if ((possibleError instanceof Error &&  abortOnFailure)  && this.shouldSkipTestsOnFail()) {
           throw possibleError;
         }
 

--- a/lib/testsuite/index.js
+++ b/lib/testsuite/index.js
@@ -863,8 +863,7 @@ class TestSuite {
           return this.retryCurrentTestCase();
         }
 
-        const abortOnFailure = isDefined(possibleError.abortOnFailure) ? possibleError.abortOnFailure :  true;
-        if ((possibleError instanceof Error &&  abortOnFailure)  && this.shouldSkipTestsOnFail()) {
+        if ((possibleError instanceof Error &&  (possibleError?.abortOnFailure ?? true))  && this.shouldSkipTestsOnFail()) {
           throw possibleError;
         }
 

--- a/test/apidemos/waitFor-commands/waitForElementTest.js
+++ b/test/apidemos/waitFor-commands/waitForElementTest.js
@@ -1,0 +1,9 @@
+describe('test wait for element commands', function() {
+  it('waitForElementVisible command - failure', function() {
+    browser.waitForElementVisible('#weblogin', 100, 90, false);
+  });
+
+  it('waitForElementNotVisible command - failure', function() {
+    browser.waitForElementNotVisible('#badElement', 100, 90, false);
+  });
+});

--- a/test/src/apidemos/waitFor-commands/testWaitForCommands.js
+++ b/test/src/apidemos/waitFor-commands/testWaitForCommands.js
@@ -1,0 +1,43 @@
+const path = require('path');
+const assert =  require('assert');
+const MockServer = require('../../../lib/mockserver.js');
+const Mocks = require('../../../lib/command-mocks.js');
+const common = require('../../../common.js');
+const {settings} = common;
+const NightwatchClient = common.require('index.js');
+
+describe('waitFor commands tests', function() {
+  beforeEach(function(done) {
+    this.server = MockServer.init();
+    this.server.on('listening', () => {
+      done();
+    });
+  });
+
+  afterEach(function(done) {
+    this.server.close(function() {
+      done();
+    });
+  });
+
+  it('run waitFor api demo tests ', function() {
+    const testsPath = path.join(__dirname, '../../../apidemos/waitFor-commands/waitForElementTest.js');
+
+    Mocks.visible('0', false);
+
+    const globals = {
+      waitForConditionPollInterval: 50,
+
+      reporter(results) {
+        assert.ok(results.lastError, 'should return NightwatchAssertError');
+        assert.strictEqual(results.skipped, 0, 'should not skip any tests');
+      }
+    };
+
+    return NightwatchClient.runTests(testsPath, settings({
+      output: false,
+      globals
+    }));
+  });
+
+});


### PR DESCRIPTION
## Changes
- Don't skip the test cases if `abortOnFailure` is set to `false`


## Impacts

- fixes #3931 