### PR TITLE
Fix shadow root not working on Firefox.

### DIFF
--- a/examples/tests/shadowRootExample.js
+++ b/examples/tests/shadowRootExample.js
@@ -1,8 +1,4 @@
 describe('Shadow Root example test', function() {
-
-  // Doesn't work in Firefox due to a serialization issue in Geckodriver
-  this.disabled = this.settings.desiredCapabilities.browserName === 'firefox';
-
   it('retrieve the shadowRoot', async function(browser) {
     browser
       .navigateTo('https://mdn.github.io/web-components-examples/popup-info-box-web-component/')
@@ -33,7 +29,9 @@ describe('Shadow Root example test', function() {
     //
     // //await expect(shadowId).to.be.a('string').and.to.include('shadow')
     //
-    const shadowRootEl = await browser.element('popup-info').getShadowRoot();
+
+    // no `await` used since `shadowRootEl` is going to be chained further
+    const shadowRootEl = browser.element('popup-info').getShadowRoot();
     const infoElement = shadowRootEl.find('.info').property('innerHTML');
     //
     // //console.log('!!! infoElement', infoElement.assert)

--- a/lib/api/element-commands/getShadowRoot.js
+++ b/lib/api/element-commands/getShadowRoot.js
@@ -39,7 +39,7 @@ class ElementCommand extends BaseElementCommand {
     const result = await this.executeProtocolAction('getShadowRoot');
 
     if (result instanceof ShadowRoot) {
-      // treating the ShadowRoot as WebElement, so that the WebElement
+      // treat the ShadowRoot as WebElement, so that the WebElement
       // methods continue to be available on shadow root.
       return this.api.createElement({[WEB_ELEMENT_ID]: result.getId()});
     }

--- a/lib/api/element-commands/getShadowRoot.js
+++ b/lib/api/element-commands/getShadowRoot.js
@@ -1,3 +1,5 @@
+const {ShadowRoot} = require('selenium-webdriver/lib/webdriver');
+const {WEB_ELEMENT_ID} = require('../../transport/selenium-webdriver/session.js');
 const BaseElementCommand = require('./_baseElementCommand.js');
 
 /**
@@ -36,8 +38,10 @@ class ElementCommand extends BaseElementCommand {
   async protocolAction() {
     const result = await this.executeProtocolAction('getShadowRoot');
 
-    if (result && result.value) {
-      return this.api.createElement(result.value);
+    if (result instanceof ShadowRoot) {
+      // treating the ShadowRoot as WebElement, so that the WebElement
+      // methods continue to be available on shadow root.
+      return this.api.createElement({[WEB_ELEMENT_ID]: result.getId()});
     }
 
     return result;

--- a/lib/api/web-element/commands/getShadowRoot.js
+++ b/lib/api/web-element/commands/getShadowRoot.js
@@ -26,9 +26,7 @@
  */
 module.exports.command = function() {
   const createAction = (actions, webElement) => function() {
-    return actions.executeScript(function(element) {
-      return element.shadowRoot;
-    }, [webElement]);
+    return actions.getShadowRoot(webElement);
   };
   const node = this.queueAction({name: 'getShadowRoot', createAction});
 

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -710,9 +710,10 @@ module.exports = class MethodMappings {
         },
 
         async getShadowRoot(webElementOrId) {
-          return await this.getElementByJs(function(element) {
-            return element && element.shadowRoot;
-          }, webElementOrId);
+          const element = this.getWebElement(webElementOrId);
+          const shadowRoot = await element.getShadowRoot();
+
+          return shadowRoot;
         },
 
         async elementHasDescendants(webElementOrId) {

--- a/test/src/api/commands/web-element/testGetShadowRoot.js
+++ b/test/src/api/commands/web-element/testGetShadowRoot.js
@@ -17,8 +17,8 @@ describe('element().getShadowRoot() command', function () {
 
   it('test .element().getShadowRoot()', async function() {
     MockServer.addMock({
-      url: '/session/13521-10219-202/execute/sync',
-      method: 'POST',
+      url: '/session/13521-10219-202/element/0/shadow',
+      method: 'GET',
       response: JSON.stringify({
         value: {
           'shadow-6066-11e4-a52e-4f735466cecf': '9'
@@ -39,8 +39,8 @@ describe('element().getShadowRoot() command', function () {
 
   it('test .element().find().getShadowRoot()', async function() {
     MockServer.addMock({
-      url: '/session/13521-10219-202/execute/sync',
-      method: 'POST',
+      url: '/session/13521-10219-202/element/1/shadow',
+      method: 'GET',
       response: JSON.stringify({
         value: {
           'shadow-6066-11e4-a52e-4f735466cecf': '10'
@@ -61,8 +61,8 @@ describe('element().getShadowRoot() command', function () {
 
   it('test .element.find().getShadowRoot()', async function() {
     MockServer.addMock({
-      url: '/session/13521-10219-202/execute/sync',
-      method: 'POST',
+      url: '/session/13521-10219-202/element/0/shadow',
+      method: 'GET',
       response: JSON.stringify({
         value: {
           'shadow-6066-11e4-a52e-4f735466cecf': '9'


### PR DESCRIPTION
Earlier, to get the shadow root of an element, we were executing a script in the browser which didn't work for Firefox due to some serialization issues. But now Selenium provides a `getShadowRoot()` method on `WebElement`, which can be used to reliably get the shadow root of an element across all browsers (as it hits the `element/{element id}/shadow` endpoint defined in the webdriver spec to get the shadow root).

Fixes: #3966 