### PR TITLE
Fix #4080 - timeout issue on find command

### DIFF
--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -169,7 +169,7 @@ class ScopedWebElement {
         if (suppressNotFoundErrors) {
           return null;
         }
-
+        error.name = 'NoSuchElementError';
         const narrowedError = createNarrowedError({error, condition, timeout});
         Logger.error(narrowedError);
 
@@ -323,8 +323,8 @@ class ScopedWebElement {
 }
 
 function createNarrowedError({error, condition, timeout}) {
-  return error.name === 'TimeoutError'
-    ? new Error(`Timed out while waiting for element "${condition}" to be present for ${timeout} milliseconds.`)
+  return error.name === 'NoSuchElementError'
+    ? new Error('Expected element to be located ' + condition + ' within ' + timeout + 'ms but it was not found.')
     : error;
 }
 


### PR DESCRIPTION
Fixes #4080 
The solution to this bug was to rename the TimoutError to NosuchElementError. 
I have also tested the command.
Below is the required video. 
If any correction is needed please let me know @garg3133 . 
If not kindly assign me this issue.  

https://github.com/nightwatchjs/nightwatch/assets/127919475/8794bddd-acf8-4128-a3e7-ec8269c190c0



Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.

- [.] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [.] If you're fixing a bug also create an issue if one doesn't exist yet;
- [ ] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [ ] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [ ] Do not include changes that are not related to the issue at hand;
- [ ] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [ ] Always add unit tests - PRs without tests are most of the times ignored.
