### PR TITLE
Fix process stalling for 4 mins after test run in Node v20+.

### DIFF
--- a/lib/utils/analytics.js
+++ b/lib/utils/analytics.js
@@ -239,6 +239,8 @@ class AnalyticsCollector {
         } else {
           resolve(response);
         }
+
+        response.on('data', (_) => {});
       });
 
       request.on('error', (result) => {


### PR DESCRIPTION
This was happening because the `https` library now creates connections to be `keep-alive` by default ([related PR](https://github.com/nodejs/node/pull/46331)), which stays open until the response is read completely (https://github.com/nodejs/node/issues/50188#issuecomment-1766866864).

So, this PR fixes the issue by reading the response data.

Another fix was to set the `Connection` header to `'close'` (https://github.com/nodejs/node/issues/50188#issuecomment-1765143646), but I think the fix in this PR is the correct one.