### PR TITLE
issue #4028 fix : added fallback for clearValue command

### DIFF
--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -589,7 +589,7 @@ module.exports = class MethodMappings {
           try {
             const value = await element.getProperty('value');
             if (isString(value) && value.length !== 0) {
-              const backArr = Array(value.length).fill(Key.BACK_SPACE);
+              const backArr = value.split('').map(() => Key.BACK_SPACE);
               await element.sendKeys(...backArr);
             }
           } catch {

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -588,7 +588,7 @@ module.exports = class MethodMappings {
           await element.clear();
           try {
             const value = await element.getProperty('value');
-            if (value.length !== 0 && isString(value)) {
+            if (isString(value) && value.length !== 0) {
               const backArr = Array(value.length).fill(Key.BACK_SPACE);
               await element.sendKeys(...backArr);
             }

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -582,10 +582,13 @@ module.exports = class MethodMappings {
 
           return value;
         },
-
+        
         async clearElementValue(webElementOrId) {
           const element = this.getWebElement(webElementOrId);
           await element.clear();
+          var value = await element.getAttribute("value");
+          const backArr = Array(value.length).fill(Key.BACK_SPACE);
+          await element.sendKeys(...backArr);
 
           return null;
         },

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -617,7 +617,7 @@ module.exports = class MethodMappings {
 
           // clear Element value
           try {
-            await element.clear();
+            await this.methods.session.clearElementValue.call(this, webElementOrId);
           } catch (err) {
             if (err.name !== 'InvalidElementStateError') {
               throw err;

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -1,12 +1,4 @@
-const {
-  WebElement,
-  WebDriver,
-  Origin,
-  Key,
-  By,
-  until,
-  Condition
-} = require('selenium-webdriver');
+const {WebElement, WebDriver, Origin, Key, By, until, Condition} = require('selenium-webdriver');
 const {Locator} = require('../../element');
 const NightwatchLocator = require('../../element/locator-factory.js');
 const {isString} = require('../../utils');
@@ -23,10 +15,7 @@ module.exports = class MethodMappings {
   }
 
   getWebElement(webElementOrString) {
-    if (
-      webElementOrString &&
-      webElementOrString.webElement instanceof WebElement
-    ) {
+    if (webElementOrString && (webElementOrString.webElement instanceof WebElement)) {
       webElementOrString = webElementOrString.webElement;
     }
 
@@ -46,9 +35,7 @@ module.exports = class MethodMappings {
     const parentElementId = await element.getId();
     const {elementKey} = this.transport;
 
-    return this.driver.executeScript(scriptFn, {
-      [elementKey]: parentElementId
-    });
+    return this.driver.executeScript(scriptFn, {[elementKey]: parentElementId});
   }
 
   async getElementByJs(scriptFn, webElementOrId) {
@@ -167,10 +154,7 @@ module.exports = class MethodMappings {
         // Session log
         ///////////////////////////////////////////////////////////
         async getSessionLogTypes() {
-          const value = await this.driver
-            .manage()
-            .logs()
-            .getAvailableLogTypes();
+          const value = await this.driver.manage().logs().getAvailableLogTypes();
 
           return {
             value
@@ -181,7 +165,7 @@ module.exports = class MethodMappings {
           const value = await this.driver.manage().logs().get(type);
 
           return {
-            value: value.map((item) => {
+            value: value.map(item => {
               return {
                 level: {
                   value: item.level.value,
@@ -385,10 +369,7 @@ module.exports = class MethodMappings {
         // Elements
         ///////////////////////////////////////////////////////////
         async locateSingleElement(element) {
-          const locator = NightwatchLocator.create(
-            element,
-            this.transport.api.isAppiumClient()
-          );
+          const locator = NightwatchLocator.create(element, this.transport.api.isAppiumClient());
           const webElement = await this.driver.findElement(locator);
           const elementId = await webElement.getId();
 
@@ -400,10 +381,7 @@ module.exports = class MethodMappings {
         },
 
         async locateMultipleElements(element) {
-          const locator = NightwatchLocator.create(
-            element,
-            this.transport.api.isAppiumClient()
-          );
+          const locator = NightwatchLocator.create(element, this.transport.api.isAppiumClient());
           const resultValue = await this.driver.findElements(locator);
 
           if (Array.isArray(resultValue) && resultValue.length === 0) {
@@ -416,16 +394,15 @@ module.exports = class MethodMappings {
           }
 
           const {elementKey} = this.transport;
-          const value = await Promise.all(
-            resultValue.map(async (webElement) => {
-              const elementId = await webElement.getId();
+          const value = await Promise.all(resultValue.map(async webElement => {
+            const elementId = await webElement.getId();
 
-              return {[elementKey]: elementId};
-            })
-          );
+            return {[elementKey]: elementId};
+          }));
 
           return value;
         },
+
 
         elementIdEquals(id, otherId) {
           return `/element/${id}/equals/${otherId}`;
@@ -452,13 +429,11 @@ module.exports = class MethodMappings {
           const resultValue = await element.findElements(locator);
 
           const {elementKey} = this.transport;
-          const resultProcessed = await Promise.all(
-            resultValue.map(async (webElement) => {
-              const elementId = await webElement.getId();
+          const resultProcessed = await Promise.all(resultValue.map(async webElement => {
+            const elementId = await webElement.getId();
 
-              return {[elementKey]: elementId};
-            })
-          );
+            return {[elementKey]: elementId};
+          }));
 
           return resultProcessed;
         },
@@ -520,45 +495,20 @@ module.exports = class MethodMappings {
         async setElementProperty(webElementOrId, name, value) {
           const element = this.getWebElement(webElementOrId);
 
-          await this.driver.executeScript(
-            function (element, name, value) {
-              element[name] = value;
-            },
-            element,
-            name,
-            value
-          );
+          await this.driver.executeScript(function (element, name, value) {
+            element[name] = value;
+          }, element, name, value);
         },
 
         async setElementAttribute(webElement, attrName, value) {
           const element = this.getWebElement(webElement);
 
           // eslint-disable-next-line
-          /* istanbul ignore next */ const fn = function (e, a, v) {
-            try {
-              if (e && typeof e.setAttribute == 'function') {
-                e.setAttribute(a, v);
-              }
-
-              return true;
-            } catch (err) {
-              return {
-                error: err.message,
-                message: err.name + ': ' + err.message
-              };
-            }
-          };
+          /* istanbul ignore next */const fn = function (e, a, v) { try { if (e && typeof e.setAttribute == 'function') { e.setAttribute(a, v); } return true; } catch (err) { return { error: err.message, message: err.name + ': ' + err.message }; } };
           const elementId = await element.getId();
 
-          const result = await this.driver.executeScript(
-            'var passedArgs = Array.prototype.slice.call(arguments,0); ' +
-              'return (' +
-              fn.toString() +
-              ').apply(window, passedArgs);',
-            {[this.transport.elementKey]: elementId},
-            attrName,
-            value
-          );
+          const result = await this.driver.executeScript('var passedArgs = Array.prototype.slice.call(arguments,0); ' +
+            'return (' + fn.toString() + ').apply(window, passedArgs);', {[this.transport.elementKey]: elementId}, attrName, value);
 
           return result;
         },
@@ -679,9 +629,7 @@ module.exports = class MethodMappings {
         async sendKeysToElement(webElementOrId, value) {
           if (Array.isArray(value)) {
             if (value.includes(undefined) || value.includes(null)) {
-              throw TypeError(
-                'each key must be a number or string; got ' + value
-              );
+              throw TypeError('each key must be a number or string; got ' + value);
             }
             value = value.join('');
           }
@@ -746,14 +694,10 @@ module.exports = class MethodMappings {
          * @param {WebElement} webElement
          */
         inspectInDevTools(webElement, content = 'Element') {
-          return this.driver.executeScript(
-            function (element, content) {
-              // eslint-disable-next-line no-console
-              console.log(content + ':', element);
-            },
-            webElement,
-            content
-          );
+          return this.driver.executeScript(function (element, content) {
+            // eslint-disable-next-line no-console
+            console.log(content + ':', element);
+          }, webElement, content);
         },
 
         async getLastElementChild(webElementOrId) {
@@ -866,10 +810,7 @@ module.exports = class MethodMappings {
           if (webElement) {
             webElement = this.getWebElement(webElement);
           }
-          await this.driver
-            .actions({async: true})
-            .doubleClick(webElement)
-            .perform();
+          await this.driver.actions({async: true}).doubleClick(webElement).perform();
 
           return null;
         },
@@ -906,6 +847,7 @@ module.exports = class MethodMappings {
             }
           };
         },
+
 
         /**
          * @param {string|WebElement|null} origin
@@ -944,31 +886,22 @@ module.exports = class MethodMappings {
             destination = this.getWebElement(destination);
           }
 
-          await this.driver
-            .actions({async: true})
-            .dragAndDrop(source, destination)
-            .perform();
+          await this.driver.actions({async: true}).dragAndDrop(source, destination).perform();
 
           return null;
         },
 
         async contextClick(webElementOrId) {
           const element = this.getWebElement(webElementOrId);
-          await this.driver
-            .actions({async: true})
-            .contextClick(element)
-            .perform();
+          await this.driver.actions({async: true}).contextClick(element).perform();
 
           return null;
         },
 
         async pressAndHold(webElementOrId) {
+
           const element = this.getWebElement(webElementOrId);
-          await this.driver
-            .actions({async: true})
-            .move({origin: element})
-            .press()
-            .perform();
+          await this.driver.actions({async: true}).move({origin: element}).press().perform();
 
           return null;
         },
@@ -1120,17 +1053,13 @@ module.exports = class MethodMappings {
         ///////////////////////////////////////////////////////////////////////////
         async wait(conditionFn, timeMs, message, retryInterval) {
           const driver = new WebDriver(Promise.resolve());
-          await driver.wait(
-            conditionFn instanceof Condition ? conditionFn : conditionFn(),
-            timeMs,
-            message,
-            retryInterval
-          );
+          await driver.wait(conditionFn instanceof Condition ? conditionFn : conditionFn(), timeMs, message, retryInterval);
 
           return {
             value: null
           };
         },
+
 
         async setNetworkConditions(spec) {
           await this.driver.setNetworkConditions(spec);
@@ -1141,12 +1070,7 @@ module.exports = class MethodMappings {
         },
 
         waitUntilElementsLocated({condition, timeout, retryInterval}) {
-          return this.driver.wait(
-            until.elementsLocated(condition),
-            timeout,
-            null,
-            retryInterval
-          );
+          return this.driver.wait(until.elementsLocated(condition), timeout, null, retryInterval);
         },
 
         ///////////////////////////////////////////////////////////////////////////
@@ -1200,7 +1124,10 @@ module.exports = class MethodMappings {
         async clearGeolocation() {
           const cdpConnection = await cdp.getConnection(this.driver);
 
-          await cdpConnection.execute('Emulation.clearGeolocationOverride', {});
+          await cdpConnection.execute(
+            'Emulation.clearGeolocationOverride',
+            {}
+          );
 
           return {
             value: null
@@ -1232,7 +1159,10 @@ module.exports = class MethodMappings {
             }
           });
 
-          await cdpConnection.execute('Network.enable', {});
+          await cdpConnection.execute(
+            'Network.enable',
+            {}
+          );
 
           return {
             value: null
@@ -1242,11 +1172,7 @@ module.exports = class MethodMappings {
         async mockNetworkResponse(urlToIntercept, response) {
           const cdpConnection = await cdp.getConnection(this.driver);
 
-          const {
-            status = 200,
-            headers: headersObject,
-            body: bodyPlain = ''
-          } = response;
+          const {status = 200, headers: headersObject, body: bodyPlain = ''} = response;
           const headers = [];
           if (headersObject) {
             for (const [name, value] of Object.entries(headersObject)) {
@@ -1256,11 +1182,7 @@ module.exports = class MethodMappings {
           // Convert body to base64
           const bodyBase64 = Buffer.from(bodyPlain, 'utf-8').toString('base64');
 
-          cdp.addNetworkMock(urlToIntercept, {
-            status,
-            headers,
-            body: bodyBase64
-          });
+          cdp.addNetworkMock(urlToIntercept, {status, headers, body: bodyBase64});
 
           // Add event listener only the first time.
           if (Object.keys(cdp.networkMocks).length === 1) {
@@ -1288,10 +1210,14 @@ module.exports = class MethodMappings {
             });
           }
 
-          await cdpConnection.execute('Fetch.enable', {});
-          await cdpConnection.execute('Network.setCacheDisabled', {
-            cacheDisabled: true
-          });
+          await cdpConnection.execute(
+            'Fetch.enable',
+            {}
+          );
+          await cdpConnection.execute(
+            'Network.setCacheDisabled',
+            {cacheDisabled: true}
+          );
 
           return {
             value: null
@@ -1311,18 +1237,21 @@ module.exports = class MethodMappings {
             }
           });
 
-          await cdpConnection.execute('HeapProfiler.enable', {});
+          await cdpConnection.execute(
+            'HeapProfiler.enable',
+            {}
+          );
 
-          await cdpConnection.execute('HeapProfiler.takeHeapSnapshot', {});
+          await cdpConnection.execute(
+            'HeapProfiler.takeHeapSnapshot',
+            {}
+          );
 
           let prevChunks = [];
 
           return new Promise((resolve) => {
             const intervalId = setInterval(() => {
-              if (
-                prevChunks.length !== 0 &&
-                prevChunks.length === chunks.length
-              ) {
+              if (prevChunks.length !== 0 && prevChunks.length === chunks.length) {
                 resolveAndClearInterval();
               }
               prevChunks = [...chunks];
@@ -1355,10 +1284,7 @@ module.exports = class MethodMappings {
         },
 
         async getPerformanceMetrics() {
-          const {metrics: metricsReturned} =
-            await this.driver.sendAndGetDevToolsCommand(
-              'Performance.getMetrics'
-            );
+          const {metrics: metricsReturned} = await this.driver.sendAndGetDevToolsCommand('Performance.getMetrics');
 
           const metrics = {};
           for (const metric of metricsReturned) {
@@ -1369,6 +1295,7 @@ module.exports = class MethodMappings {
             value: metrics
           };
         }
+
       }
     };
   }

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -1,4 +1,4 @@
-const {WebElement, WebDriver, Origin, By, until, Condition} = require('selenium-webdriver');
+const {WebElement, WebDriver, Origin,Key, By, until, Condition} = require('selenium-webdriver');
 const {Locator} = require('../../element');
 const NightwatchLocator = require('../../element/locator-factory.js');
 const {isString} = require('../../utils');
@@ -584,12 +584,22 @@ module.exports = class MethodMappings {
         },
         
         async clearElementValue(webElementOrId) {
+         
           const element = this.getWebElement(webElementOrId);
           await element.clear();
-          var value = await element.getAttribute('value');
+          try{
+          const value = await element.getProperty("value");
+          if(value.length !== 0){
           const backArr = Array(value.length).fill(Key.BACK_SPACE);
           await element.sendKeys(...backArr);
-
+          }
+          }
+          catch(err){
+            return{
+            error: err.name,
+            message: err.message,
+            }
+          }
           return null;
         },
 

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -1,4 +1,12 @@
-const {WebElement, WebDriver, Origin,Key, By, until, Condition} = require('selenium-webdriver');
+const {
+  WebElement,
+  WebDriver,
+  Origin,
+  Key,
+  By,
+  until,
+  Condition
+} = require('selenium-webdriver');
 const {Locator} = require('../../element');
 const NightwatchLocator = require('../../element/locator-factory.js');
 const {isString} = require('../../utils');
@@ -15,7 +23,10 @@ module.exports = class MethodMappings {
   }
 
   getWebElement(webElementOrString) {
-    if (webElementOrString && (webElementOrString.webElement instanceof WebElement)) {
+    if (
+      webElementOrString &&
+      webElementOrString.webElement instanceof WebElement
+    ) {
       webElementOrString = webElementOrString.webElement;
     }
 
@@ -35,7 +46,9 @@ module.exports = class MethodMappings {
     const parentElementId = await element.getId();
     const {elementKey} = this.transport;
 
-    return this.driver.executeScript(scriptFn, {[elementKey]: parentElementId});
+    return this.driver.executeScript(scriptFn, {
+      [elementKey]: parentElementId
+    });
   }
 
   async getElementByJs(scriptFn, webElementOrId) {
@@ -154,7 +167,10 @@ module.exports = class MethodMappings {
         // Session log
         ///////////////////////////////////////////////////////////
         async getSessionLogTypes() {
-          const value = await this.driver.manage().logs().getAvailableLogTypes();
+          const value = await this.driver
+            .manage()
+            .logs()
+            .getAvailableLogTypes();
 
           return {
             value
@@ -165,7 +181,7 @@ module.exports = class MethodMappings {
           const value = await this.driver.manage().logs().get(type);
 
           return {
-            value: value.map(item => {
+            value: value.map((item) => {
               return {
                 level: {
                   value: item.level.value,
@@ -369,7 +385,10 @@ module.exports = class MethodMappings {
         // Elements
         ///////////////////////////////////////////////////////////
         async locateSingleElement(element) {
-          const locator = NightwatchLocator.create(element, this.transport.api.isAppiumClient());
+          const locator = NightwatchLocator.create(
+            element,
+            this.transport.api.isAppiumClient()
+          );
           const webElement = await this.driver.findElement(locator);
           const elementId = await webElement.getId();
 
@@ -381,7 +400,10 @@ module.exports = class MethodMappings {
         },
 
         async locateMultipleElements(element) {
-          const locator = NightwatchLocator.create(element, this.transport.api.isAppiumClient());
+          const locator = NightwatchLocator.create(
+            element,
+            this.transport.api.isAppiumClient()
+          );
           const resultValue = await this.driver.findElements(locator);
 
           if (Array.isArray(resultValue) && resultValue.length === 0) {
@@ -394,15 +416,16 @@ module.exports = class MethodMappings {
           }
 
           const {elementKey} = this.transport;
-          const value = await Promise.all(resultValue.map(async webElement => {
-            const elementId = await webElement.getId();
+          const value = await Promise.all(
+            resultValue.map(async (webElement) => {
+              const elementId = await webElement.getId();
 
-            return {[elementKey]: elementId};
-          }));
+              return {[elementKey]: elementId};
+            })
+          );
 
           return value;
         },
-
 
         elementIdEquals(id, otherId) {
           return `/element/${id}/equals/${otherId}`;
@@ -429,11 +452,13 @@ module.exports = class MethodMappings {
           const resultValue = await element.findElements(locator);
 
           const {elementKey} = this.transport;
-          const resultProcessed = await Promise.all(resultValue.map(async webElement => {
-            const elementId = await webElement.getId();
+          const resultProcessed = await Promise.all(
+            resultValue.map(async (webElement) => {
+              const elementId = await webElement.getId();
 
-            return {[elementKey]: elementId};
-          }));
+              return {[elementKey]: elementId};
+            })
+          );
 
           return resultProcessed;
         },
@@ -495,20 +520,45 @@ module.exports = class MethodMappings {
         async setElementProperty(webElementOrId, name, value) {
           const element = this.getWebElement(webElementOrId);
 
-          await this.driver.executeScript(function (element, name, value) {
-            element[name] = value;
-          }, element, name, value);
+          await this.driver.executeScript(
+            function (element, name, value) {
+              element[name] = value;
+            },
+            element,
+            name,
+            value
+          );
         },
 
         async setElementAttribute(webElement, attrName, value) {
           const element = this.getWebElement(webElement);
 
           // eslint-disable-next-line
-          /* istanbul ignore next */const fn = function (e, a, v) { try { if (e && typeof e.setAttribute == 'function') { e.setAttribute(a, v); } return true; } catch (err) { return { error: err.message, message: err.name + ': ' + err.message }; } };
+          /* istanbul ignore next */ const fn = function (e, a, v) {
+            try {
+              if (e && typeof e.setAttribute == 'function') {
+                e.setAttribute(a, v);
+              }
+
+              return true;
+            } catch (err) {
+              return {
+                error: err.message,
+                message: err.name + ': ' + err.message
+              };
+            }
+          };
           const elementId = await element.getId();
 
-          const result = await this.driver.executeScript('var passedArgs = Array.prototype.slice.call(arguments,0); ' +
-            'return (' + fn.toString() + ').apply(window, passedArgs);', {[this.transport.elementKey]: elementId}, attrName, value);
+          const result = await this.driver.executeScript(
+            'var passedArgs = Array.prototype.slice.call(arguments,0); ' +
+              'return (' +
+              fn.toString() +
+              ').apply(window, passedArgs);',
+            {[this.transport.elementKey]: elementId},
+            attrName,
+            value
+          );
 
           return result;
         },
@@ -582,24 +632,20 @@ module.exports = class MethodMappings {
 
           return value;
         },
-        
+
         async clearElementValue(webElementOrId) {
-         
           const element = this.getWebElement(webElementOrId);
           await element.clear();
-          try{
-          const value = await element.getProperty("value");
-          if(value.length !== 0){
-          const backArr = Array(value.length).fill(Key.BACK_SPACE);
-          await element.sendKeys(...backArr);
-          }
-          }
-          catch(err){
-            return{
-            error: err.name,
-            message: err.message,
+          try {
+            const value = await element.getProperty('value');
+            if (value.length !== 0 && isString(value)) {
+              const backArr = Array(value.length).fill(Key.BACK_SPACE);
+              await element.sendKeys(...backArr);
             }
+          } catch {
+            // silent catch
           }
+
           return null;
         },
 
@@ -633,7 +679,9 @@ module.exports = class MethodMappings {
         async sendKeysToElement(webElementOrId, value) {
           if (Array.isArray(value)) {
             if (value.includes(undefined) || value.includes(null)) {
-              throw TypeError('each key must be a number or string; got ' + value);
+              throw TypeError(
+                'each key must be a number or string; got ' + value
+              );
             }
             value = value.join('');
           }
@@ -698,10 +746,14 @@ module.exports = class MethodMappings {
          * @param {WebElement} webElement
          */
         inspectInDevTools(webElement, content = 'Element') {
-          return this.driver.executeScript(function (element, content) {
-            // eslint-disable-next-line no-console
-            console.log(content + ':', element);
-          }, webElement, content);
+          return this.driver.executeScript(
+            function (element, content) {
+              // eslint-disable-next-line no-console
+              console.log(content + ':', element);
+            },
+            webElement,
+            content
+          );
         },
 
         async getLastElementChild(webElementOrId) {
@@ -814,7 +866,10 @@ module.exports = class MethodMappings {
           if (webElement) {
             webElement = this.getWebElement(webElement);
           }
-          await this.driver.actions({async: true}).doubleClick(webElement).perform();
+          await this.driver
+            .actions({async: true})
+            .doubleClick(webElement)
+            .perform();
 
           return null;
         },
@@ -851,7 +906,6 @@ module.exports = class MethodMappings {
             }
           };
         },
-
 
         /**
          * @param {string|WebElement|null} origin
@@ -890,22 +944,31 @@ module.exports = class MethodMappings {
             destination = this.getWebElement(destination);
           }
 
-          await this.driver.actions({async: true}).dragAndDrop(source, destination).perform();
+          await this.driver
+            .actions({async: true})
+            .dragAndDrop(source, destination)
+            .perform();
 
           return null;
         },
 
         async contextClick(webElementOrId) {
           const element = this.getWebElement(webElementOrId);
-          await this.driver.actions({async: true}).contextClick(element).perform();
+          await this.driver
+            .actions({async: true})
+            .contextClick(element)
+            .perform();
 
           return null;
         },
 
         async pressAndHold(webElementOrId) {
-
           const element = this.getWebElement(webElementOrId);
-          await this.driver.actions({async: true}).move({origin: element}).press().perform();
+          await this.driver
+            .actions({async: true})
+            .move({origin: element})
+            .press()
+            .perform();
 
           return null;
         },
@@ -1057,13 +1120,17 @@ module.exports = class MethodMappings {
         ///////////////////////////////////////////////////////////////////////////
         async wait(conditionFn, timeMs, message, retryInterval) {
           const driver = new WebDriver(Promise.resolve());
-          await driver.wait(conditionFn instanceof Condition ? conditionFn : conditionFn(), timeMs, message, retryInterval);
+          await driver.wait(
+            conditionFn instanceof Condition ? conditionFn : conditionFn(),
+            timeMs,
+            message,
+            retryInterval
+          );
 
           return {
             value: null
           };
         },
-
 
         async setNetworkConditions(spec) {
           await this.driver.setNetworkConditions(spec);
@@ -1074,7 +1141,12 @@ module.exports = class MethodMappings {
         },
 
         waitUntilElementsLocated({condition, timeout, retryInterval}) {
-          return this.driver.wait(until.elementsLocated(condition), timeout, null, retryInterval);
+          return this.driver.wait(
+            until.elementsLocated(condition),
+            timeout,
+            null,
+            retryInterval
+          );
         },
 
         ///////////////////////////////////////////////////////////////////////////
@@ -1128,10 +1200,7 @@ module.exports = class MethodMappings {
         async clearGeolocation() {
           const cdpConnection = await cdp.getConnection(this.driver);
 
-          await cdpConnection.execute(
-            'Emulation.clearGeolocationOverride',
-            {}
-          );
+          await cdpConnection.execute('Emulation.clearGeolocationOverride', {});
 
           return {
             value: null
@@ -1163,10 +1232,7 @@ module.exports = class MethodMappings {
             }
           });
 
-          await cdpConnection.execute(
-            'Network.enable',
-            {}
-          );
+          await cdpConnection.execute('Network.enable', {});
 
           return {
             value: null
@@ -1176,7 +1242,11 @@ module.exports = class MethodMappings {
         async mockNetworkResponse(urlToIntercept, response) {
           const cdpConnection = await cdp.getConnection(this.driver);
 
-          const {status = 200, headers: headersObject, body: bodyPlain = ''} = response;
+          const {
+            status = 200,
+            headers: headersObject,
+            body: bodyPlain = ''
+          } = response;
           const headers = [];
           if (headersObject) {
             for (const [name, value] of Object.entries(headersObject)) {
@@ -1186,7 +1256,11 @@ module.exports = class MethodMappings {
           // Convert body to base64
           const bodyBase64 = Buffer.from(bodyPlain, 'utf-8').toString('base64');
 
-          cdp.addNetworkMock(urlToIntercept, {status, headers, body: bodyBase64});
+          cdp.addNetworkMock(urlToIntercept, {
+            status,
+            headers,
+            body: bodyBase64
+          });
 
           // Add event listener only the first time.
           if (Object.keys(cdp.networkMocks).length === 1) {
@@ -1214,14 +1288,10 @@ module.exports = class MethodMappings {
             });
           }
 
-          await cdpConnection.execute(
-            'Fetch.enable',
-            {}
-          );
-          await cdpConnection.execute(
-            'Network.setCacheDisabled',
-            {cacheDisabled: true}
-          );
+          await cdpConnection.execute('Fetch.enable', {});
+          await cdpConnection.execute('Network.setCacheDisabled', {
+            cacheDisabled: true
+          });
 
           return {
             value: null
@@ -1241,21 +1311,18 @@ module.exports = class MethodMappings {
             }
           });
 
-          await cdpConnection.execute(
-            'HeapProfiler.enable',
-            {}
-          );
+          await cdpConnection.execute('HeapProfiler.enable', {});
 
-          await cdpConnection.execute(
-            'HeapProfiler.takeHeapSnapshot',
-            {}
-          );
+          await cdpConnection.execute('HeapProfiler.takeHeapSnapshot', {});
 
           let prevChunks = [];
 
           return new Promise((resolve) => {
             const intervalId = setInterval(() => {
-              if (prevChunks.length !== 0 && prevChunks.length === chunks.length) {
+              if (
+                prevChunks.length !== 0 &&
+                prevChunks.length === chunks.length
+              ) {
                 resolveAndClearInterval();
               }
               prevChunks = [...chunks];
@@ -1288,7 +1355,10 @@ module.exports = class MethodMappings {
         },
 
         async getPerformanceMetrics() {
-          const {metrics: metricsReturned} = await this.driver.sendAndGetDevToolsCommand('Performance.getMetrics');
+          const {metrics: metricsReturned} =
+            await this.driver.sendAndGetDevToolsCommand(
+              'Performance.getMetrics'
+            );
 
           const metrics = {};
           for (const metric of metricsReturned) {
@@ -1299,7 +1369,6 @@ module.exports = class MethodMappings {
             value: metrics
           };
         }
-
       }
     };
   }

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -586,7 +586,7 @@ module.exports = class MethodMappings {
         async clearElementValue(webElementOrId) {
           const element = this.getWebElement(webElementOrId);
           await element.clear();
-          var value = await element.getAttribute("value");
+          var value = await element.getAttribute('value');
           const backArr = Array(value.length).fill(Key.BACK_SPACE);
           await element.sendKeys(...backArr);
 

--- a/lib/transport/selenium-webdriver/method-mappings.js
+++ b/lib/transport/selenium-webdriver/method-mappings.js
@@ -586,10 +586,11 @@ module.exports = class MethodMappings {
         async clearElementValue(webElementOrId) {
           const element = this.getWebElement(webElementOrId);
           await element.clear();
+
           try {
             const value = await element.getProperty('value');
-            if (isString(value) && value.length !== 0) {
-              const backArr = value.split('').map(() => Key.BACK_SPACE);
+            if (isString(value) && value.length > 0) {
+              const backArr = Array(value.length).fill(Key.BACK_SPACE);
               await element.sendKeys(...backArr);
             }
           } catch {

--- a/test/src/api/commands/element/testClearValue.js
+++ b/test/src/api/commands/element/testClearValue.js
@@ -1,37 +1,37 @@
-const assert = require("assert");
-const MockServer = require("../../../../lib/mockserver.js");
-const Nightwatch = require("../../../../lib/nightwatch.js");
-const { Key } = require("selenium-webdriver");
+const assert = require('assert');
+const MockServer = require('../../../../lib/mockserver.js');
+const Nightwatch = require('../../../../lib/nightwatch.js');
+const { Key } = require('selenium-webdriver');
 
-describe("clearValue", function () {
+describe('clearValue', function () {
   before(function (done) {
     this.server = MockServer.init();
-    this.server.on("listening", () => done());
+    this.server.on('listening', () => done());
   });
 
   after(function (done) {
     this.server.close(() => done());
   });
 
-  it("client.clearValue()", function (done) {
+  it('client.clearValue()', function (done) {
     Nightwatch.initClient({
       output: false,
       silent: false,
     }).then((client) => {
       MockServer.addMock({
-        url: "/wd/hub/session/1352110219202/element/0/clear",
+        url: '/wd/hub/session/1352110219202/element/0/clear',
         response: {
-          sessionId: "1352110219202",
+          sessionId: '1352110219202',
           status: 0,
         },
       });
 
       client.api
-        .clearValue("#weblogin", function callback(result) {
+        .clearValue('#weblogin', function callback(result) {
           assert.strictEqual(result.status, 0);
           assert.strictEqual(this, client.api);
         })
-        .clearValue("css selector", "#weblogin", function callback(result) {
+        .clearValue('css selector', '#weblogin', function callback(result) {
           assert.strictEqual(result.status, 0);
         });
 
@@ -39,14 +39,14 @@ describe("clearValue", function () {
     });
   });
 
-  it("client.clearValue() with invalid locate strategy", function (done) {
+  it('client.clearValue() with invalid locate strategy', function (done) {
     Nightwatch.initClient({
       output: false,
       silent: false,
     }).then((client) => {
       client.api.clearValue(
-        "invalid strategy",
-        "#weblogin",
+        'invalid strategy',
+        '#weblogin',
         function callback(result) {
           assert.strictEqual(result.status, 0);
         }
@@ -57,7 +57,7 @@ describe("clearValue", function () {
           assert.ok(err instanceof Error);
           assert.ok(
             err.message.includes(
-              'Provided locating strategy "invalid strategy" is not supported for .clearValue()'
+              `Provided locating strategy 'invalid strategy' is not supported for .clearValue()`
             )
           );
           done();
@@ -68,28 +68,28 @@ describe("clearValue", function () {
     });
   });
 
-  it("client.clearValue() with no callback", function (done) {
+  it('client.clearValue() with no callback', function (done) {
     Nightwatch.initClient({
       output: false,
       silent: false,
     }).then((client) => {
       MockServer.addMock({
-        url: "/wd/hub/session/1352110219202/element/0/clear",
+        url: '/wd/hub/session/1352110219202/element/0/clear',
         response: {
-          sessionId: "1352110219202",
+          sessionId: '1352110219202',
           status: 0,
         },
       });
 
-      client.api.elements("css selector", "body", (res) => {
-        client.api.clearValue("#weblogin");
+      client.api.elements('css selector', 'body', (res) => {
+        client.api.clearValue('#weblogin');
       });
 
       client.start(done);
     });
   });
 
-  it("client.clearValue() with webdriver protocol", function (done) {
+  it('client.clearValue() with webdriver protocol', function (done) {
     Nightwatch.initClient({
       selenium: {
         version2: false,
@@ -99,13 +99,13 @@ describe("clearValue", function () {
       output: false,
       silent: false,
       webdriver: {
-        host: "localhost",
+        host: 'localhost',
         start_process: false,
       },
     }).then((client) => {
       MockServer.addMock(
         {
-          url: "/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear",
+          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
           response: { value: null },
         },
         true
@@ -113,17 +113,17 @@ describe("clearValue", function () {
 
       MockServer.addMock(
         {
-          url: "/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear",
+          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
           response: { value: null },
         },
         true
       );
 
       client.api
-        .clearValue("#webdriver", function (result) {
+        .clearValue('#webdriver', function (result) {
           assert.strictEqual(result.value, null);
         })
-        .clearValue("css selector", "#webdriver", function (result) {
+        .clearValue('css selector', '#webdriver', function (result) {
           assert.strictEqual(result.value, null);
         });
 
@@ -131,7 +131,7 @@ describe("clearValue", function () {
     });
   });
 
-  it("client.clearValue() with webdriver protocol - ensuring that fallback is working", function (done) {
+  it('client.clearValue() with webdriver protocol - ensuring that fallback is working', function (done) {
     Nightwatch.initClient({
       selenium: {
         version2: false,
@@ -141,27 +141,25 @@ describe("clearValue", function () {
       output: true,
       silent: false,
       webdriver: {
-        host: "localhost",
+        host: 'localhost',
         start_process: false,
       },
     }).then((client) => {
       const bArr = Array(6).fill(Key.BACK_SPACE);
-      const str = bArr.join("");
-
+      const str = bArr.join('');
 
       MockServer.addMock(
         {
-          url: "/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear",
+          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
           response: { value: 'sample' },
         },
         true
       );
 
-     
       MockServer.addMock(
         {
           url: `/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/value`,
-          method: "POST",
+          method: 'POST',
           postdata: {
             str,
             value: bArr,
@@ -173,9 +171,8 @@ describe("clearValue", function () {
         },
         true
       );
-     
 
-      client.api.clearValue("#webdriver", function (result) {
+      client.api.clearValue('#webdriver', function (result) {
         assert.strictEqual(result.value, null);
         // ensures fallback is working
       });
@@ -184,7 +181,7 @@ describe("clearValue", function () {
     });
   });
 
-  it("client.clearValue() with webdriver protocol - element not found", function (done) {
+  it('client.clearValue() with webdriver protocol - element not found', function (done) {
     Nightwatch.initClient({
       selenium: {
         version2: false,
@@ -192,7 +189,7 @@ describe("clearValue", function () {
         host: null,
       },
       webdriver: {
-        host: "localhost",
+        host: 'localhost',
         start_process: false,
       },
       silent: false,
@@ -204,24 +201,24 @@ describe("clearValue", function () {
       let retries = 0;
       MockServer.addMock({
         statusCode: 404,
-        url: "/session/13521-10219-202/elements",
-        postdata: { using: "css selector", value: "#webdriver-notfound" },
+        url: '/session/13521-10219-202/elements',
+        postdata: { using: 'css selector', value: '#webdriver-notfound' },
         times: 2,
         onResponse() {
           retries++;
         },
         response: {
           value: {
-            error: "no such element",
-            message: "Unable to locate element: #webdriver-notfound",
+            error: 'no such element',
+            message: 'Unable to locate element: #webdriver-notfound',
             stacktrace:
-              "WebDriverError@chrome://marionette/content/error.js:172:5\nNoSuchElementError@chrome://marionette/content/error.js:400:5",
+              'WebDriverError@chrome://marionette/content/error.js:172:5\nNoSuchElementError@chrome://marionette/content/error.js:400:5',
           },
         },
       });
 
       client.api.clearValue(
-        { selector: "#webdriver-notfound", timeout: 11 },
+        { selector: '#webdriver-notfound', timeout: 11 },
         function (result) {
           assert.strictEqual(result.status, -1);
           assert.strictEqual(retries, 2);

--- a/test/src/api/commands/element/testClearValue.js
+++ b/test/src/api/commands/element/testClearValue.js
@@ -1,95 +1,91 @@
 const assert = require('assert');
-const MockServer = require('../../../../lib/mockserver.js');
+const MockServer  = require('../../../../lib/mockserver.js');
 const Nightwatch = require('../../../../lib/nightwatch.js');
 const {Key} = require('selenium-webdriver');
 
-describe('clearValue', function () {
-  before(function (done) {
+describe('clearValue', function() {
+
+  before(function(done) {
     this.server = MockServer.init();
     this.server.on('listening', () => done());
   });
 
-  after(function (done) {
+  after(function(done) {
     this.server.close(() => done());
   });
 
-  it('client.clearValue()', function (done) {
+  it('client.clearValue()', function(done) {
     Nightwatch.initClient({
       output: false,
       silent: false
-    }).then((client) => {
-      MockServer.addMock({
-        url: '/wd/hub/session/1352110219202/element/0/clear',
-        response: {
-          sessionId: '1352110219202',
-          status: 0
-        }
-      });
+    })
+      .then(client => {
+        MockServer.addMock({
+          'url': '/wd/hub/session/1352110219202/element/0/clear',
+          'response': {
+            sessionId: '1352110219202',
+            status: 0
+          }
+        });
 
-      client.api
-        .clearValue('#weblogin', function callback(result) {
+        client.api.clearValue('#weblogin', function callback(result) {
           assert.strictEqual(result.status, 0);
           assert.strictEqual(this, client.api);
         })
-        .clearValue('css selector', '#weblogin', function callback(result) {
+          .clearValue('css selector', '#weblogin', function callback(result) {
+            assert.strictEqual(result.status, 0);
+          });
+
+        client.start(done);
+      });
+  });
+
+  it('client.clearValue() with invalid locate strategy', function(done) {
+    Nightwatch.initClient({
+      output: false,
+      silent: false
+    })
+      .then(client => {
+        client.api.clearValue('invalid strategy', '#weblogin', function callback(result) {
           assert.strictEqual(result.status, 0);
         });
 
-      client.start(done);
-    });
+        client.start(function(err) {
+          try {
+            assert.ok(err instanceof Error);
+            assert.ok(err.message.includes('Provided locating strategy "invalid strategy" is not supported for .clearValue()'));
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+      });
   });
 
-  it('client.clearValue() with invalid locate strategy', function (done) {
+  it('client.clearValue() with no callback', function(done) {
     Nightwatch.initClient({
       output: false,
       silent: false
-    }).then((client) => {
-      client.api.clearValue(
-        'invalid strategy',
-        '#weblogin',
-        function callback(result) {
-          assert.strictEqual(result.status, 0);
-        }
-      );
+    })
+      .then(client => {
+        MockServer.addMock({
+          'url': '/wd/hub/session/1352110219202/element/0/clear',
+          'response': {
+            sessionId: '1352110219202',
+            status: 0
+          }
+        });
 
-      client.start(function (err) {
-        try {
-          assert.ok(err instanceof Error);
-          assert.ok(
-            err.message.includes(
-              'Provided locating strategy "invalid strategy" is not supported for .clearValue()'
-            )
-          );
-          done();
-        } catch (e) {
-          done(e);
-        }
+
+        client.api.elements('css selector', 'body', res => {
+          client.api.clearValue('#weblogin');
+        });
+
+        client.start(done);
       });
-    });
   });
 
-  it('client.clearValue() with no callback', function (done) {
-    Nightwatch.initClient({
-      output: false,
-      silent: false
-    }).then((client) => {
-      MockServer.addMock({
-        url: '/wd/hub/session/1352110219202/element/0/clear',
-        response: {
-          sessionId: '1352110219202',
-          status: 0
-        }
-      });
-
-      client.api.elements('css selector', 'body', (res) => {
-        client.api.clearValue('#weblogin');
-      });
-
-      client.start(done);
-    });
-  });
-
-  it('client.clearValue() with webdriver protocol', function (done) {
+  it('client.clearValue() with webdriver protocol', function(done) {
     Nightwatch.initClient({
       selenium: {
         version2: false,
@@ -102,35 +98,27 @@ describe('clearValue', function () {
         host: 'localhost',
         start_process: false
       }
-    }).then((client) => {
-      MockServer.addMock(
-        {
-          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
-          response: {value: null}
-        },
-        true
-      );
+    }).then(client => {
+      MockServer.addMock({
+        url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
+        response: {value: null}
+      }, true);
 
-      MockServer.addMock(
-        {
-          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
-          response: {value: null}
-        },
-        true
-      );
+      MockServer.addMock({
+        url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
+        response: {value: null}
+      }, true);
 
-      client.api
-        .clearValue('#webdriver', function (result) {
-          assert.strictEqual(result.value, null);
-        })
-        .clearValue('css selector', '#webdriver', function (result) {
-          assert.strictEqual(result.value, null);
-        });
+      client.api.clearValue('#webdriver', function(result) {
+        assert.strictEqual(result.value, null);
+      }).clearValue('css selector', '#webdriver', function(result) {
+        assert.strictEqual(result.value, null);
+      });
 
       client.start(done);
     });
   });
-
+ 
   it('client.clearValue() with webdriver protocol - ensuring working of sendKeys()', function (done) {
     Nightwatch.initClient({
       selenium: {
@@ -170,7 +158,7 @@ describe('clearValue', function () {
     });
   });
 
-  it('client.clearValue() with webdriver protocol - element not found', function (done) {
+  it('client.clearValue() with webdriver protocol - element not found', function(done) {
     Nightwatch.initClient({
       selenium: {
         version2: false,
@@ -186,7 +174,7 @@ describe('clearValue', function () {
       globals: {
         waitForConditionPollInterval: 5
       }
-    }).then((client) => {
+    }).then(client => {
       let retries = 0;
       MockServer.addMock({
         statusCode: 404,
@@ -200,27 +188,17 @@ describe('clearValue', function () {
           value: {
             error: 'no such element',
             message: 'Unable to locate element: #webdriver-notfound',
-            stacktrace:
-              'WebDriverError@chrome://marionette/content/error.js:172:5\nNoSuchElementError@chrome://marionette/content/error.js:400:5'
+            stacktrace: 'WebDriverError@chrome://marionette/content/error.js:172:5\nNoSuchElementError@chrome://marionette/content/error.js:400:5'
           }
         }
       });
 
-      client.api.clearValue(
-        {selector: '#webdriver-notfound', timeout: 11},
-        function (result) {
-          assert.strictEqual(result.status, -1);
-          assert.strictEqual(retries, 2);
-          assert.strictEqual(
-            result.value.error,
-            'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.'
-          );
-          assert.strictEqual(
-            result.value.message,
-            'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.'
-          );
-        }
-      );
+      client.api.clearValue({selector: '#webdriver-notfound', timeout: 11}, function(result) {
+        assert.strictEqual(result.status, -1);
+        assert.strictEqual(retries, 2);
+        assert.strictEqual(result.value.error, 'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.');
+        assert.strictEqual(result.value.message, 'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.');
+      });
 
       client.start(done);
     });

--- a/test/src/api/commands/element/testClearValue.js
+++ b/test/src/api/commands/element/testClearValue.js
@@ -126,32 +126,24 @@ describe('clearValue', function() {
         start_process: false,
         host: null
       },
-      output: false,
+      output: true,
       silent: false,
       webdriver: {
         host: 'localhost',
         start_process: false
       }
     }).then((client) => {
-      MockServer.addMock(
-        {
-          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/property/value',
-          response: {value: 'sampleText'}
-        },
-        true
-      );
+      MockServer.addMock({
+        url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/property/clear',
+        response: {value: null}
+      }, true);
+      
+
+      
 
       client.api.clearValue('#webdriver', function (result) {
         assert.strictEqual(result.value, null);
-        // ensures working of clearValue
-        const sentValue = MockServer.getLastRequestData().data.value;
-        if (sentValue !== '') {
-          assert.deepStrictEqual(
-            sentValue,
-            Array(sentValue.length).fill(Key.BACK_SPACE)
-            //ensures that Keys were sent
-          );
-        }
+        // ensures fallback is working
       });
 
       client.start(done);

--- a/test/src/api/commands/element/testClearValue.js
+++ b/test/src/api/commands/element/testClearValue.js
@@ -119,7 +119,7 @@ describe('clearValue', function() {
     });
   });
  
-  it('client.clearValue() with webdriver protocol - ensuring working of sendKeys()', function (done) {
+  it('client.clearValue() with webdriver protocol - ensuring that fallback is working', function (done) {
     Nightwatch.initClient({
       selenium: {
         version2: false,
@@ -146,7 +146,7 @@ describe('clearValue', function() {
         // ensures working of clearValue
         const sentValue = MockServer.getLastRequestData().data.value;
         if (sentValue !== '') {
-          assert.strictEqual(
+          assert.deepStrictEqual(
             sentValue,
             Array(sentValue.length).fill(Key.BACK_SPACE)
             //ensures that Keys were sent

--- a/test/src/api/commands/element/testClearValue.js
+++ b/test/src/api/commands/element/testClearValue.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const MockServer = require('../../../../lib/mockserver.js');
 const Nightwatch = require('../../../../lib/nightwatch.js');
-const { Key } = require('selenium-webdriver');
+const {Key} = require('selenium-webdriver');
 
 describe('clearValue', function () {
   before(function (done) {
@@ -16,14 +16,14 @@ describe('clearValue', function () {
   it('client.clearValue()', function (done) {
     Nightwatch.initClient({
       output: false,
-      silent: false,
+      silent: false
     }).then((client) => {
       MockServer.addMock({
         url: '/wd/hub/session/1352110219202/element/0/clear',
         response: {
           sessionId: '1352110219202',
-          status: 0,
-        },
+          status: 0
+        }
       });
 
       client.api
@@ -42,7 +42,7 @@ describe('clearValue', function () {
   it('client.clearValue() with invalid locate strategy', function (done) {
     Nightwatch.initClient({
       output: false,
-      silent: false,
+      silent: false
     }).then((client) => {
       client.api.clearValue(
         'invalid strategy',
@@ -57,7 +57,7 @@ describe('clearValue', function () {
           assert.ok(err instanceof Error);
           assert.ok(
             err.message.includes(
-              `Provided locating strategy 'invalid strategy' is not supported for .clearValue()`
+              'Provided locating strategy \'invalid strategy\' is not supported for .clearValue()'
             )
           );
           done();
@@ -71,14 +71,14 @@ describe('clearValue', function () {
   it('client.clearValue() with no callback', function (done) {
     Nightwatch.initClient({
       output: false,
-      silent: false,
+      silent: false
     }).then((client) => {
       MockServer.addMock({
         url: '/wd/hub/session/1352110219202/element/0/clear',
         response: {
           sessionId: '1352110219202',
-          status: 0,
-        },
+          status: 0
+        }
       });
 
       client.api.elements('css selector', 'body', (res) => {
@@ -94,19 +94,19 @@ describe('clearValue', function () {
       selenium: {
         version2: false,
         start_process: false,
-        host: null,
+        host: null
       },
       output: false,
       silent: false,
       webdriver: {
         host: 'localhost',
-        start_process: false,
-      },
+        start_process: false
+      }
     }).then((client) => {
       MockServer.addMock(
         {
           url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
-          response: { value: null },
+          response: {value: null}
         },
         true
       );
@@ -114,7 +114,7 @@ describe('clearValue', function () {
       MockServer.addMock(
         {
           url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
-          response: { value: null },
+          response: {value: null}
         },
         true
       );
@@ -136,14 +136,14 @@ describe('clearValue', function () {
       selenium: {
         version2: false,
         start_process: false,
-        host: null,
+        host: null
       },
       output: true,
       silent: false,
       webdriver: {
         host: 'localhost',
-        start_process: false,
-      },
+        start_process: false
+      }
     }).then((client) => {
       const bArr = Array(6).fill(Key.BACK_SPACE);
       const str = bArr.join('');
@@ -151,23 +151,23 @@ describe('clearValue', function () {
       MockServer.addMock(
         {
           url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
-          response: { value: 'sample' },
+          response: {value: 'sample'}
         },
         true
       );
 
       MockServer.addMock(
         {
-          url: `/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/value`,
+          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/value',
           method: 'POST',
           postdata: {
             str,
-            value: bArr,
+            value: bArr
           },
           response: {
-            value: null,
+            value: null
           },
-          statusCode: 200,
+          statusCode: 200
         },
         true
       );
@@ -186,23 +186,23 @@ describe('clearValue', function () {
       selenium: {
         version2: false,
         start_process: false,
-        host: null,
+        host: null
       },
       webdriver: {
         host: 'localhost',
-        start_process: false,
+        start_process: false
       },
       silent: false,
       output: false,
       globals: {
-        waitForConditionPollInterval: 5,
-      },
+        waitForConditionPollInterval: 5
+      }
     }).then((client) => {
       let retries = 0;
       MockServer.addMock({
         statusCode: 404,
         url: '/session/13521-10219-202/elements',
-        postdata: { using: 'css selector', value: '#webdriver-notfound' },
+        postdata: {using: 'css selector', value: '#webdriver-notfound'},
         times: 2,
         onResponse() {
           retries++;
@@ -212,13 +212,13 @@ describe('clearValue', function () {
             error: 'no such element',
             message: 'Unable to locate element: #webdriver-notfound',
             stacktrace:
-              'WebDriverError@chrome://marionette/content/error.js:172:5\nNoSuchElementError@chrome://marionette/content/error.js:400:5',
-          },
-        },
+              'WebDriverError@chrome://marionette/content/error.js:172:5\nNoSuchElementError@chrome://marionette/content/error.js:400:5'
+          }
+        }
       });
 
       client.api.clearValue(
-        { selector: '#webdriver-notfound', timeout: 11 },
+        {selector: '#webdriver-notfound', timeout: 11},
         function (result) {
           assert.strictEqual(result.status, -1);
           assert.strictEqual(retries, 2);

--- a/test/src/api/commands/element/testClearValue.js
+++ b/test/src/api/commands/element/testClearValue.js
@@ -1,95 +1,91 @@
 const assert = require('assert');
-const MockServer = require('../../../../lib/mockserver.js');
+const MockServer  = require('../../../../lib/mockserver.js');
 const Nightwatch = require('../../../../lib/nightwatch.js');
 const {Key} = require('selenium-webdriver');
 
-describe('clearValue', function () {
-  before(function (done) {
+describe('clearValue', function() {
+
+  before(function(done) {
     this.server = MockServer.init();
     this.server.on('listening', () => done());
   });
 
-  after(function (done) {
+  after(function(done) {
     this.server.close(() => done());
   });
 
-  it('client.clearValue()', function (done) {
+  it('client.clearValue()', function(done) {
     Nightwatch.initClient({
       output: false,
       silent: false
-    }).then((client) => {
-      MockServer.addMock({
-        url: '/wd/hub/session/1352110219202/element/0/clear',
-        response: {
-          sessionId: '1352110219202',
-          status: 0
-        }
-      });
+    })
+      .then(client => {
+        MockServer.addMock({
+          'url': '/wd/hub/session/1352110219202/element/0/clear',
+          'response': {
+            sessionId: '1352110219202',
+            status: 0
+          }
+        });
 
-      client.api
-        .clearValue('#weblogin', function callback(result) {
+        client.api.clearValue('#weblogin', function callback(result) {
           assert.strictEqual(result.status, 0);
           assert.strictEqual(this, client.api);
         })
-        .clearValue('css selector', '#weblogin', function callback(result) {
+          .clearValue('css selector', '#weblogin', function callback(result) {
+            assert.strictEqual(result.status, 0);
+          });
+
+        client.start(done);
+      });
+  });
+
+  it('client.clearValue() with invalid locate strategy', function(done) {
+    Nightwatch.initClient({
+      output: false,
+      silent: false
+    })
+      .then(client => {
+        client.api.clearValue('invalid strategy', '#weblogin', function callback(result) {
           assert.strictEqual(result.status, 0);
         });
 
-      client.start(done);
-    });
+        client.start(function(err) {
+          try {
+            assert.ok(err instanceof Error);
+            assert.ok(err.message.includes('Provided locating strategy "invalid strategy" is not supported for .clearValue()'));
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+      });
   });
 
-  it('client.clearValue() with invalid locate strategy', function (done) {
+  it('client.clearValue() with no callback', function(done) {
     Nightwatch.initClient({
       output: false,
       silent: false
-    }).then((client) => {
-      client.api.clearValue(
-        'invalid strategy',
-        '#weblogin',
-        function callback(result) {
-          assert.strictEqual(result.status, 0);
-        }
-      );
+    })
+      .then(client => {
+        MockServer.addMock({
+          'url': '/wd/hub/session/1352110219202/element/0/clear',
+          'response': {
+            sessionId: '1352110219202',
+            status: 0
+          }
+        });
 
-      client.start(function (err) {
-        try {
-          assert.ok(err instanceof Error);
-          assert.ok(
-            err.message.includes(
-              'Provided locating strategy \'invalid strategy\' is not supported for .clearValue()'
-            )
-          );
-          done();
-        } catch (e) {
-          done(e);
-        }
+
+        client.api.elements('css selector', 'body', res => {
+          client.api.clearValue('#weblogin');
+        });
+
+        client.start(done);
       });
-    });
   });
 
-  it('client.clearValue() with no callback', function (done) {
-    Nightwatch.initClient({
-      output: false,
-      silent: false
-    }).then((client) => {
-      MockServer.addMock({
-        url: '/wd/hub/session/1352110219202/element/0/clear',
-        response: {
-          sessionId: '1352110219202',
-          status: 0
-        }
-      });
-
-      client.api.elements('css selector', 'body', (res) => {
-        client.api.clearValue('#weblogin');
-      });
-
-      client.start(done);
-    });
-  });
-
-  it('client.clearValue() with webdriver protocol', function (done) {
+  it('client.clearValue() with webdriver protocol', function(done) {
     Nightwatch.initClient({
       selenium: {
         version2: false,
@@ -102,30 +98,22 @@ describe('clearValue', function () {
         host: 'localhost',
         start_process: false
       }
-    }).then((client) => {
-      MockServer.addMock(
-        {
-          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
-          response: {value: null}
-        },
-        true
-      );
+    }).then(client => {
+      MockServer.addMock({
+        url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
+        response: {value: null}
+      }, true);
 
-      MockServer.addMock(
-        {
-          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
-          response: {value: null}
-        },
-        true
-      );
+      MockServer.addMock({
+        url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
+        response: {value: null}
+      }, true);
 
-      client.api
-        .clearValue('#webdriver', function (result) {
-          assert.strictEqual(result.value, null);
-        })
-        .clearValue('css selector', '#webdriver', function (result) {
-          assert.strictEqual(result.value, null);
-        });
+      client.api.clearValue('#webdriver', function(result) {
+        assert.strictEqual(result.value, null);
+      }).clearValue('css selector', '#webdriver', function(result) {
+        assert.strictEqual(result.value, null);
+      });
 
       client.start(done);
     });
@@ -147,7 +135,7 @@ describe('clearValue', function () {
     }).then((client) => {
       const bArr = Array(6).fill(Key.BACK_SPACE);
       const str = bArr.join('');
-
+  
       MockServer.addMock(
         {
           url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
@@ -155,7 +143,7 @@ describe('clearValue', function () {
         },
         true
       );
-
+  
       MockServer.addMock(
         {
           url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/value',
@@ -171,17 +159,17 @@ describe('clearValue', function () {
         },
         true
       );
-
+  
       client.api.clearValue('#webdriver', function (result) {
         assert.strictEqual(result.value, null);
         // ensures fallback is working
       });
-
+  
       client.start(done);
     });
   });
 
-  it('client.clearValue() with webdriver protocol - element not found', function (done) {
+  it('client.clearValue() with webdriver protocol - element not found', function(done) {
     Nightwatch.initClient({
       selenium: {
         version2: false,
@@ -197,7 +185,7 @@ describe('clearValue', function () {
       globals: {
         waitForConditionPollInterval: 5
       }
-    }).then((client) => {
+    }).then(client => {
       let retries = 0;
       MockServer.addMock({
         statusCode: 404,
@@ -211,27 +199,17 @@ describe('clearValue', function () {
           value: {
             error: 'no such element',
             message: 'Unable to locate element: #webdriver-notfound',
-            stacktrace:
-              'WebDriverError@chrome://marionette/content/error.js:172:5\nNoSuchElementError@chrome://marionette/content/error.js:400:5'
+            stacktrace: 'WebDriverError@chrome://marionette/content/error.js:172:5\nNoSuchElementError@chrome://marionette/content/error.js:400:5'
           }
         }
       });
 
-      client.api.clearValue(
-        {selector: '#webdriver-notfound', timeout: 11},
-        function (result) {
-          assert.strictEqual(result.status, -1);
-          assert.strictEqual(retries, 2);
-          assert.strictEqual(
-            result.value.error,
-            'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.'
-          );
-          assert.strictEqual(
-            result.value.message,
-            'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.'
-          );
-        }
-      );
+      client.api.clearValue({selector: '#webdriver-notfound', timeout: 11}, function(result) {
+        assert.strictEqual(result.status, -1);
+        assert.strictEqual(retries, 2);
+        assert.strictEqual(result.value.error, 'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.');
+        assert.strictEqual(result.value.message, 'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.');
+      });
 
       client.start(done);
     });

--- a/test/src/api/commands/element/testClearValue.js
+++ b/test/src/api/commands/element/testClearValue.js
@@ -1,90 +1,95 @@
 const assert = require('assert');
-const MockServer  = require('../../../../lib/mockserver.js');
+const MockServer = require('../../../../lib/mockserver.js');
 const Nightwatch = require('../../../../lib/nightwatch.js');
+const {Key} = require('selenium-webdriver');
 
-describe('clearValue', function() {
-
-  before(function(done) {
+describe('clearValue', function () {
+  before(function (done) {
     this.server = MockServer.init();
     this.server.on('listening', () => done());
   });
 
-  after(function(done) {
+  after(function (done) {
     this.server.close(() => done());
   });
 
-  it('client.clearValue()', function(done) {
+  it('client.clearValue()', function (done) {
     Nightwatch.initClient({
       output: false,
       silent: false
-    })
-      .then(client => {
-        MockServer.addMock({
-          'url': '/wd/hub/session/1352110219202/element/0/clear',
-          'response': {
-            sessionId: '1352110219202',
-            status: 0
-          }
-        });
+    }).then((client) => {
+      MockServer.addMock({
+        url: '/wd/hub/session/1352110219202/element/0/clear',
+        response: {
+          sessionId: '1352110219202',
+          status: 0
+        }
+      });
 
-        client.api.clearValue('#weblogin', function callback(result) {
+      client.api
+        .clearValue('#weblogin', function callback(result) {
           assert.strictEqual(result.status, 0);
           assert.strictEqual(this, client.api);
         })
-          .clearValue('css selector', '#weblogin', function callback(result) {
-            assert.strictEqual(result.status, 0);
-          });
-
-        client.start(done);
-      });
-  });
-
-  it('client.clearValue() with invalid locate strategy', function(done) {
-    Nightwatch.initClient({
-      output: false,
-      silent: false
-    })
-      .then(client => {
-        client.api.clearValue('invalid strategy', '#weblogin', function callback(result) {
+        .clearValue('css selector', '#weblogin', function callback(result) {
           assert.strictEqual(result.status, 0);
         });
 
-        client.start(function(err) {
-          try {
-            assert.ok(err instanceof Error);
-            assert.ok(err.message.includes('Provided locating strategy "invalid strategy" is not supported for .clearValue()'));
-            done();
-          } catch (e) {
-            done(e);
-          }
-        });
-      });
+      client.start(done);
+    });
   });
 
-  it('client.clearValue() with no callback', function(done) {
+  it('client.clearValue() with invalid locate strategy', function (done) {
     Nightwatch.initClient({
       output: false,
       silent: false
-    })
-      .then(client => {
-        MockServer.addMock({
-          'url': '/wd/hub/session/1352110219202/element/0/clear',
-          'response': {
-            sessionId: '1352110219202',
-            status: 0
-          }
-        });
+    }).then((client) => {
+      client.api.clearValue(
+        'invalid strategy',
+        '#weblogin',
+        function callback(result) {
+          assert.strictEqual(result.status, 0);
+        }
+      );
 
-
-        client.api.elements('css selector', 'body', res => {
-          client.api.clearValue('#weblogin');
-        });
-
-        client.start(done);
+      client.start(function (err) {
+        try {
+          assert.ok(err instanceof Error);
+          assert.ok(
+            err.message.includes(
+              'Provided locating strategy "invalid strategy" is not supported for .clearValue()'
+            )
+          );
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
+    });
   });
 
-  it('client.clearValue() with webdriver protocol', function(done) {
+  it('client.clearValue() with no callback', function (done) {
+    Nightwatch.initClient({
+      output: false,
+      silent: false
+    }).then((client) => {
+      MockServer.addMock({
+        url: '/wd/hub/session/1352110219202/element/0/clear',
+        response: {
+          sessionId: '1352110219202',
+          status: 0
+        }
+      });
+
+      client.api.elements('css selector', 'body', (res) => {
+        client.api.clearValue('#weblogin');
+      });
+
+      client.start(done);
+    });
+  });
+
+  it('client.clearValue() with webdriver protocol', function (done) {
     Nightwatch.initClient({
       selenium: {
         version2: false,
@@ -97,28 +102,75 @@ describe('clearValue', function() {
         host: 'localhost',
         start_process: false
       }
-    }).then(client => {
-      MockServer.addMock({
-        url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
-        response: {value: null}
-      }, true);
+    }).then((client) => {
+      MockServer.addMock(
+        {
+          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
+          response: {value: null}
+        },
+        true
+      );
 
-      MockServer.addMock({
-        url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
-        response: {value: null}
-      }, true);
+      MockServer.addMock(
+        {
+          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
+          response: {value: null}
+        },
+        true
+      );
 
-      client.api.clearValue('#webdriver', function(result) {
+      client.api
+        .clearValue('#webdriver', function (result) {
+          assert.strictEqual(result.value, null);
+        })
+        .clearValue('css selector', '#webdriver', function (result) {
+          assert.strictEqual(result.value, null);
+        });
+
+      client.start(done);
+    });
+  });
+
+  it('client.clearValue() with webdriver protocol - ensuring working of sendKeys()', function (done) {
+    Nightwatch.initClient({
+      selenium: {
+        version2: false,
+        start_process: false,
+        host: null
+      },
+      output: false,
+      silent: false,
+      webdriver: {
+        host: 'localhost',
+        start_process: false
+      }
+    }).then((client) => {
+      MockServer.addMock(
+        {
+          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/property/value',
+          response: {value: 'sampleText'}
+        },
+        true
+      );
+
+      client.api.clearValue('#webdriver', function (result) {
         assert.strictEqual(result.value, null);
-      }).clearValue('css selector', '#webdriver', function(result) {
-        assert.strictEqual(result.value, null);
+        // ensures working of clearValue
+        const sentValue = MockServer.getLastRequestData().data.value;
+        if (sentValue !== '') {
+          assert.strictEqual(
+            sentValue,
+            Array(sentValue.length).fill(Key.BACK_SPACE)
+            //ensures that Keys were sent
+          );
+        }
       });
 
       client.start(done);
     });
   });
 
-  it('client.clearValue() with webdriver protocol - element not found', function(done) {
+  it('client.clearValue() with webdriver protocol - element not found', function (done) {
     Nightwatch.initClient({
       selenium: {
         version2: false,
@@ -134,7 +186,7 @@ describe('clearValue', function() {
       globals: {
         waitForConditionPollInterval: 5
       }
-    }).then(client => {
+    }).then((client) => {
       let retries = 0;
       MockServer.addMock({
         statusCode: 404,
@@ -148,17 +200,27 @@ describe('clearValue', function() {
           value: {
             error: 'no such element',
             message: 'Unable to locate element: #webdriver-notfound',
-            stacktrace: 'WebDriverError@chrome://marionette/content/error.js:172:5\nNoSuchElementError@chrome://marionette/content/error.js:400:5'
+            stacktrace:
+              'WebDriverError@chrome://marionette/content/error.js:172:5\nNoSuchElementError@chrome://marionette/content/error.js:400:5'
           }
         }
       });
 
-      client.api.clearValue({selector: '#webdriver-notfound', timeout: 11}, function(result) {
-        assert.strictEqual(result.status, -1);
-        assert.strictEqual(retries, 2);
-        assert.strictEqual(result.value.error, 'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.');
-        assert.strictEqual(result.value.message, 'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.');
-      });
+      client.api.clearValue(
+        {selector: '#webdriver-notfound', timeout: 11},
+        function (result) {
+          assert.strictEqual(result.status, -1);
+          assert.strictEqual(retries, 2);
+          assert.strictEqual(
+            result.value.error,
+            'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.'
+          );
+          assert.strictEqual(
+            result.value.message,
+            'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.'
+          );
+        }
+      );
 
       client.start(done);
     });

--- a/test/src/api/commands/element/testClearValue.js
+++ b/test/src/api/commands/element/testClearValue.js
@@ -183,16 +183,12 @@ describe('clearValue', function() {
       },
       output: false,
       silent: false,
-      globals: {
-        reporter(results) {
-          console.log('reporter results', results);
-        }
-      },
       webdriver: {
         host: 'localhost',
         start_process: false
       }
     }).then((client) => {
+      let sendKeysMockCalled = false;
       let callbackResultValue;
   
       MockServer
@@ -204,6 +200,14 @@ describe('clearValue', function() {
           url: '/session/13521-10219-202/element/0/property/value',
           method: 'GET',
           response: {value: ''}
+        }, true)
+        .addMock({
+          url: '/session/13521-10219-202/element/0/value',
+          method: 'POST',
+          response: {value: null},
+          onRequest() {
+            sendKeysMockCalled = true;
+          }
         }, true);
 
       client.api.clearValue('css selector', '#signupSection', function (result) {
@@ -214,6 +218,7 @@ describe('clearValue', function() {
         try {
           assert.strictEqual(err, undefined);
           assert.strictEqual(callbackResultValue, null);
+          assert.strictEqual(sendKeysMockCalled, false);
           done();
         } catch (e) {
           done(e);

--- a/test/src/api/commands/element/testClearValue.js
+++ b/test/src/api/commands/element/testClearValue.js
@@ -138,16 +138,16 @@ describe('clearValue', function() {
   
       MockServer
         .addMock({
-          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
+          url: '/session/13521-10219-202/element/0/clear',
           response: {value: null}
         }, true)
         .addMock({
-          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/property/value',
+          url: '/session/13521-10219-202/element/0/property/value',
           method: 'GET',
           response: {value: 'sample'}
         }, true)
         .addMock({
-          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/value',
+          url: '/session/13521-10219-202/element/0/value',
           method: 'POST',
           response: {value: null},
           onRequest(_, requestData) {
@@ -156,7 +156,7 @@ describe('clearValue', function() {
           }
         }, true);
 
-      client.api.clearValue('css selector', '#webdriver', function (result) {
+      client.api.clearValue('css selector', '#signupSection', function (result) {
         callbackResultValue = result.value;
       });
   
@@ -197,16 +197,16 @@ describe('clearValue', function() {
   
       MockServer
         .addMock({
-          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
+          url: '/session/13521-10219-202/element/0/clear',
           response: {value: null}
         }, true)
         .addMock({
-          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/property/value',
+          url: '/session/13521-10219-202/element/0/property/value',
           method: 'GET',
           response: {value: ''}
         }, true);
 
-      client.api.clearValue('css selector', '#webdriver', function (result) {
+      client.api.clearValue('css selector', '#signupSection', function (result) {
         callbackResultValue = result.value;
       });
   

--- a/test/src/api/commands/element/testClearValue.js
+++ b/test/src/api/commands/element/testClearValue.js
@@ -1,147 +1,181 @@
-const assert = require('assert');
-const MockServer  = require('../../../../lib/mockserver.js');
-const Nightwatch = require('../../../../lib/nightwatch.js');
-const {Key} = require('selenium-webdriver');
+const assert = require("assert");
+const MockServer = require("../../../../lib/mockserver.js");
+const Nightwatch = require("../../../../lib/nightwatch.js");
+const { Key } = require("selenium-webdriver");
 
-describe('clearValue', function() {
-
-  before(function(done) {
+describe("clearValue", function () {
+  before(function (done) {
     this.server = MockServer.init();
-    this.server.on('listening', () => done());
+    this.server.on("listening", () => done());
   });
 
-  after(function(done) {
+  after(function (done) {
     this.server.close(() => done());
   });
 
-  it('client.clearValue()', function(done) {
+  it("client.clearValue()", function (done) {
     Nightwatch.initClient({
       output: false,
-      silent: false
-    })
-      .then(client => {
-        MockServer.addMock({
-          'url': '/wd/hub/session/1352110219202/element/0/clear',
-          'response': {
-            sessionId: '1352110219202',
-            status: 0
-          }
-        });
+      silent: false,
+    }).then((client) => {
+      MockServer.addMock({
+        url: "/wd/hub/session/1352110219202/element/0/clear",
+        response: {
+          sessionId: "1352110219202",
+          status: 0,
+        },
+      });
 
-        client.api.clearValue('#weblogin', function callback(result) {
+      client.api
+        .clearValue("#weblogin", function callback(result) {
           assert.strictEqual(result.status, 0);
           assert.strictEqual(this, client.api);
         })
-          .clearValue('css selector', '#weblogin', function callback(result) {
-            assert.strictEqual(result.status, 0);
-          });
-
-        client.start(done);
-      });
-  });
-
-  it('client.clearValue() with invalid locate strategy', function(done) {
-    Nightwatch.initClient({
-      output: false,
-      silent: false
-    })
-      .then(client => {
-        client.api.clearValue('invalid strategy', '#weblogin', function callback(result) {
+        .clearValue("css selector", "#weblogin", function callback(result) {
           assert.strictEqual(result.status, 0);
         });
 
-        client.start(function(err) {
-          try {
-            assert.ok(err instanceof Error);
-            assert.ok(err.message.includes('Provided locating strategy "invalid strategy" is not supported for .clearValue()'));
-            done();
-          } catch (e) {
-            done(e);
-          }
-        });
-      });
+      client.start(done);
+    });
   });
 
-  it('client.clearValue() with no callback', function(done) {
+  it("client.clearValue() with invalid locate strategy", function (done) {
     Nightwatch.initClient({
-      output: false,
-      silent: false
-    })
-      .then(client => {
-        MockServer.addMock({
-          'url': '/wd/hub/session/1352110219202/element/0/clear',
-          'response': {
-            sessionId: '1352110219202',
-            status: 0
-          }
-        });
-
-
-        client.api.elements('css selector', 'body', res => {
-          client.api.clearValue('#weblogin');
-        });
-
-        client.start(done);
-      });
-  });
-
-  it('client.clearValue() with webdriver protocol', function(done) {
-    Nightwatch.initClient({
-      selenium: {
-        version2: false,
-        start_process: false,
-        host: null
-      },
       output: false,
       silent: false,
-      webdriver: {
-        host: 'localhost',
-        start_process: false
-      }
-    }).then(client => {
-      MockServer.addMock({
-        url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
-        response: {value: null}
-      }, true);
+    }).then((client) => {
+      client.api.clearValue(
+        "invalid strategy",
+        "#weblogin",
+        function callback(result) {
+          assert.strictEqual(result.status, 0);
+        }
+      );
 
-      MockServer.addMock({
-        url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
-        response: {value: null}
-      }, true);
+      client.start(function (err) {
+        try {
+          assert.ok(err instanceof Error);
+          assert.ok(
+            err.message.includes(
+              'Provided locating strategy "invalid strategy" is not supported for .clearValue()'
+            )
+          );
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+    });
+  });
 
-      client.api.clearValue('#webdriver', function(result) {
-        assert.strictEqual(result.value, null);
-      }).clearValue('css selector', '#webdriver', function(result) {
-        assert.strictEqual(result.value, null);
+  it("client.clearValue() with no callback", function (done) {
+    Nightwatch.initClient({
+      output: false,
+      silent: false,
+    }).then((client) => {
+      MockServer.addMock({
+        url: "/wd/hub/session/1352110219202/element/0/clear",
+        response: {
+          sessionId: "1352110219202",
+          status: 0,
+        },
+      });
+
+      client.api.elements("css selector", "body", (res) => {
+        client.api.clearValue("#weblogin");
       });
 
       client.start(done);
     });
   });
- 
-  it('client.clearValue() with webdriver protocol - ensuring that fallback is working', function (done) {
+
+  it("client.clearValue() with webdriver protocol", function (done) {
     Nightwatch.initClient({
       selenium: {
         version2: false,
         start_process: false,
-        host: null
+        host: null,
+      },
+      output: false,
+      silent: false,
+      webdriver: {
+        host: "localhost",
+        start_process: false,
+      },
+    }).then((client) => {
+      MockServer.addMock(
+        {
+          url: "/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear",
+          response: { value: null },
+        },
+        true
+      );
+
+      MockServer.addMock(
+        {
+          url: "/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear",
+          response: { value: null },
+        },
+        true
+      );
+
+      client.api
+        .clearValue("#webdriver", function (result) {
+          assert.strictEqual(result.value, null);
+        })
+        .clearValue("css selector", "#webdriver", function (result) {
+          assert.strictEqual(result.value, null);
+        });
+
+      client.start(done);
+    });
+  });
+
+  it("client.clearValue() with webdriver protocol - ensuring that fallback is working", function (done) {
+    Nightwatch.initClient({
+      selenium: {
+        version2: false,
+        start_process: false,
+        host: null,
       },
       output: true,
       silent: false,
       webdriver: {
-        host: 'localhost',
-        start_process: false
-      }
+        host: "localhost",
+        start_process: false,
+      },
     }).then((client) => {
-      MockServer.addMock({
-        url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/property/clear',
-        response: {value: null}
-      }, true);
-      
+      const bArr = Array(6).fill(Key.BACK_SPACE);
+      const str = bArr.join("");
 
-      
 
-      client.api.clearValue('#webdriver', function (result) {
+      MockServer.addMock(
+        {
+          url: "/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear",
+          response: { value: 'sample' },
+        },
+        true
+      );
+
+     
+      MockServer.addMock(
+        {
+          url: `/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/value`,
+          method: "POST",
+          postdata: {
+            str,
+            value: bArr,
+          },
+          response: {
+            value: null,
+          },
+          statusCode: 200,
+        },
+        true
+      );
+     
+
+      client.api.clearValue("#webdriver", function (result) {
         assert.strictEqual(result.value, null);
         // ensures fallback is working
       });
@@ -150,47 +184,57 @@ describe('clearValue', function() {
     });
   });
 
-  it('client.clearValue() with webdriver protocol - element not found', function(done) {
+  it("client.clearValue() with webdriver protocol - element not found", function (done) {
     Nightwatch.initClient({
       selenium: {
         version2: false,
         start_process: false,
-        host: null
+        host: null,
       },
       webdriver: {
-        host: 'localhost',
-        start_process: false
+        host: "localhost",
+        start_process: false,
       },
       silent: false,
       output: false,
       globals: {
-        waitForConditionPollInterval: 5
-      }
-    }).then(client => {
+        waitForConditionPollInterval: 5,
+      },
+    }).then((client) => {
       let retries = 0;
       MockServer.addMock({
         statusCode: 404,
-        url: '/session/13521-10219-202/elements',
-        postdata: {using: 'css selector', value: '#webdriver-notfound'},
+        url: "/session/13521-10219-202/elements",
+        postdata: { using: "css selector", value: "#webdriver-notfound" },
         times: 2,
         onResponse() {
           retries++;
         },
         response: {
           value: {
-            error: 'no such element',
-            message: 'Unable to locate element: #webdriver-notfound',
-            stacktrace: 'WebDriverError@chrome://marionette/content/error.js:172:5\nNoSuchElementError@chrome://marionette/content/error.js:400:5'
-          }
-        }
+            error: "no such element",
+            message: "Unable to locate element: #webdriver-notfound",
+            stacktrace:
+              "WebDriverError@chrome://marionette/content/error.js:172:5\nNoSuchElementError@chrome://marionette/content/error.js:400:5",
+          },
+        },
       });
 
-      client.api.clearValue({selector: '#webdriver-notfound', timeout: 11}, function(result) {
-        assert.strictEqual(result.status, -1);
-        assert.strictEqual(retries, 2);
-        assert.strictEqual(result.value.error, 'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.');
-        assert.strictEqual(result.value.message, 'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.');
-      });
+      client.api.clearValue(
+        { selector: "#webdriver-notfound", timeout: 11 },
+        function (result) {
+          assert.strictEqual(result.status, -1);
+          assert.strictEqual(retries, 2);
+          assert.strictEqual(
+            result.value.error,
+            'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.'
+          );
+          assert.strictEqual(
+            result.value.message,
+            'An error occurred while running .clearValue() command on <#webdriver-notfound>: Timed out while waiting for element "#webdriver-notfound" with "css selector" to be present for 11 milliseconds.'
+          );
+        }
+      );
 
       client.start(done);
     });

--- a/test/src/api/commands/element/testClearValue.js
+++ b/test/src/api/commands/element/testClearValue.js
@@ -159,7 +159,7 @@ describe('clearValue', function() {
           url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/value',
           method: 'POST',
           postdata: {
-            text : str,
+            text: str,
             value: bArr
           },
           response: {
@@ -177,7 +177,7 @@ describe('clearValue', function() {
   
       client.api.sendKeys('css selector', '#webdriver', bArr, function callback(result) {
         assert.strictEqual(sendKeysMockCalled, true);
-      }).clearValue('css selector','#webdriver', function (result) {
+      }).clearValue('css selector', '#webdriver', function (result) {
         assert.strictEqual(result.value, null);
         // ensures fallback is working
       });

--- a/test/src/api/commands/element/testClearValue.js
+++ b/test/src/api/commands/element/testClearValue.js
@@ -135,32 +135,49 @@ describe('clearValue', function() {
     }).then((client) => {
       const bArr = Array(6).fill(Key.BACK_SPACE);
       const str = bArr.join('');
+      let sendKeysMockCalled = false;
   
       MockServer.addMock(
         {
           url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/clear',
+          response: {value: null}
+        },
+        true
+      );
+
+      MockServer.addMock(
+        {
+          url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/property/value',
           response: {value: 'sample'}
         },
         true
       );
+
   
       MockServer.addMock(
         {
           url: '/session/13521-10219-202/element/5cc459b8-36a8-3042-8b4a-258883ea642b/value',
           method: 'POST',
           postdata: {
-            str,
+            text : str,
             value: bArr
           },
           response: {
-            value: null
+            sessionId: '13521-10219-202',
+            status: 0
+          },
+          onRequest() {
+            sendKeysMockCalled = true;
           },
           statusCode: 200
         },
         true
       );
+      
   
-      client.api.clearValue('#webdriver', function (result) {
+      client.api.sendKeys('css selector', '#webdriver', bArr, function callback(result) {
+        assert.strictEqual(sendKeysMockCalled, true);
+      }).clearValue('css selector','#webdriver', function (result) {
         assert.strictEqual(result.value, null);
         // ensures fallback is working
       });

--- a/test/src/api/commands/web-element/testSetValue.js
+++ b/test/src/api/commands/web-element/testSetValue.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const {WebElement} = require('selenium-webdriver');
+const {WebElement, Key} = require('selenium-webdriver');
 const MockServer  = require('../../../../lib/mockserver.js');
 const CommandGlobals = require('../../../../lib/globals/commands-w3c.js');
 const common = require('../../../../common.js');
@@ -150,5 +150,69 @@ describe('element().setValue() command', function () {
     const result = await resultPromise;
     assert.strictEqual(result instanceof WebElement, true);
     assert.strictEqual(await result.getId(), '9');
+  });
+
+  it('test .element().setValue() with clear fallback sending keys', async function() {
+    let sendKeysMockCalled = 0;
+
+    MockServer
+      .addMock({
+        url: '/session/13521-10219-202/elements',
+        postdata: {
+          using: 'css selector',
+          value: 'input[name=q]'
+        },
+        method: 'POST',
+        response: JSON.stringify({
+          value: [{'element-6066-11e4-a52e-4f735466cecf': '9'}]
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/9/clear',
+        method: 'POST',
+        postdata: {},
+        response: JSON.stringify({
+          value: null
+        })
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/9/property/value',
+        method: 'GET',
+        response: {value: 'sample'}
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/9/value',
+        method: 'POST',
+        response: {value: null},
+        onRequest(_, requestData) {
+          assert.strictEqual(requestData.text, Array(6).fill(Key.BACK_SPACE).join(''));
+          sendKeysMockCalled++;
+        }
+      }, true)
+      .addMock({
+        url: '/session/13521-10219-202/element/9/value',
+        method: 'POST',
+        postdata: {
+          text: 'nightwatch',
+          value: [
+            'n', 'i', 'g', 'h', 't', 'w', 'a', 't', 'c', 'h'
+          ]
+        },
+        response: JSON.stringify({
+          value: null
+        }),
+        onRequest(_, requestData) {
+          assert.strictEqual(requestData.text, 'nightwatch');
+          sendKeysMockCalled++;
+        }
+      }, true);
+
+    const resultPromise = this.client.api.element('input[name=q]').setValue('nightwatch');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, true);
+    assert.strictEqual(await result.getId(), '9');
+
+    assert.strictEqual(sendKeysMockCalled, 2);
   });
 });

--- a/test/src/api/protocol/testElementCommands.js
+++ b/test/src/api/protocol/testElementCommands.js
@@ -512,13 +512,20 @@ describe('element actions', function () {
         },
         commandName: 'elementIdValue',
         args: ['TEST_ELEMENT', 'test', function(result) {
+          // accounting for fallback for clearElement as well.
+          assert.strictEqual(assertions.length, 4);
+
           assert.strictEqual(assertions[0].command, 'clearElement');
           assert.ok(assertions[0].args.id instanceof WebElement);
 
-          assert.strictEqual(assertions[1].command, 'sendKeysToElement');
-          assert.strictEqual(assertions[1].args.text, 'test');
-          assert.deepStrictEqual(assertions[1].args.value, ['t', 'e', 's', 't']);
-          assert.ok(assertions[1].args.id instanceof WebElement);
+          // fallback for clearElement
+          assert.strictEqual(assertions[1].command, 'getElementProperty');
+          assert.strictEqual(assertions[2].command, 'sendKeysToElement');
+
+          assert.strictEqual(assertions[3].command, 'sendKeysToElement');
+          assert.strictEqual(assertions[3].args.text, 'test');
+          assert.deepStrictEqual(assertions[3].args.value, ['t', 'e', 's', 't']);
+          assert.ok(assertions[3].args.id instanceof WebElement);
 
           assert.deepStrictEqual(result, {value: null, status: 0});
         }]


### PR DESCRIPTION
Add a fallback for `clearValue` command where Nightwatch will now try to delete the text in an input field by sending backspaces if the text is not deleted by the clear command directly.

This fallback will also work for commands like `setValue`, `updateValue`, etc. which clears the text before entering new text.