### PR TITLE
Returning error instead of throwing when passed wrong index in selector

### DIFF
--- a/lib/element/locator.js
+++ b/lib/element/locator.js
@@ -291,7 +291,7 @@ class LocateElement {
    * @return {*}
    */
   filterElements(element, result) {
-    let filtered = Element.applyFiltering(element, result.value);
+    const filtered = Element.applyFiltering(element, result.value);
 
     if (filtered) {
       result.value = filtered;
@@ -301,7 +301,12 @@ class LocateElement {
 
     const errorResult = this.transport.getElementNotFoundResult(result);
 
-    throw new Error(`Element ${element.toString()} not found.${errorResult.message ? (' ' + errorResult.message) : ''}`);
+    return {
+      status: errorResult.status,
+      value: null,
+      error: errorResult.errorStatus,
+      message: errorResult.message
+    };
   }
 
   /**
@@ -310,13 +315,13 @@ class LocateElement {
    * @return {Promise}
    */
   findElementsUsingRecursion({element, returnSingleElement = true}) {
-    let recursion = new ElementsByRecursion(this.nightwatchInstance);
+    const recursion = new ElementsByRecursion(this.nightwatchInstance);
 
     return recursion.locateElements({element, returnSingleElement});
   }
 
   findSingleElementUsingRecursion(element) {
-    let recursion = new SingleElementByRecursion(this.nightwatchInstance);
+    const recursion = new SingleElementByRecursion(this.nightwatchInstance);
 
     return recursion.locateElement(element.selector);
   }


### PR DESCRIPTION
Fixes: #3810 

Earlier we used to throw the error if the element is not found by it's CSS selector.
Here are few cases

for `.expect.element().to.not.be.present test` here are some cases

1. (#wrong_selector) used to return error due to wrong selector, test passes
2. (#wrong_selector, wrong_index) used to return error due to wrong selector, doesn't go to test for index, test passes
3. (#right_selector, wrong_index) used to return element as selector was right, but used to *throw* error when filtering by index (not return it).

This PR fixes that last case.

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.

- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [x] If you're fixing a bug also create an issue if one doesn't exist yet;
- [ ] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [x] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [x] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [x] Do not include changes that are not related to the issue at hand;
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [x] Always add unit tests - PRs without tests are most of the times ignored.
