### PR TITLE
Fix TS tests not working in ESM project.

### DIFF
--- a/lib/runner/cli/cli.js
+++ b/lib/runner/cli/cli.js
@@ -325,12 +325,12 @@ class CliRunner {
     const usingESM = packageInfo.type === 'module';
 
     const usingTS = Utils.fileExistsSync(CliRunner.CONFIG_FILE_TS);
+    if (usingTS) {
+      return path.resolve(CliRunner.CONFIG_FILE_TS);
+    }
 
     if (usingESM) {
       return path.resolve(CliRunner.CONFIG_FILE_CJS);
-    }
-    if (usingTS) {
-      return path.resolve(CliRunner.CONFIG_FILE_TS);
     }
 
     return path.resolve(CliRunner.CONFIG_FILE_JS);

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -591,7 +591,12 @@ class Utils {
       require('ts-node').register({
         esm: false,
         transpileOnly: true,
-        project: projectTsFile
+        project: projectTsFile,
+        // Always compile and execute .ts files as CommonJS,
+        // even in ESM projects.
+        moduleTypes: {
+          '**/*.ts': 'cjs'
+        }
       });
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {


### PR DESCRIPTION
Fixes: #3959.

Apparently, `ts-node` does not work with `import()` calls, even when its `esm` config is set to `true`. So, this PR sets ts-node to compile and execute all `.ts` files as CommonJS, so that they can be imported using the trivial `require()` calls only, even in ESM projects, instead of having to use the `import()` call. But for importing JS files in ESM projects, `import()` will be used as before.

More details on the added config: https://www.npmjs.com/package/ts-node#module-type-overrides