### PR TITLE
Disable HTML reporter in Cucumber.

### DIFF
--- a/lib/reporter/global-reporter.js
+++ b/lib/reporter/global-reporter.js
@@ -36,11 +36,13 @@ module.exports = class GlobalReporter {
     this.suiteResults = [];
     this.skippedSuites = 0;
     this.uncaughtErr = null;
-    this.reporterFile = reporter;
     this.reportFileName = reportFileName;
 
-    if (!Array.isArray(this.reporterFile) && typeof this.reporterFile == 'string') {
-      this.reporterFile = this.reporterFile.split(',');
+    this.reporterFile = [];
+    if (Array.isArray(reporter)) {
+      this.reporterFile = reporter.slice(0);
+    } else if (typeof reporter == 'string') {
+      this.reporterFile = reporter.split(',');
     }
     this.settings = settings;
     this.summary = new Summary(settings);

--- a/lib/reporter/global-reporter.js
+++ b/lib/reporter/global-reporter.js
@@ -40,6 +40,8 @@ module.exports = class GlobalReporter {
 
     this.reporterFile = [];
     if (Array.isArray(reporter)) {
+      // Any subsequent changes in `this.reporterFile` shouldn't lead to changes in
+      // `argv.reporter` provided by the user, or `DefaultSettings.default_reporter`.
       this.reporterFile = reporter.slice(0);
     } else if (typeof reporter == 'string') {
       this.reporterFile = reporter.split(',');

--- a/lib/runner/test-runners/cucumber.js
+++ b/lib/runner/test-runners/cucumber.js
@@ -256,8 +256,6 @@ class CucumberRunnner extends Runner {
     super(settings, argv, addtOpts);
 
     // Disable HTML Reporter as it is not yet supported in Cucumber.
-    // Changing `reporterFile` here shouldn't change the `argv.reporter`
-    // provided by the user, or `DefaultSettings.default_reporter`.
     const reporterFile = this.globalReporter.reporterFile;
     if (reporterFile && reporterFile.includes('html')) {
       const index = reporterFile.indexOf('html');

--- a/lib/runner/test-runners/cucumber.js
+++ b/lib/runner/test-runners/cucumber.js
@@ -4,6 +4,7 @@ const TestSuite =  require('../../testsuite');
 const {Logger, isString, isDefined} = require('../../utils');
 const {NightwatchEventHub} = require('../eventHub.js');
 const {getTestSourceForRerunFailed} = require('../rerunUtil.js');
+const DefaultSettings = require('../../settings/defaults.js');
 
 class CucumberSuite extends TestSuite {
   static isSessionCreateError(err) {
@@ -258,6 +259,12 @@ class CucumberRunnner extends Runner {
     // Disable HTML Reporter as it is not yet supported in Cucumber.
     const reporterFile = this.globalReporter.reporterFile;
     if (reporterFile && reporterFile.includes('html')) {
+      if (reporterFile.toString() !== DefaultSettings.default_reporter.toString()) {
+        // user has specifically asked for HTML report.
+        // eslint-disable-next-line no-console
+        console.warn(Logger.colors.yellow('HTML reporter is not supported with Cucumber runner.'));
+      }
+
       const index = reporterFile.indexOf('html');
       if (index > -1) {
         reporterFile.splice(index, 1);

--- a/lib/runner/test-runners/cucumber.js
+++ b/lib/runner/test-runners/cucumber.js
@@ -252,6 +252,21 @@ class CucumberRunnner extends Runner {
     return 'cucumber';
   }
 
+  constructor(settings, argv, addtOpts) {
+    super(settings, argv, addtOpts);
+
+    // Disable HTML Reporter as it is not yet supported in Cucumber.
+    // Changing `reporterFile` here shouldn't change the `argv.reporter`
+    // provided by the user, or `DefaultSettings.default_reporter`.
+    const reporterFile = this.globalReporter.reporterFile;
+    if (reporterFile && reporterFile.includes('html')) {
+      const index = reporterFile.indexOf('html');
+      if (index > -1) {
+        reporterFile.splice(index, 1);
+      }
+    }
+  }
+
   hasTestFailures(result) {
     return result && result.success === false;
   }

--- a/lib/runner/test-runners/cucumber/_setup_cucumber_runner.js
+++ b/lib/runner/test-runners/cucumber/_setup_cucumber_runner.js
@@ -7,8 +7,6 @@ Before(function({pickle, testCaseStartedId}) {
   const webdriver = {};
 
   process.env.CUCUMBER_TEST_CASE_STARTED_ID = testCaseStartedId;
-  // eslint-disable-next-line no-console
-  console.log('setup_cucumber_before', 'PID:', process.pid, 'testCaseStartedId:', testCaseStartedId);
 
   if (this.parameters['webdriver-host']) {
     webdriver.host = this.parameters['webdriver-host'];


### PR DESCRIPTION
Currently, the HTML reporter is not supported in Cucumber, but still the console logs say that an HTML report has been created for the test, leading to confusion for users since the created HTML reporter does not work in actual.
