### PR TITLE
Add exhaustive types for waitFor commands.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -58,6 +58,11 @@ export interface JSON_WEB_OBJECT extends ElementResult {
 export type ScopedSelector = string | ElementProperties | Element | SeleniumBy | RelativeBy;
 export type Definition = ScopedSelector | WebElement;
 
+export type NightwatchGenericCallback<T> = (
+  this: NightwatchAPI,
+  result: NightwatchCallbackResult<T>
+) => void
+
 export type Awaitable<T, V> = Omit<T, 'then'> & PromiseLike<V>;
 
 // tslint:disable-next-line
@@ -3366,6 +3371,8 @@ export interface ElementCommands {
    * @returns `null` if element not found, `Error` otherwise.
    *
    * @example
+   * // 'message' should always be the last argument (if provided).
+   * // 'callback' should only be second-last to the 'message' argument, otherwise always last.
    * module.exports = {
    *  'demo Test': function() {
    *     // with default implicit timeout of 5000ms (can be overwritten in settings under 'globals.waitForConditionTimeout')
@@ -3431,25 +3438,19 @@ export interface ElementCommands {
    */
   waitForElementNotPresent(
     selector: Definition,
-    time?: number,
-    poll?: number,
-    abortOnFailure?: boolean,
-    callback?: (
-      this: NightwatchAPI,
-      result: NightwatchCallbackResult<null | ElementResult[]>
-    ) => void,
+    timeoutOrCallbackOrMessage?: number | NightwatchGenericCallback<null | ElementResult[]> | string,
+    pollIntervalOrAbortOnFailureOrCallbackOrMessage?: number | boolean | NightwatchGenericCallback<null | ElementResult[]> | string,
+    abortOnFailureOrCallbackOrMessage?: boolean | NightwatchGenericCallback<null | ElementResult[]> | string,
+    callbackOrMessage?: NightwatchGenericCallback<null | ElementResult[]> | string,
     message?: string
   ): Awaitable<this, null | Error>;
   waitForElementNotPresent(
     using: LocateStrategy,
     selector: Definition,
-    time?: number,
-    poll?: number,
-    abortOnFailure?: boolean,
-    callback?: (
-      this: NightwatchAPI,
-      result: NightwatchCallbackResult<null | ElementResult[]>
-    ) => void,
+    timeoutOrCallbackOrMessage?: number | NightwatchGenericCallback<null | ElementResult[]> | string,
+    pollIntervalOrAbortOnFailureOrCallbackOrMessage?: number | boolean | NightwatchGenericCallback<null | ElementResult[]> | string,
+    abortOnFailureOrCallbackOrMessage?: boolean | NightwatchGenericCallback<null | ElementResult[]> | string,
+    callbackOrMessage?: NightwatchGenericCallback<null | ElementResult[]> | string,
     message?: string
   ): Awaitable<this, null | Error>;
 
@@ -3465,6 +3466,8 @@ export interface ElementCommands {
    * @returns `false` if element not visible, `Error` otherwise.
    *
    * @example
+   * // 'message' should always be the last argument (if provided).
+   * // 'callback' should only be second-last to the 'message' argument, otherwise always last.
    * module.exports = {
    *  'demo Test': function() {
    *     // with default implicit timeout of 5000ms (can be overwritten in settings under 'globals.waitForConditionTimeout')
@@ -3530,25 +3533,19 @@ export interface ElementCommands {
    */
   waitForElementNotVisible(
     selector: Definition,
-    time?: number,
-    poll?: number,
-    abortOnFailure?: boolean,
-    callback?: (
-      this: NightwatchAPI,
-      result: NightwatchCallbackResult<boolean>
-    ) => void,
+    timeoutOrCallbackOrMessage?: number | NightwatchGenericCallback<boolean> | string,
+    pollIntervalOrAbortOnFailureOrCallbackOrMessage?: number | boolean | NightwatchGenericCallback<boolean> | string,
+    abortOnFailureOrCallbackOrMessage?: boolean | NightwatchGenericCallback<boolean> | string,
+    callbackOrMessage?: NightwatchGenericCallback<boolean> | string,
     message?: string
   ): Awaitable<this, false | Error>;
   waitForElementNotVisible(
     using: LocateStrategy,
     selector: Definition,
-    time?: number,
-    poll?: number,
-    abortOnFailure?: boolean,
-    callback?: (
-      this: NightwatchAPI,
-      result: NightwatchCallbackResult<boolean>
-    ) => void,
+    timeoutOrCallbackOrMessage?: number | NightwatchGenericCallback<boolean> | string,
+    pollIntervalOrAbortOnFailureOrCallbackOrMessage?: number | boolean | NightwatchGenericCallback<boolean> | string,
+    abortOnFailureOrCallbackOrMessage?: boolean | NightwatchGenericCallback<boolean> | string,
+    callbackOrMessage?: NightwatchGenericCallback<boolean> | string,
     message?: string
   ): Awaitable<this, false | Error>;
 
@@ -3562,6 +3559,8 @@ export interface ElementCommands {
    * @returns `ElementResult[]` if element is found, `Error` otherwise.
    *
    * @example
+   * // 'message' should always be the last argument (if provided).
+   * // 'callback' should only be second-last to the 'message' argument, otherwise always last.
    * module.exports = {
    *  'demo Test': function() {
    *     // with default implicit timeout of 5000ms (can be overwritten in settings under 'globals.waitForConditionTimeout')
@@ -3626,25 +3625,19 @@ export interface ElementCommands {
    */
   waitForElementPresent(
     selector: Definition,
-    time?: number,
-    poll?: number,
-    abortOnFailure?: boolean,
-    callback?: (
-      this: NightwatchAPI,
-      result: NightwatchCallbackResult<ElementResult[] | null>
-    ) => void,
+    timeoutOrCallbackOrMessage?: number | NightwatchGenericCallback<null | ElementResult[]> | string,
+    pollIntervalOrAbortOnFailureOrCallbackOrMessage?: number | boolean | NightwatchGenericCallback<null | ElementResult[]> | string,
+    abortOnFailureOrCallbackOrMessage?: boolean | NightwatchGenericCallback<null | ElementResult[]> | string,
+    callbackOrMessage?: NightwatchGenericCallback<null | ElementResult[]> | string,
     message?: string
   ): Awaitable<this, ElementResult[] | Error>;
   waitForElementPresent(
     using: LocateStrategy,
     selector: Definition,
-    time?: number,
-    poll?: number,
-    abortOnFailure?: boolean,
-    callback?: (
-      this: NightwatchAPI,
-      result: NightwatchCallbackResult<ElementResult[] | null>
-    ) => void,
+    timeoutOrCallbackOrMessage?: number | NightwatchGenericCallback<null | ElementResult[]> | string,
+    pollIntervalOrAbortOnFailureOrCallbackOrMessage?: number | boolean | NightwatchGenericCallback<null | ElementResult[]> | string,
+    abortOnFailureOrCallbackOrMessage?: boolean | NightwatchGenericCallback<null | ElementResult[]> | string,
+    callbackOrMessage?: NightwatchGenericCallback<null | ElementResult[]> | string,
     message?: string
   ): Awaitable<this, ElementResult[] | Error>;
 
@@ -3660,6 +3653,8 @@ export interface ElementCommands {
    * @returns `true` is element is visible, `Error` otherwise.
    *
    * @example
+   * // 'message' should always be the last argument (if provided).
+   * // 'callback' should only be second-last to the 'message' argument, otherwise always last.
    * this.demoTest = function (browser) {
    *   browser.waitForElementVisible('body', 1000);
    *   // continue if failed
@@ -3678,26 +3673,20 @@ export interface ElementCommands {
    */
   waitForElementVisible(
     selector: Definition,
-    time?: number,
-    poll?: number,
-    abortOnFailure?: boolean,
-    callback?: (
-      this: NightwatchAPI,
-      result: NightwatchCallbackResult<boolean>
-    ) => void,
+    timeoutOrCallbackOrMessage?: number | NightwatchGenericCallback<boolean> | string,
+    pollIntervalOrAbortOnFailureOrCallbackOrMessage?: number | boolean | NightwatchGenericCallback<boolean> | string,
+    abortOnFailureOrCallbackOrMessage?: boolean | NightwatchGenericCallback<boolean> | string,
+    callbackOrMessage?: NightwatchGenericCallback<boolean> | string,
     message?: string
   ): Awaitable<this, true | Error>;
 
   waitForElementVisible(
     using: LocateStrategy,
     selector: Definition,
-    time?: number,
-    poll?: number,
-    abortOnFailure?: boolean,
-    callback?: (
-      this: NightwatchAPI,
-      result: NightwatchCallbackResult<boolean>
-    ) => void,
+    timeoutOrCallbackOrMessage?: number | NightwatchGenericCallback<boolean> | string,
+    pollIntervalOrAbortOnFailureOrCallbackOrMessage?: number | boolean | NightwatchGenericCallback<boolean> | string,
+    abortOnFailureOrCallbackOrMessage?: boolean | NightwatchGenericCallback<boolean> | string,
+    callbackOrMessage?: NightwatchGenericCallback<boolean> | string,
     message?: string
   ): Awaitable<this, true | Error>;
 

--- a/types/tests/elementCommands.test-d.ts
+++ b/types/tests/elementCommands.test-d.ts
@@ -466,6 +466,54 @@ describe('waitForElementVisible command demo', function () {
       expectType<NightwatchAPI>(this);
       expectType<NightwatchCallbackResult<boolean>>(result);
     });
+
+    // - with no arguments; in this case a global default timeout is used
+    browser.waitForElementVisible('body');
+
+    // specify the locate strategy (css selector/xpath) as the first argument
+    browser.waitForElementVisible('css selector', '#dialog');
+
+    // with custom output message - the locate strategy is required
+    browser.waitForElementVisible('css selector', '#dialog', 'The dialog container is removed.');
+  
+    // - with a global default timeout and a callback
+    browser.waitForElementVisible('body', function() {});
+  
+    // - with a global default timeout, a callback, and a custom message
+    browser.waitForElementVisible('body', function() {}, 'test message');
+  
+    // - with a global default timeout a custom message
+    browser.waitForElementVisible('body', 'test message');
+  
+    // - with only the timeout
+    browser.waitForElementVisible('body', 500);
+  
+    // - with a timeout and a custom message
+    browser.waitForElementVisible('body', 500, 'test message');
+  
+    // - with a timeout and a callback
+    browser.waitForElementVisible('body', 500, function() {});
+  
+    // - with a timeout and a custom abortOnFailure
+    browser.waitForElementVisible('body', 500, true);
+  
+    // - with a timeout, a custom abortOnFailure, and a custom message
+    browser.waitForElementVisible('body', 500, true, 'test message');
+  
+    // - with a timeout, a custom abortOnFailure, and a callback
+    browser.waitForElementVisible('body', 500, true, function() {});
+  
+    // - with a timeout, a custom abortOnFailure, a callback and a custom message
+    browser.waitForElementVisible('body', 500, true, function() {}, 'test message');
+  
+    // - with a timeout, a custom reschedule interval, and a callback
+    browser.waitForElementVisible('body', 500, 100, function() {});
+  
+    // - with a timeout, a custom rescheduleInterval, and a custom abortOnFailure
+    browser.waitForElementVisible('body', 500, 100, false);
+
+    // - with a timeout, a custom rescheduleInterval, a custom abortOnFailure, and a custom message
+    browser.waitForElementVisible('body', 500, 100, false, 'test message');
   });
 
   test('async demo test', async function (browser) {
@@ -488,6 +536,54 @@ describe('waitForElementPresent command demo', function () {
 
       expectType<NightwatchCallbackResult<null | ElementResult[]>>(result);
     });
+
+    // - with no arguments; in this case a global default timeout is used
+    browser.waitForElementPresent('body');
+
+    // specify the locate strategy (css selector/xpath) as the first argument
+    browser.waitForElementPresent('css selector', '#dialog');
+
+    // with custom output message - the locate strategy is required
+    browser.waitForElementPresent('css selector', '#dialog', 'The dialog container is removed.');
+  
+    // - with a global default timeout and a callback
+    browser.waitForElementPresent('body', function() {});
+  
+    // - with a global default timeout, a callback, and a custom message
+    browser.waitForElementPresent('body', function() {}, 'test message');
+  
+    // - with a global default timeout a custom message
+    browser.waitForElementPresent('body', 'test message');
+  
+    // - with only the timeout
+    browser.waitForElementPresent('body', 500);
+  
+    // - with a timeout and a custom message
+    browser.waitForElementPresent('body', 500, 'test message');
+  
+    // - with a timeout and a callback
+    browser.waitForElementPresent('body', 500, function() {});
+  
+    // - with a timeout and a custom abortOnFailure
+    browser.waitForElementPresent('body', 500, true);
+  
+    // - with a timeout, a custom abortOnFailure, and a custom message
+    browser.waitForElementPresent('body', 500, true, 'test message');
+  
+    // - with a timeout, a custom abortOnFailure, and a callback
+    browser.waitForElementPresent('body', 500, true, function() {});
+  
+    // - with a timeout, a custom abortOnFailure, a callback and a custom message
+    browser.waitForElementPresent('body', 500, true, function() {}, 'test message');
+  
+    // - with a timeout, a custom reschedule interval, and a callback
+    browser.waitForElementPresent('body', 500, 100, function() {});
+  
+    // - with a timeout, a custom rescheduleInterval, and a custom abortOnFailure
+    browser.waitForElementPresent('body', 500, 100, false);
+
+    // - with a timeout, a custom rescheduleInterval, a custom abortOnFailure, and a custom message
+    browser.waitForElementPresent('body', 500, 100, false, 'test message');
   });
 
   test('async demo test', async function (browser) {


### PR DESCRIPTION
Fixes: #3981

Earlier, the typings for the waitFor commands were very restrictive due to which the formats which worked in JS were not working in TS.

This PR makes the types for the waitFor commands lenient so that everything that works in JS continues to work in TS, but at the added expense of not at all strict typings which could be error-prone for users (though the argument names have been constructed in a way to reduce this).

Other solution to this would have been to create an overload corresponding to every way the command can be used, but that would have led to way too many overloads for each waitFor command and would have been hard to manage.