### PR TITLE
Update the description of abortOnFailure for waitForElementVisible.js

### DIFF
--- a/lib/api/element-commands/waitForElementVisible.js
+++ b/lib/api/element-commands/waitForElementVisible.js
@@ -3,7 +3,7 @@ const WaitForDisplayed = require('./_waitForDisplayed.js');
 /**
  * Waits a given time in milliseconds (default 5000ms) for an element to be visible in the page before performing any other commands or assertions.
  *
- * If the element fails to be present and visible in the specified amount of time,  the test will be marked as failed, and ordinarily, the subsequent tests within the test suite will be skipped. However, you have the option to prevent the remaining tests from being skipped by setting `abortOnFailure` to `false`.
+ * If the element fails to be present and visible in the specified amount of time,  the test will be marked as failed, and ordinarily, the subsequent steps/commands within the test-case/section will not be performed. However, you have the option to prevent the remaining steps/commands from being skipped by setting `abortOnFailure` to `false`.
  *
  * You can change the polling interval by defining a `waitForConditionPollInterval` property (in milliseconds) in as a global property in your `nightwatch.json` or in your external globals file.
  *

--- a/lib/api/element-commands/waitForElementVisible.js
+++ b/lib/api/element-commands/waitForElementVisible.js
@@ -3,7 +3,7 @@ const WaitForDisplayed = require('./_waitForDisplayed.js');
 /**
  * Waits a given time in milliseconds (default 5000ms) for an element to be visible in the page before performing any other commands or assertions.
  *
- * If the element fails to be present and visible in the specified amount of time,  the test will be marked as failed, and ordinarily, the subsequent tests within the test suite will be skipped. However, you have the option to prevent the remaining tests from being skipped by setting `abortOnFailure` to `false`."
+ * If the element fails to be present and visible in the specified amount of time,  the test will be marked as failed, and ordinarily, the subsequent tests within the test suite will be skipped. However, you have the option to prevent the remaining tests from being skipped by setting `abortOnFailure` to `false`.
  *
  * You can change the polling interval by defining a `waitForConditionPollInterval` property (in milliseconds) in as a global property in your `nightwatch.json` or in your external globals file.
  *

--- a/lib/api/element-commands/waitForElementVisible.js
+++ b/lib/api/element-commands/waitForElementVisible.js
@@ -3,7 +3,7 @@ const WaitForDisplayed = require('./_waitForDisplayed.js');
 /**
  * Waits a given time in milliseconds (default 5000ms) for an element to be visible in the page before performing any other commands or assertions.
  *
- * If the element fails to be present and visible in the specified amount of time, the test fails. You can change this by setting `abortOnFailure` to `false`.
+ * If the element fails to be present and visible in the specified amount of time,  the test will be marked as failed, and ordinarily, the subsequent tests within the test suite will be skipped. However, you have the option to prevent the remaining tests from being skipped by setting `abortOnFailure` to `false`."
  *
  * You can change the polling interval by defining a `waitForConditionPollInterval` property (in milliseconds) in as a global property in your `nightwatch.json` or in your external globals file.
  *


### PR DESCRIPTION
##  Changes 

- fix the description of `abortOnFailure` in `waitForElementVisible` command.

