### PR TITLE
Fixes/3948 enable worker threads for mobile while using cloud services

### DIFF
--- a/lib/runner/cli/cli.js
+++ b/lib/runner/cli/cli.js
@@ -443,6 +443,12 @@ class CliRunner {
     return this.isTestWorkersEnabled() && !this.testRunner.isTestWorker();
   }
 
+  usingServer(test_settings = {}) {
+    // TODO: selenium_host and seleniumHost are for backwards compatability.
+    // remove these in future versions.
+    return  test_settings.selenium?.host || test_settings.selenium_host || test_settings.seleniumHost;
+  }
+
   isTestWorkersEnabled() {
     const testWorkers =  this.test_settings.testWorkersEnabled && !singleSourceFile(this.argv);
     if (!testWorkers) {
@@ -458,7 +464,7 @@ class CliRunner {
       const {webdriver = {}} = this.testEnvSettings[env];
       const desiredCapabilities = this.testEnvSettings[env].capabilities || this.testEnvSettings[env].desiredCapabilities;
 
-      if (isMobile(desiredCapabilities)) {
+      if (isMobile(desiredCapabilities) && this.usingServer(this.testEnvSettings[env])) {
 
         if  (Concurrency.isWorker()) {
           Logger.info('Disabling parallelism while running tests on mobile platform');

--- a/test/src/runner/cli/testCliRunnerParallel.js
+++ b/test/src/runner/cli/testCliRunnerParallel.js
@@ -208,6 +208,46 @@ describe('Test CLI Runner in Parallel', function () {
     assert.strictEqual(runner.parallelMode(), false);
   });
 
+  it('mobile config setup on with worker threads - enable worker threads while using server config', function() {
+    class RunnerBaseMock extends RunnerBase {
+      static readTestSource(settings, argv) {
+        assert.strictEqual(settings.testWorkersEnabled, true);
+
+        return [
+          'test_file_1.js',
+          'test_file_2.js'
+        ];
+      }
+    }
+    mockery.registerMock('../runner.js', RunnerBaseMock);
+    mockery.registerMock(path.join(process.cwd(), 'ios_config.json'), {
+      test_settings: {
+        desiredCapabilities: {
+          browserName: 'firefox'
+        },
+        'simulator.ios': {
+          selenium: {
+            use_appium: true
+          },
+          desiredCapabilities: {
+            browserName: null,
+            platformName: 'iOS',
+            'appium:deviceName': 'iPhone 13',
+            'appium:platformVersion': '15.0'
+          }
+        }
+      }
+    });
+    const runner = NightwatchClient.CliRunner({
+      config: 'ios_config.json',
+      env: 'simulator.ios',
+      workers: 4
+    }).setup();
+    assert.strictEqual(runner.isTestWorkersEnabled(), true);
+    assert.strictEqual(runner.parallelMode(), true);
+  });
+
+
   it('disable parallelism when running tests on safari', function() {
     class RunnerBaseMock extends RunnerBase {
       static readTestSource(settings, argv) {


### PR DESCRIPTION
## Changes
- enable worker threads for mobile while using against the selenium server.

## Impacts
- fixes #3948 