### PR TITLE
Handle unhandledRejection and uncaughtException in workers.

### DIFF
--- a/lib/runner/concurrency/task.js
+++ b/lib/runner/concurrency/task.js
@@ -17,6 +17,20 @@ function runWorkerTask({argv, port1}) {
   //send reports to main thread using message port
   process.port = port1;
 
+  process.on('unhandledRejection', function (err) {
+    port1.postMessage({
+      type: 'unhandledRejection',
+      err: err
+    });
+  });
+
+  process.on('uncaughtException', function (err) {
+    port1.postMessage({
+      type: 'uncaughtException',
+      err: err
+    });
+  });
+
   return Nightwatch.runTests(argv, {});
 }
 

--- a/lib/runner/concurrency/worker-task.js
+++ b/lib/runner/concurrency/worker-task.js
@@ -65,12 +65,29 @@ class WorkerTask extends EventEmitter {
     }
   }
 
+  emitWorkerOutput(failures) {
+    if (this.settings.disable_output_boxes){
+      // eslint-disable-next-line no-console
+      console.log(`${failures ? symbols.fail : symbols.ok} ${this.task_label}\n`, this.task_output.join('\n'), '\n');
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(boxen(this.task_output.join('\n'), {title: `────────────────── ${failures ? symbols.fail : symbols.ok} ${this.task_label}`, padding: 1, borderColor: 'cyan'}));
+    }
+  }
+
   async runWorkerTask(colors, type) {
     this.availColors = colors;
     const colorPair = this.availColors[this.index % 4];
     this.setlabel(colorPair);
 
     this.printLog('Running ' + Logger.colors[colorPair[0]][colorPair[1]](` ${this.task_label} `));
+
+    let resolvePromise;
+    let rejectPromise;
+    const promise = new Promise((resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    });
 
     const {port1, port2} = new MessageChannel();
     port2.onmessage = ({data: result}) => {
@@ -81,6 +98,15 @@ class WorkerTask extends EventEmitter {
         } catch (e) {}
       }
 
+      const handleError = (err, errType) => {
+        this.writeToStdOut(Logger.colors.red.bold(`\n${errType}:`));
+        this.writeToStdOut(Logger.colors.red(err.stack));
+
+        this.emitWorkerOutput(err);
+
+        rejectPromise(err);
+      };
+
       switch (result.type) {
         case 'testsuite_finished':
           result.itemKey = this.label,
@@ -90,31 +116,33 @@ class WorkerTask extends EventEmitter {
         case 'stdout':
           this.writeToStdOut(result.data);
           break;
+
+        case 'unhandledRejection':
+          handleError(result.err, 'Unhandled rejection');
+          break;
+
+        case 'uncaughtException':
+          handleError(result.err, 'Uncaught exception');
+          break;
       }
     };
     port2.unref();
 
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        this.piscina.run({argv: this.argv, port1}, {transferList: [port1]})
-          .catch(err => err)
-          .then(failures => {
-            if (this.settings.disable_output_boxes){
-            // eslint-disable-next-line no-console
-              console.log(`${failures ? symbols.fail : symbols.ok} ${this.task_label}\n`, this.task_output.join('\n'), '\n');
-            } else {
-            // eslint-disable-next-line no-console
-              console.log(boxen(this.task_output.join('\n'), {title: `────────────────── ${failures ? symbols.fail : symbols.ok} ${this.task_label}`, padding: 1, borderColor: 'cyan'}));
-            }
+    setTimeout(() => {
+      this.piscina.run({argv: this.argv, port1}, {transferList: [port1]})
+        .catch(err => err)
+        .then(failures => {
+          this.emitWorkerOutput(failures);
 
-            //throw error to mark exit-code of the process
-            if (failures) {
-              return reject(new Error());
-            }
-            resolve();
-          });
-      }, this.index * this.startDelay);
-    });
+          //throw error to mark exit-code of the process
+          if (failures) {
+            return rejectPromise(new Error());
+          }
+          resolvePromise();
+        });
+    }, this.index * this.startDelay);
+
+    return promise;
   }
 }
 


### PR DESCRIPTION
Right now, if there is ever an `unhandledRejection` or `uncaughtException` in a worker thread, it just exits along with the main thread and all the user sees is:
![image](https://github.com/nightwatchjs/nightwatch/assets/39924567/71f791dd-2372-48af-adb1-ec6c42d174cf)

In such cases, the user gets no information on what went wrong and it is only after they run the tests serially that they get some information:
![image](https://github.com/nightwatchjs/nightwatch/assets/39924567/9ad3d969-f674-4bef-b83a-f6f821c3c63a)

This PR resolves this by informing the main thread of any `unhandledRejection` or `uncaughtException` in the worker threads so that appropriate actions can be performed after that in the main thread, which otherwise just exits in case of such errors in the worker threads.

On a side note, it seems very weird to me that the main thread just goes _poof!_ whenever there is an `unhandledRejection` in any of the worker threads and I tried to debug it but couldn't find the reason why this is happening.
