### PR TITLE
Send `POST_SESSION_EVENT` with capabilities on session creation.

### DIFF
--- a/lib/runner/test-runners/cucumber/nightwatch-format.js
+++ b/lib/runner/test-runners/cucumber/nightwatch-format.js
@@ -3,7 +3,7 @@ const {Logger, SafeJSON, isFunction} = Utils;
 const {Formatter} = require('@cucumber/cucumber');
 
 const {NightwatchEventHub, CUCUMBER_RUNNER_EVENTS: {
-  TestStarted, 
+  TestStarted,
   TestFinished,
   TestCaseStarted,
   TestCaseFinished,
@@ -28,11 +28,20 @@ module.exports = class NightwatchFormatter extends Formatter {
     data = {...data, testCaseStartedId: process.env.CUCUMBER_TEST_CASE_STARTED_ID};
 
     if (isFunction(process.send)) {
-      process.send({'jsonEnvelope': SafeJSON.stringify({
-        session: {
-          ...data,
-          workerId: process.env.CUCUMBER_WORKER_ID
-        }})});
+      process.send({
+        'jsonEnvelope': SafeJSON.stringify({
+          session: {
+            ...data,
+            workerId: process.env.CUCUMBER_WORKER_ID
+          }
+        }),
+        'POST_SESSION_EVENT': SafeJSON.stringify({
+          session: {
+            ...data,
+            workerId: process.env.CUCUMBER_WORKER_ID
+          }
+        })
+      });
     } else {
       NightwatchFormatter.eventBroadcaster?.emit('envelope', {session: data});
     }
@@ -143,7 +152,7 @@ module.exports = class NightwatchFormatter extends Formatter {
       if (!NightwatchEventHub.isAvailable) {
         return;
       }
-  
+
       const handlers = {
         meta: this.onMeta,
         gherkinDocument: this.onGherkinDocument,
@@ -161,7 +170,7 @@ module.exports = class NightwatchFormatter extends Formatter {
         testStepStarted: this.onTestStepStarted,
         session: this.onSessionCapabilities
       };
-    
+
       const cucumberEvent = Object.keys(envelope)[0];
       if (cucumberEvent && handlers[cucumberEvent]) {
         handlers[cucumberEvent].call(this, envelope[cucumberEvent]);


### PR DESCRIPTION
Send a `POST_SESSION_EVENT` event to parent worker with capabilities as soon as a session is created in worker thread when using Cucumber with `NightwatchEventHub` enabled (used for Test Observability).