### PR TITLE
Removed wrong example from `getText()`

### DIFF
--- a/lib/api/web-element/commands/getText.js
+++ b/lib/api/web-element/commands/getText.js
@@ -6,7 +6,7 @@
  * @example
  * export default {
  *   demoTest(browser: NightwatchAPI): void {
- *     const result = browser.element('#main ul li a.first').getText();
+ *     const result = browser.element('#main ul li a.first').getText()
  *       .assert.valueEquals('custom text');
  *   },
  *

--- a/lib/api/web-element/commands/getText.js
+++ b/lib/api/web-element/commands/getText.js
@@ -5,10 +5,6 @@
  *
  * @example
  * export default {
- *   demoTest(browser: NightwatchAPI): void {
- *     const result = browser.element('#main ul li a.first').getText()
- *       .assert.valueEquals('custom text');
- *   },
  *
  *   async demoTestAsync(browser: NightwatchAPI): Promise<void> {
  *     const result = await browser.element('#main ul li a.first').getText();


### PR DESCRIPTION
Fixes: #4103 

@reallymello 

Upon investigation, it does seem the non-awaited command doesn't work.
<img width="685" alt="Screenshot 2024-03-08 at 5 24 21 PM" src="https://github.com/nightwatchjs/nightwatch/assets/31622972/0080a558-e138-4e30-9092-a2ff496e4b78">

This is because the method used for getText in method-maping.js is getElementText, which is an async function.

https://github.com/nightwatchjs/nightwatch/blob/a441ca42e162766cd384ff41158a14c03bc5ab42/lib/transport/selenium-webdriver/method-mappings.js#L543-L548

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.


- [ ] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [ ] If you're fixing a bug also create an issue if one doesn't exist yet;
- [ ] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [ ] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [ ] Do not include changes that are not related to the issue at hand;
- [ ] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [ ] Always add unit tests - PRs without tests are most of the times ignored.
