### PR TITLE
Fix Nightwatch overwriting test status set by user.

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -184,6 +184,11 @@ class HttpRequest extends EventEmitter {
       const url = new URL(options.url);
       reqOptions.path = url.pathname;
       reqOptions.host = url.hostname;
+
+      if (url.search && reqOptions.method === HttpUtil.Method.GET) {
+        // append search query parameters to path.
+        reqOptions.path += url.search;
+      }
     }
 
     this.auth = options.auth || null;

--- a/lib/transport/selenium-webdriver/browserstack/browserstack.js
+++ b/lib/transport/selenium-webdriver/browserstack/browserstack.js
@@ -100,7 +100,7 @@ class Browserstack extends AppiumBaseServer {
   async getBuildId() {
     try {
       const builds = await this.sendHttpRequest({
-        url: `${this.ApiUrl}/builds.json`,
+        url: `${this.ApiUrl}/builds.json?status=running`,
         method: 'GET',
         use_ssl: true,
         auth: {
@@ -120,6 +120,22 @@ class Browserstack extends AppiumBaseServer {
   }
 
   async sendReasonToBrowserstack(isFailure = false, reason = '') {
+    const sessionDetails = await this.sendHttpRequest({
+      url: `${this.ApiUrl}/sessions/${this.sessionId}.json`,
+      method: 'GET',
+      use_ssl: true,
+      auth: {
+        user: this.username,
+        pass: this.accessKey
+      }
+    });
+
+    const status = sessionDetails?.automation_session?.status;
+    if (['passed', 'failed'].includes(status)) {
+      // status has already been set by user
+      return;
+    }
+
     reason = stripAnsi(reason);
     await this.sendHttpRequest({
       url: `${this.ApiUrl}/sessions/${this.sessionId}.json`,
@@ -134,7 +150,6 @@ class Browserstack extends AppiumBaseServer {
         pass: this.accessKey
       }
     });
-
   }
 
   async sessionFinished(reason, err) {

--- a/test/src/core/testCreateSession.js
+++ b/test/src/core/testCreateSession.js
@@ -543,7 +543,8 @@ describe('test Request With Credentials', function () {
       });
 
     nock('https://api.browserstack.com')
-      .get('/automate/builds.json')
+      .get('/automate/builds.json?status=running')
+      .times(2)
       .reply(200, [
         {
           automation_build: {
@@ -620,6 +621,9 @@ describe('test Request With Credentials', function () {
       }
     });
 
+    const buildId = await client.transport.getBuildId();
+    assert.strictEqual(buildId, undefined);
+
     assert.strictEqual(client.api.isAppiumClient(), false);
   });
 
@@ -667,7 +671,8 @@ describe('test Request With Credentials', function () {
       });
 
     nock('https://api.browserstack.com')
-      .get('/app-automate/builds.json')
+      .get('/app-automate/builds.json?status=running')
+      .times(2)
       .reply(200, [
         {
           automation_build: {
@@ -733,6 +738,9 @@ describe('test Request With Credentials', function () {
         realMobile: true
       }
     });
+
+    const buildId = await client.transport.getBuildId();
+    assert.strictEqual(buildId, undefined);
   
     assert.strictEqual(client.transport.uploadedAppUrl, 'bs://878bdf21505f0004ce');
 
@@ -796,8 +804,16 @@ describe('test Request With Credentials', function () {
       });
 
     nock('https://api.browserstack.com')
-      .get('/app-automate/builds.json')
+      .get('/app-automate/builds.json?status=running')
+      .times(2)
       .reply(200, [
+        {
+          automation_build: {
+            name: 'Nightwatch Programmatic Api Demo',
+            status: 'running',
+            hashed_id: '123456789'
+          }
+        },
         {
           automation_build: {
             name: 'WIN_CHROME_PROD_SANITY_LIVE_1831',
@@ -865,6 +881,9 @@ describe('test Request With Credentials', function () {
       }
     });
 
+    const buildId = await client.transport.getBuildId();
+    assert.strictEqual(buildId, '123456789');
+
     assert.strictEqual(client.transport.uploadedAppUrl, undefined);
 
     assert.strictEqual(client.settings.selenium.use_appium, undefined);
@@ -902,8 +921,16 @@ describe('test Request With Credentials', function () {
       });
 
     nock('https://api.browserstack.com')
-      .get('/automate/builds.json')
+      .get('/automate/builds.json?status=running')
+      .times(2)
       .reply(200, [
+        {
+          automation_build: {
+            name: 'nightwatch-test-build',
+            status: 'running',
+            hashed_id: '123-456-789'
+          }
+        },
         {
           automation_build: {
             name: 'WIN_CHROME_PROD_SANITY_LIVE_1831',
@@ -968,6 +995,9 @@ describe('test Request With Credentials', function () {
         }
       }
     });
+
+    const buildId = await client.transport.getBuildId();
+    assert.strictEqual(buildId, '123-456-789');
   });
 
   it('Test create session with browserstack with random browser and update buildName', async function () {
@@ -1001,8 +1031,16 @@ describe('test Request With Credentials', function () {
       });
 
     nock('https://api.browserstack.com')
-      .get('/automate/builds.json')
+      .get('/automate/builds.json?status=running')
+      .times(2)
       .reply(200, [
+        {
+          automation_build: {
+            name: 'Nightwatch Programmatic Api Demo',
+            status: 'running',
+            hashed_id: '123456789'
+          }
+        },
         {
           automation_build: {
             name: 'WIN_CHROME_PROD_SANITY_LIVE_1831',
@@ -1070,5 +1108,8 @@ describe('test Request With Credentials', function () {
         }
       }
     });
+
+    const buildId = await client.transport.getBuildId();
+    assert.strictEqual(buildId, '123456789');
   });
 });

--- a/test/src/index/transport/testBrowserstackTransport.js
+++ b/test/src/index/transport/testBrowserstackTransport.js
@@ -75,7 +75,7 @@ xdescribe('BrowserstackTransport', function () {
       });
   
     nock('https://api.browserstack.com')
-      .get('/automate/builds.json')
+      .get('/automate/builds.json?status=running')
       .reply(200, [
         {
           automation_build: {
@@ -129,7 +129,7 @@ xdescribe('BrowserstackTransport', function () {
       });
     
     nock('https://api.browserstack.com')
-      .get('/automate/builds.json')
+      .get('/automate/builds.json?status=running')
       .reply(200, [
         {
           automation_build: {
@@ -160,6 +160,11 @@ xdescribe('BrowserstackTransport', function () {
     assert.strictEqual(transport.accessKey, 'test-access-key');
     assert.strictEqual(client.settings.webdriver.start_process, false);
       
+    nock('https://api.browserstack.com')
+      .get('/automate/sessions/1234567.json')
+      .reply(200, {
+        automation_session: {status: 'done'}
+      });
     nock('https://api.browserstack.com')
       .put('/automate/sessions/1234567.json', {
         status: 'passed',
@@ -201,7 +206,7 @@ xdescribe('BrowserstackTransport', function () {
       });
 
     nock('https://api.browserstack.com')
-      .get('/app-automate/builds.json')
+      .get('/app-automate/builds.json?status=running')
       .reply(200, [
         {
           automation_build: {
@@ -232,6 +237,11 @@ xdescribe('BrowserstackTransport', function () {
     assert.strictEqual(transport.accessKey, 'test-access-key');
     assert.strictEqual(client.settings.webdriver.start_process, false);
       
+    nock('https://api.browserstack.com')
+      .get('/app-automate/sessions/1234567.json')
+      .reply(200, {
+        automation_session: {status: 'done'}
+      });
     nock('https://api.browserstack.com')
       .put('/app-automate/sessions/1234567.json', {
         status: 'passed',
@@ -275,7 +285,7 @@ xdescribe('BrowserstackTransport', function () {
       });
 
     nock('https://api.browserstack.com')
-      .get('/automate/builds.json')
+      .get('/automate/builds.json?status=running')
       .reply(200, [
         {
           automation_build: {
@@ -298,6 +308,11 @@ xdescribe('BrowserstackTransport', function () {
     return new Promise((resolve, reject) => {
       setTimeout(async function() {
         try {
+          nock('https://api.browserstack.com')
+            .get('/automate/sessions/1234567.json')
+            .reply(200, {
+              automation_session: {status: 'done'}
+            });
           nock('https://api.browserstack.com')
             .put('/automate/sessions/1234567.json', {
               status: 'failed',


### PR DESCRIPTION
Fixes: #3998 

This PR does the following:
* If the status of a test is already found to be set in BrowserStack, it does not overwrite the status.
* Only request for builds currently running while trying to get the build id (otherwise if there are too many builds, the build used in the test run is never returned by BrowserStack, due to which the build id is set to `undefined`).