### PR TITLE
Update nightwatch-axe-verbose dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "minimatch": "3.1.2",
         "minimist": "1.2.6",
         "mocha": "10.2.0",
-        "nightwatch-axe-verbose": "^2.2.2",
+        "nightwatch-axe-verbose": "^2.3.0",
         "open": "8.4.2",
         "ora": "5.4.1",
         "piscina": "3.2.0",
@@ -2092,9 +2092,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
-      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.3.tgz",
+      "integrity": "sha512-d5ZQHPSPkF9Tw+yfyDcRoUOc4g/8UloJJe5J8m4L5+c7AtDdjDLRxew/knnI4CxvtdxEUVgWz4x3OIQUIFiMfw==",
       "engines": {
         "node": ">=4"
       }
@@ -6403,11 +6403,11 @@
       }
     },
     "node_modules/nightwatch-axe-verbose": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nightwatch-axe-verbose/-/nightwatch-axe-verbose-2.2.2.tgz",
-      "integrity": "sha512-MvCrQb9D/ixtGtyN5fh7YCkelXuPup3X9D2Zhhk1PWyALtkdYCFadnIGif1irpQ1BLNSlqC+FDNnsNald7KHYA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/nightwatch-axe-verbose/-/nightwatch-axe-verbose-2.3.0.tgz",
+      "integrity": "sha512-IC29PLvYrbbKRdIU/NJaxk/UvTmQ5EiNN08UnCWyImpzV0Y7tE1CYchrvFTaHXBZkkZTQC3uHTeHF/41mvK8eQ==",
       "dependencies": {
-        "axe-core": "^4.7.2"
+        "axe-core": "^4.8.3"
       }
     },
     "node_modules/no-case": {
@@ -10798,9 +10798,9 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "axe-core": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
-      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g=="
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.3.tgz",
+      "integrity": "sha512-d5ZQHPSPkF9Tw+yfyDcRoUOc4g/8UloJJe5J8m4L5+c7AtDdjDLRxew/knnI4CxvtdxEUVgWz4x3OIQUIFiMfw=="
     },
     "axios": {
       "version": "1.6.5",
@@ -14006,11 +14006,11 @@
       }
     },
     "nightwatch-axe-verbose": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nightwatch-axe-verbose/-/nightwatch-axe-verbose-2.2.2.tgz",
-      "integrity": "sha512-MvCrQb9D/ixtGtyN5fh7YCkelXuPup3X9D2Zhhk1PWyALtkdYCFadnIGif1irpQ1BLNSlqC+FDNnsNald7KHYA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/nightwatch-axe-verbose/-/nightwatch-axe-verbose-2.3.0.tgz",
+      "integrity": "sha512-IC29PLvYrbbKRdIU/NJaxk/UvTmQ5EiNN08UnCWyImpzV0Y7tE1CYchrvFTaHXBZkkZTQC3uHTeHF/41mvK8eQ==",
       "requires": {
-        "axe-core": "^4.7.2"
+        "axe-core": "^4.8.3"
       }
     },
     "no-case": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "minimatch": "3.1.2",
     "minimist": "1.2.6",
     "mocha": "10.2.0",
-    "nightwatch-axe-verbose": "^2.2.2",
+    "nightwatch-axe-verbose": "^2.3.0",
     "open": "8.4.2",
     "ora": "5.4.1",
     "piscina": "3.2.0",


### PR DESCRIPTION
Update `nightwatch-axe-verbose` plugin to the latest version to include the changes done in https://github.com/reallymello/nightwatch-axe-verbose/pull/17, which makes the `.axeRun()` command much more powerful.