### PR TITLE
Fix error while exiting Nightwatch using Ctrl+C.

### DIFF
--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -87,9 +87,9 @@ class BaseService {
 
     process.on('exit', this.exitListener);
 
-    process.on('SIGINT', (code) => {
+    process.on('SIGINT', () => {
       this.stop().then(_ => {
-        process.exit(code);
+        process.exit(0);
       });
     });
   }


### PR DESCRIPTION
Right now, if we try to exit Nightwatch by pressing `Ctrl+C`, we get an `uncaughtException` error. This happens because starting with Node 16, a signal of `string` type (i.e. `SIGINT`) is emitted on pressing `Ctrl+C` instead of `number` type, but `process.exit()` still accepts a code of  `number` type as the first argument.

![image](https://github.com/nightwatchjs/nightwatch/assets/39924567/80f9f9c5-9e8e-443d-a626-da838004b2a3)

This PR fixes this by always exiting the process with code `0` in case a `SIGINT` signal is encountered. (In Node 14 also, the process used to exit with code `0` upon pressing `Ctrl+C`.)