### PR TITLE
Warn about two `describe()`s in a single testsuite.

### DIFF
--- a/lib/testsuite/context.js
+++ b/lib/testsuite/context.js
@@ -343,8 +343,14 @@ class Context extends EventEmitter {
    * @param {Boolean=false} [runOnly] If the runner should run only this testsuite
    */
   setDescribeContext({describeTitle, describeInstance, runOnly}) {
-    if (this.__testSuiteName && !describeInstance) {
-      throw new Error('There is already a top-level "describe"/"context" declaration in this testsuite.');
+    // if `setDescribeContext` is called twice for the same test suite,
+    // that would mean that there are two `describe()`s in same test suite.
+    if (this.__testSuiteName && describeInstance) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Nightwatch does not support more than one "describe" declarations in a single testsuite.' +
+        ' Using this might give unexpected results.'
+      );
     }
 
     if (runOnly) {


### PR DESCRIPTION
Nightwatch does not support using more than one `describe()` block in a single test suite (or test file), and using them might give unexpected results.

Ideally, we should warn the users about this, and there seems to be an implementation in place for just that where Nightwatch would throw an error if there is more than one "describe" in a test suite but I think due to a small bug of using `!describeInstance` instead of `describeInstance`, we never throw that error.

Now, because there were no warnings in place, many users might be using more than one describe block in their test suites, so we can't just throw an error in that case because that would break their tests.

So, this PR fixes that bug, and instead of throwing an error, it just gives out a harmless warning to the users.