### PR TITLE
deps: Update `piscina` dependency to `v4.3.1`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "nightwatch-axe-verbose": "^2.3.0",
         "open": "8.4.2",
         "ora": "5.4.1",
-        "piscina": "3.2.0",
+        "piscina": "^4.3.1",
         "selenium-webdriver": "4.16.0",
         "semver": "7.5.4",
         "stacktrace-parser": "0.1.10",
@@ -114,11 +114,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/@assemblyscript/loader": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.10.1.tgz",
-      "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.22.13",
@@ -3467,11 +3462,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter-asyncresource": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter-asyncresource/-/eventemitter-asyncresource-1.0.0.tgz",
-      "integrity": "sha512-39F7TBIV0G7gTelxwbEqnwhp90eqCPON1k0NwNfwhgKn4Co4ybUbj2pECcXT0B3ztRKZ7Pw1JujUUgmQJHcVAQ=="
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -4095,21 +4085,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/hdr-histogram-js": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-2.0.3.tgz",
-      "integrity": "sha512-Hkn78wwzWHNCp2uarhzQ2SGFLU3JY8SBDDd3TAABK4fc30wm+MuPOrg5QVFVfkKOQd6Bfz3ukJEI+q9sXEkK1g==",
-      "dependencies": {
-        "@assemblyscript/loader": "^0.10.1",
-        "base64-js": "^1.2.0",
-        "pako": "^1.0.3"
-      }
-    },
-    "node_modules/hdr-histogram-percentiles-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
-      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw=="
     },
     "node_modules/he": {
       "version": "1.2.0",
@@ -6965,14 +6940,9 @@
       }
     },
     "node_modules/piscina": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-3.2.0.tgz",
-      "integrity": "sha512-yn/jMdHRw+q2ZJhFhyqsmANcbF6V2QwmD84c6xRau+QpQOmtrBCoRGdvTfeuFDYXB5W2m6MfLkjkvQa9lUSmIA==",
-      "dependencies": {
-        "eventemitter-asyncresource": "^1.0.0",
-        "hdr-histogram-js": "^2.0.1",
-        "hdr-histogram-percentiles-obj": "^3.0.0"
-      },
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.3.1.tgz",
+      "integrity": "sha512-MBj0QYm3hJQ/C/wIXTN1OCYC8uQ4BBJ4LVele2P4ZwVQAH04vkk8E1SpDbuemLAL1dZorbuOob9rYqJeWCcCRg==",
       "optionalDependencies": {
         "nice-napi": "^1.0.2"
       }
@@ -9226,11 +9196,6 @@
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
       }
-    },
-    "@assemblyscript/loader": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.10.1.tgz",
-      "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg=="
     },
     "@babel/code-frame": {
       "version": "7.22.13",
@@ -11685,11 +11650,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "eventemitter-asyncresource": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter-asyncresource/-/eventemitter-asyncresource-1.0.0.tgz",
-      "integrity": "sha512-39F7TBIV0G7gTelxwbEqnwhp90eqCPON1k0NwNfwhgKn4Co4ybUbj2pECcXT0B3ztRKZ7Pw1JujUUgmQJHcVAQ=="
-    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -12135,21 +12095,6 @@
           "dev": true
         }
       }
-    },
-    "hdr-histogram-js": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-2.0.3.tgz",
-      "integrity": "sha512-Hkn78wwzWHNCp2uarhzQ2SGFLU3JY8SBDDd3TAABK4fc30wm+MuPOrg5QVFVfkKOQd6Bfz3ukJEI+q9sXEkK1g==",
-      "requires": {
-        "@assemblyscript/loader": "^0.10.1",
-        "base64-js": "^1.2.0",
-        "pako": "^1.0.3"
-      }
-    },
-    "hdr-histogram-percentiles-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
-      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw=="
     },
     "he": {
       "version": "1.2.0",
@@ -14307,13 +14252,10 @@
       "dev": true
     },
     "piscina": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-3.2.0.tgz",
-      "integrity": "sha512-yn/jMdHRw+q2ZJhFhyqsmANcbF6V2QwmD84c6xRau+QpQOmtrBCoRGdvTfeuFDYXB5W2m6MfLkjkvQa9lUSmIA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.3.1.tgz",
+      "integrity": "sha512-MBj0QYm3hJQ/C/wIXTN1OCYC8uQ4BBJ4LVele2P4ZwVQAH04vkk8E1SpDbuemLAL1dZorbuOob9rYqJeWCcCRg==",
       "requires": {
-        "eventemitter-asyncresource": "^1.0.0",
-        "hdr-histogram-js": "^2.0.1",
-        "hdr-histogram-percentiles-obj": "^3.0.0",
         "nice-napi": "^1.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "nightwatch-axe-verbose": "^2.3.0",
     "open": "8.4.2",
     "ora": "5.4.1",
-    "piscina": "3.2.0",
+    "piscina": "^4.3.1",
     "selenium-webdriver": "4.16.0",
     "semver": "7.5.4",
     "stacktrace-parser": "0.1.10",


### PR DESCRIPTION
Updating Piscina dependency to the latest version (`v4.3.1`) partially solves issue #4009 in that the main process no longer exits completely without showing any error in case of `uncaughtException` or `unhandledRejection` in one of the worker threads. Instead, any such error in worker threads is handled properly now, thanks to https://github.com/piscinajs/piscina/pull/361, and the error message appears in the console output of the affected test suites.

But there are still two issues remaining to be resolved for such cases:
* In case of an `unhandledRejection` or `uncaughtException`, the browser session is not closed properly and the browser window remains open while the test run exits. This happens in both serial and parallel mode of execution.
* While the process does not exit now in case of error in a worker thread and the error appears in the console output, the final report does not show any error, which might lead to errors in such cases getting missed out.

