### PR TITLE
Added NoSuchElementError instead of TimeoutError when chained .find()…

### DIFF
--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -170,6 +170,7 @@ class ScopedWebElement {
           return null;
         }
 
+        error.name = 'NoSuchElementError';
         const narrowedError = createNarrowedError({error, condition, timeout});
         Logger.error(narrowedError);
 
@@ -323,8 +324,8 @@ class ScopedWebElement {
 }
 
 function createNarrowedError({error, condition, timeout}) {
-  return error.name === 'TimeoutError'
-    ? new Error(`Timed out while waiting for element "${condition}" to be present for ${timeout} milliseconds.`)
+  return error.name === 'NoSuchElementError'
+    ? new Error('Expected element is not present')
     : error;
 }
 


### PR DESCRIPTION
… command fails
Added NoSuchElementError instead of TimeoutError when chained .find()
fix - #4078 
![Screenshot 2024-03-02 at 10 52 45 PM](https://github.com/nightwatchjs/nightwatch/assets/99127578/afef228c-32b8-4434-a8d3-53f04a0ce9b9)


Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.

- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [x] If you're fixing a bug also create an issue if one doesn't exist yet;
- [x] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [ ] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [ ] Do not include changes that are not related to the issue at hand;
- [ ] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [ ] Always add unit tests - PRs without tests are most of the times ignored.
