### PR TITLE
Issue/4105 is displayed() alias added

### DIFF
--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -24,7 +24,8 @@ class ScopedWebElement {
       'findAllByAltText': ['getAllByAltText'],
       'getRect': ['getSize', 'getLocation'],
       'getProperty': ['property'],
-      'getCssProperty': ['css']
+      'getCssProperty': ['css'],
+      'isVisible': ['isDisplayed']
     };
   }
 

--- a/test/src/api/commands/web-element/testIsVisible.js
+++ b/test/src/api/commands/web-element/testIsVisible.js
@@ -147,4 +147,138 @@ describe('element().isVisible() command', function() {
     assert.strictEqual(await resultPromise.assert.not.equals(false), true);
     assert.strictEqual(elementId, '0');
   });
+
+  it('test .element().isDisplayed() displayed', async function() {
+    let elementId;
+
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: true
+      }),
+      onRequest(_, requestData) {
+        elementId = requestData.args[0]['element-6066-11e4-a52e-4f735466cecf'];
+      }
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').isDisplayed();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, true);
+    assert.strictEqual(elementId, '0');
+  });
+
+  it('test .element().isDisplayed() not displayed', async function() {
+    let elementId;
+
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: false
+      }),
+      onRequest(_, requestData) {
+        elementId = requestData.args[0]['element-6066-11e4-a52e-4f735466cecf'];
+      }
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').isDisplayed();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, false);
+    assert.strictEqual(elementId, '0');
+  });
+
+  it('test .element().find().isDisplayed()', async function() {
+    let elementId;
+
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: true
+      }),
+      onRequest(_, requestData) {
+        elementId = requestData.args[0]['element-6066-11e4-a52e-4f735466cecf'];
+      }
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').isDisplayed();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, true);
+    assert.strictEqual(elementId, '1');
+  });
+
+  it('test .element.find().isDisplayed() not displayed', async function() {
+    let elementId;
+
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: false
+      }),
+      onRequest(_, requestData) {
+        elementId = requestData.args[0]['element-6066-11e4-a52e-4f735466cecf'];
+      }
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').isDisplayed();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, false);
+    assert.strictEqual(elementId, '0');
+  });
+
+  it('test .element().isDisplayed() assert', async function() {
+    let elementId;
+
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: true
+      }),
+      onRequest(_, requestData) {
+        elementId = requestData.args[0]['element-6066-11e4-a52e-4f735466cecf'];
+      }
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').isDisplayed();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    assert.strictEqual(await resultPromise.assert.equals(true), true);
+    assert.strictEqual(await resultPromise.assert.not.equals(false), true);
+    assert.strictEqual(elementId, '0');
+  });
 });

--- a/types/tests/webElement.test-d.ts
+++ b/types/tests/webElement.test-d.ts
@@ -142,6 +142,7 @@ describe('new element() api', function () {
     expectType<ElementValue<string | null>>(elem.getValue());
     expectType<ElementValue<boolean>>(elem.isEnabled());
     expectType<ElementValue<boolean>>(elem.isVisible());
+    expectType<ElementValue<boolean>>(elem.isDisplayed());
 
     expectType<ElementValue<ScopedElementRect>>(elem.getRect());
     expectType<ElementValue<ScopedElementRect>>(elem.getSize());

--- a/types/web-element.d.ts
+++ b/types/web-element.d.ts
@@ -2,11 +2,11 @@ import {
   By,
   RelativeBy,
   WebElement,
-  WebElementPromise,
-} from "selenium-webdriver";
+  WebElementPromise
+} from 'selenium-webdriver';
 
-import { ElementProperties } from "./page-object";
-import { Element, LocateStrategy, NightwatchClient } from "./index";
+import {ElementProperties} from './page-object';
+import {Element, LocateStrategy, NightwatchClient} from './index';
 
 export interface ScopedElement extends Element, PromiseLike<WebElement> {
   assert: ElementAssertions;
@@ -18,14 +18,14 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   findByText(
     text: string,
-    options?: Omit<ScopedSelectorObject, "selector"> & {
+    options?: Omit<ScopedSelectorObject, 'selector'> & {
       readonly exact?: boolean;
     }
   ): ScopedElement;
 
   findByRole(
-    role: "heading",
-    options?: Omit<ScopedSelectorObject, "selector"> & {
+    role: 'heading',
+    options?: Omit<ScopedSelectorObject, 'selector'> & {
       readonly level?: number;
       readonly checked?: boolean;
       readonly current?: boolean | string;
@@ -37,7 +37,7 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   findByRole(
     role: string,
-    options?: Omit<ScopedSelectorObject, "selector"> & {
+    options?: Omit<ScopedSelectorObject, 'selector'> & {
       readonly current?: boolean | string;
       readonly checked?: boolean;
       readonly pressed?: boolean;
@@ -45,41 +45,41 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
       readonly expanded?: boolean;
     }
   ): ScopedElement;
-
+  
   findByPlaceholderText(
     text: string,
-    options?: Omit<ScopedSelectorObject, "selector"> & {
+    options?: Omit<ScopedSelectorObject, 'selector'> & {
       readonly exact?: boolean;
     }
   ): ScopedElement;
-
+  
   findByLabelText(
     text: string,
-    options?: Omit<ScopedSelectorObject, "selector"> & {
+    options?: Omit<ScopedSelectorObject, 'selector'> & {
       readonly exact?: boolean;
     }
   ): ScopedElement;
-
+  
   findByAltText(
     text: string,
-    options?: Omit<ScopedSelectorObject, "selector"> & {
+    options?: Omit<ScopedSelectorObject, 'selector'> & {
       readonly exact?: boolean;
     }
   ): ScopedElement;
-
+  
   findAll(selector: ScopedSelector | Promise<ScopedSelector>): Elements;
   getAll(selector: ScopedSelector | Promise<ScopedSelector>): Elements;
 
   findAllByText(
     text: string,
-    options?: Omit<ScopedSelectorObject, "selector"> & {
+    options?: Omit<ScopedSelectorObject, 'selector'> & {
       readonly exact?: boolean;
     }
   ): Elements;
 
   findAllByRole(
-    role: "heading",
-    options?: Omit<ScopedSelectorObject, "selector"> & {
+    role: 'heading',
+    options?: Omit<ScopedSelectorObject, 'selector'> & {
       readonly level?: number;
       readonly checked?: boolean;
       readonly current?: boolean | string;
@@ -91,7 +91,7 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   findAllByRole(
     role: string,
-    options?: Omit<ScopedSelectorObject, "selector"> & {
+    options?: Omit<ScopedSelectorObject, 'selector'> & {
       readonly current?: boolean | string;
       readonly checked?: boolean;
       readonly pressed?: boolean;
@@ -102,7 +102,7 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   getAllByRole(
     role: string,
-    options?: Omit<ScopedSelectorObject, "selector"> & {
+    options?: Omit<ScopedSelectorObject, 'selector'> & {
       readonly current?: boolean | string;
       readonly checked?: boolean;
       readonly pressed?: boolean;
@@ -113,14 +113,14 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   findAllByPlaceholderText(
     text: string,
-    options?: Omit<ScopedSelectorObject, "selector"> & {
+    options?: Omit<ScopedSelectorObject, 'selector'> & {
       readonly exact?: boolean;
     }
   ): Elements;
 
   findAllByAltText(
     text: string,
-    options?: Omit<ScopedSelectorObject, "selector"> & {
+    options?: Omit<ScopedSelectorObject, 'selector'> & {
       readonly exact?: boolean;
     }
   ): Elements;
@@ -133,7 +133,7 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   getPreviousElementSibling(): ScopedElement;
 
-  getShadowRoot(): Omit<ScopedElement, "then"> & PromiseLike<ShadowRoot>;
+  getShadowRoot(): Omit<ScopedElement, 'then'> & PromiseLike<ShadowRoot>;
 
   getId(): ElementValue<string>;
 
@@ -189,10 +189,7 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   isSelected(): ElementValue<boolean>;
 
-  waitUntil(
-    signalOrOptions: WaitUntilActions | WaitUntilOptions,
-    waitOptions?: WaitUntilOptions
-  ): Promise<WebElement>;
+  waitUntil(signalOrOptions: WaitUntilActions | WaitUntilOptions, waitOptions?: WaitUntilOptions): Promise<WebElement>;
 
   isEnabled(): ElementValue<boolean>;
 
@@ -210,16 +207,7 @@ type WaitUntilOptions = {
   abortOnFailure?: boolean;
 };
 
-type WaitUntilActions =
-  | "selected"
-  | "visible"
-  | "disabled"
-  | "enabled"
-  | "not.selected"
-  | "not.visible"
-  | "not.enabled"
-  | "present"
-  | "not.present";
+type WaitUntilActions = 'selected' | 'visible' | 'disabled' | 'enabled' | 'not.selected' | 'not.visible' | 'not.enabled' | 'present' | 'not.present';
 
 export class Elements implements PromiseLike<WebElement[]> {
   constructor(
@@ -268,6 +256,7 @@ export class ElementsAssertions {
   constructor(elements: Elements, options: ElementsAssertionsOptions);
 
   get not(): ElementsAssertions;
+
 }
 
 export type ElementAssertionsOptions = {
@@ -312,7 +301,7 @@ export class ElementValue<T> implements PromiseLike<T> {
 
 export type ScopedSelectorObject = Omit<
   ElementProperties,
-  "webElement" | "webElementId" | "selector"
+  'webElement' | 'webElementId' | 'selector'
 > & {
   readonly selector: string | By | RelativeBy;
 };
@@ -355,17 +344,8 @@ export type DragAndDropDestination = {
 export interface ElementFunction
   extends Pick<
     ScopedElement,
-    | "find"
-    | "findByText"
-    | "findByRole"
-    | "findByPlaceholderText"
-    | "findByLabelText"
-    | "findByAltText"
-    | "findAll"
-    | "findAllByText"
-    | "findAllByRole"
-    | "findAllByPlaceholderText"
-    | "findAllByAltText"
+    'find' | 'findByText' | 'findByRole' | 'findByPlaceholderText' | 'findByLabelText' | 'findByAltText' |
+    'findAll' | 'findAllByText' | 'findAllByRole' | 'findAllByPlaceholderText' | 'findAllByAltText'
   > {
   (selector: ScopedElementSelector): ScopedElement;
   (

--- a/types/web-element.d.ts
+++ b/types/web-element.d.ts
@@ -2,11 +2,11 @@ import {
   By,
   RelativeBy,
   WebElement,
-  WebElementPromise
-} from 'selenium-webdriver';
+  WebElementPromise,
+} from "selenium-webdriver";
 
-import {ElementProperties} from './page-object';
-import {Element, LocateStrategy, NightwatchClient} from './index';
+import { ElementProperties } from "./page-object";
+import { Element, LocateStrategy, NightwatchClient } from "./index";
 
 export interface ScopedElement extends Element, PromiseLike<WebElement> {
   assert: ElementAssertions;
@@ -18,14 +18,14 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   findByText(
     text: string,
-    options?: Omit<ScopedSelectorObject, 'selector'> & {
+    options?: Omit<ScopedSelectorObject, "selector"> & {
       readonly exact?: boolean;
     }
   ): ScopedElement;
 
   findByRole(
-    role: 'heading',
-    options?: Omit<ScopedSelectorObject, 'selector'> & {
+    role: "heading",
+    options?: Omit<ScopedSelectorObject, "selector"> & {
       readonly level?: number;
       readonly checked?: boolean;
       readonly current?: boolean | string;
@@ -37,7 +37,7 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   findByRole(
     role: string,
-    options?: Omit<ScopedSelectorObject, 'selector'> & {
+    options?: Omit<ScopedSelectorObject, "selector"> & {
       readonly current?: boolean | string;
       readonly checked?: boolean;
       readonly pressed?: boolean;
@@ -45,41 +45,41 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
       readonly expanded?: boolean;
     }
   ): ScopedElement;
-  
+
   findByPlaceholderText(
     text: string,
-    options?: Omit<ScopedSelectorObject, 'selector'> & {
+    options?: Omit<ScopedSelectorObject, "selector"> & {
       readonly exact?: boolean;
     }
   ): ScopedElement;
-  
+
   findByLabelText(
     text: string,
-    options?: Omit<ScopedSelectorObject, 'selector'> & {
+    options?: Omit<ScopedSelectorObject, "selector"> & {
       readonly exact?: boolean;
     }
   ): ScopedElement;
-  
+
   findByAltText(
     text: string,
-    options?: Omit<ScopedSelectorObject, 'selector'> & {
+    options?: Omit<ScopedSelectorObject, "selector"> & {
       readonly exact?: boolean;
     }
   ): ScopedElement;
-  
+
   findAll(selector: ScopedSelector | Promise<ScopedSelector>): Elements;
   getAll(selector: ScopedSelector | Promise<ScopedSelector>): Elements;
 
   findAllByText(
     text: string,
-    options?: Omit<ScopedSelectorObject, 'selector'> & {
+    options?: Omit<ScopedSelectorObject, "selector"> & {
       readonly exact?: boolean;
     }
   ): Elements;
 
   findAllByRole(
-    role: 'heading',
-    options?: Omit<ScopedSelectorObject, 'selector'> & {
+    role: "heading",
+    options?: Omit<ScopedSelectorObject, "selector"> & {
       readonly level?: number;
       readonly checked?: boolean;
       readonly current?: boolean | string;
@@ -91,7 +91,7 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   findAllByRole(
     role: string,
-    options?: Omit<ScopedSelectorObject, 'selector'> & {
+    options?: Omit<ScopedSelectorObject, "selector"> & {
       readonly current?: boolean | string;
       readonly checked?: boolean;
       readonly pressed?: boolean;
@@ -102,7 +102,7 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   getAllByRole(
     role: string,
-    options?: Omit<ScopedSelectorObject, 'selector'> & {
+    options?: Omit<ScopedSelectorObject, "selector"> & {
       readonly current?: boolean | string;
       readonly checked?: boolean;
       readonly pressed?: boolean;
@@ -113,14 +113,14 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   findAllByPlaceholderText(
     text: string,
-    options?: Omit<ScopedSelectorObject, 'selector'> & {
+    options?: Omit<ScopedSelectorObject, "selector"> & {
       readonly exact?: boolean;
     }
   ): Elements;
 
   findAllByAltText(
     text: string,
-    options?: Omit<ScopedSelectorObject, 'selector'> & {
+    options?: Omit<ScopedSelectorObject, "selector"> & {
       readonly exact?: boolean;
     }
   ): Elements;
@@ -133,7 +133,7 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   getPreviousElementSibling(): ScopedElement;
 
-  getShadowRoot(): Omit<ScopedElement, 'then'> & PromiseLike<ShadowRoot>;
+  getShadowRoot(): Omit<ScopedElement, "then"> & PromiseLike<ShadowRoot>;
 
   getId(): ElementValue<string>;
 
@@ -189,11 +189,16 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   isSelected(): ElementValue<boolean>;
 
-  waitUntil(signalOrOptions: WaitUntilActions | WaitUntilOptions, waitOptions?: WaitUntilOptions): Promise<WebElement>;
+  waitUntil(
+    signalOrOptions: WaitUntilActions | WaitUntilOptions,
+    waitOptions?: WaitUntilOptions
+  ): Promise<WebElement>;
 
   isEnabled(): ElementValue<boolean>;
 
   isVisible(): ElementValue<boolean>;
+
+  isDisplayed(): ElementValue<boolean>;
 }
 
 type WaitUntilOptions = {
@@ -205,7 +210,16 @@ type WaitUntilOptions = {
   abortOnFailure?: boolean;
 };
 
-type WaitUntilActions = 'selected' | 'visible' | 'disabled' | 'enabled' | 'not.selected' | 'not.visible' | 'not.enabled' | 'present' | 'not.present';
+type WaitUntilActions =
+  | "selected"
+  | "visible"
+  | "disabled"
+  | "enabled"
+  | "not.selected"
+  | "not.visible"
+  | "not.enabled"
+  | "present"
+  | "not.present";
 
 export class Elements implements PromiseLike<WebElement[]> {
   constructor(
@@ -254,7 +268,6 @@ export class ElementsAssertions {
   constructor(elements: Elements, options: ElementsAssertionsOptions);
 
   get not(): ElementsAssertions;
-
 }
 
 export type ElementAssertionsOptions = {
@@ -299,7 +312,7 @@ export class ElementValue<T> implements PromiseLike<T> {
 
 export type ScopedSelectorObject = Omit<
   ElementProperties,
-  'webElement' | 'webElementId' | 'selector'
+  "webElement" | "webElementId" | "selector"
 > & {
   readonly selector: string | By | RelativeBy;
 };
@@ -342,8 +355,17 @@ export type DragAndDropDestination = {
 export interface ElementFunction
   extends Pick<
     ScopedElement,
-    'find' | 'findByText' | 'findByRole' | 'findByPlaceholderText' | 'findByLabelText' | 'findByAltText' |
-    'findAll' | 'findAllByText' | 'findAllByRole' | 'findAllByPlaceholderText' | 'findAllByAltText'
+    | "find"
+    | "findByText"
+    | "findByRole"
+    | "findByPlaceholderText"
+    | "findByLabelText"
+    | "findByAltText"
+    | "findAll"
+    | "findAllByText"
+    | "findAllByRole"
+    | "findAllByPlaceholderText"
+    | "findAllByAltText"
   > {
   (selector: ScopedElementSelector): ScopedElement;
   (


### PR DESCRIPTION
## Issues Fixed https://github.com/nightwatchjs/nightwatch/issues/4105 :

Task:
- [x] Add isDisplayed as an alias to isVisible command.
- [x] Add some more test cases to test isDisplayed alias to the already present web-element/testIsVisible.js test file.
- [x] Add types and tests for types.

Changes:
- Added `isDisplayed()` alias in `scoped-element.js`
- Added test cases for `isDisplayed()` in `web-element/testIsVisible.js`
- Added type definition for `isDisplayed()` in `types/web-element.d.ts`
- Added test for newly added type `isDisplayed()` in `types/tests/webElement.test-d.ts`

**Followed all steps to reproduce the `browser.element(...).isDisplayed is not a function` error again after making the changes locally. Also successfully passed all the test on local machine**

Followed all the checkpoints mentioned:
- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [x] If you're fixing a bug also create an issue if one doesn't exist yet;
- [x] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [x] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [x] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [x] Do not include changes that are not related to the issue at hand;
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [x] Always add unit tests - PRs without tests are most of the times ignored.
