### PR TITLE
issue/4105-added isDisplayed() as an alias command for isVisible()

### DIFF
--- a/examples/tests/ecosia.js
+++ b/examples/tests/ecosia.js
@@ -7,6 +7,7 @@ describe('Ecosia.org Demo', function() {
 
   it('Demo test ecosia.org', function(browser) {
     browser
+      .element('input[name=q]').isDisplayed()
       .waitForElementVisible('body')
       .assert.titleContains('Ecosia')
       .assert.visible('input[type=search]')

--- a/examples/tests/ecosia.js
+++ b/examples/tests/ecosia.js
@@ -7,7 +7,6 @@ describe('Ecosia.org Demo', function() {
 
   it('Demo test ecosia.org', function(browser) {
     browser
-      .element('input[name=q]').isDisplayed()
       .waitForElementVisible('body')
       .assert.titleContains('Ecosia')
       .assert.visible('input[type=search]')

--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -24,7 +24,8 @@ class ScopedWebElement {
       'findAllByAltText': ['getAllByAltText'],
       'getRect': ['getSize', 'getLocation'],
       'getProperty': ['property'],
-      'getCssProperty': ['css']
+      'getCssProperty': ['css'],
+      'isVisible': ['isDisplayed'],
     };
   }
 

--- a/test/src/api/commands/web-element/testIsVisible.js
+++ b/test/src/api/commands/web-element/testIsVisible.js
@@ -55,7 +55,7 @@ describe('element().isVisible() command', function () {
       }
     }, true);
 
-    const resultPromise = this.client.api.element('#signupSection').isVisible();
+    const resultPromise = this.client.api.element('#signupSection').isDisplayed();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
 
@@ -109,7 +109,7 @@ describe('element().isVisible() command', function () {
       }
     }, true);
 
-    const resultPromise = this.client.api.element('#signupSection').isVisible();
+    const resultPromise = this.client.api.element('#signupSection').isDisplayed();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
 
@@ -163,7 +163,7 @@ describe('element().isVisible() command', function () {
       }
     }, true);
 
-    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').isVisible();
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').isDisplayed();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
 
@@ -217,7 +217,7 @@ describe('element().isVisible() command', function () {
       }
     }, true);
 
-    const resultPromise = this.client.api.element.find('#signupSection').isVisible();
+    const resultPromise = this.client.api.element.find('#signupSection').isDisplayed();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
 
@@ -270,7 +270,7 @@ describe('element().isVisible() command', function () {
       }
     }, true);
 
-    const resultPromise = this.client.api.element('#signupSection').isVisible();
+    const resultPromise = this.client.api.element('#signupSection').isDisplayed();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
 

--- a/test/src/api/commands/web-element/testIsVisible.js
+++ b/test/src/api/commands/web-element/testIsVisible.js
@@ -1,11 +1,11 @@
 const assert = require('assert');
-const {WebElement} = require('selenium-webdriver');
-const MockServer  = require('../../../../lib/mockserver.js');
+const { WebElement } = require('selenium-webdriver');
+const MockServer = require('../../../../lib/mockserver.js');
 const CommandGlobals = require('../../../../lib/globals/commands-w3c.js');
 const common = require('../../../../common.js');
 const Element = common.require('element/index.js');
 
-describe('element().isVisible() command', function() {
+describe('element().isVisible() command', function () {
   before(function (done) {
     CommandGlobals.beforeEach.call(this, done);
   });
@@ -14,7 +14,7 @@ describe('element().isVisible() command', function() {
     CommandGlobals.afterEach.call(this, done);
   });
 
-  it('test .element().isVisible() displayed', async function() {
+  it('test .element().isVisible() displayed', async function () {
     let elementId;
 
     MockServer.addMock({
@@ -41,7 +41,34 @@ describe('element().isVisible() command', function() {
     assert.strictEqual(elementId, '0');
   });
 
-  it('test .element().isVisible() not displayed', async function() {
+  it('test .element().isDisplayed() displayed', async function () {
+    let elementId;
+
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: true
+      }),
+      onRequest(_, requestData) {
+        elementId = requestData.args[0]['element-6066-11e4-a52e-4f735466cecf'];
+      }
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').isVisible();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, true);
+    assert.strictEqual(elementId, '0');
+  });
+
+  it('test .element().isVisible() not displayed', async function () {
     let elementId;
 
     MockServer.addMock({
@@ -68,7 +95,34 @@ describe('element().isVisible() command', function() {
     assert.strictEqual(elementId, '0');
   });
 
-  it('test .element().find().isVisible()', async function() {
+  it('test .element().isDisplayed() not displayed', async function () {
+    let elementId;
+
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: false
+      }),
+      onRequest(_, requestData) {
+        elementId = requestData.args[0]['element-6066-11e4-a52e-4f735466cecf'];
+      }
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').isVisible();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, false);
+    assert.strictEqual(elementId, '0');
+  });
+
+  it('test .element().find().isVisible()', async function () {
     let elementId;
 
     MockServer.addMock({
@@ -95,7 +149,34 @@ describe('element().isVisible() command', function() {
     assert.strictEqual(elementId, '1');
   });
 
-  it('test .element.find().isVisible() not displayed', async function() {
+  it('test .element().find().isDisplayed()', async function () {
+    let elementId;
+
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: true
+      }),
+      onRequest(_, requestData) {
+        elementId = requestData.args[0]['element-6066-11e4-a52e-4f735466cecf'];
+      }
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').find('#helpBtn').isVisible();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, true);
+    assert.strictEqual(elementId, '1');
+  });
+
+  it('test .element.find().isVisible() not displayed', async function () {
     let elementId;
 
     MockServer.addMock({
@@ -122,7 +203,60 @@ describe('element().isVisible() command', function() {
     assert.strictEqual(elementId, '0');
   });
 
-  it('test .element().isVisible() assert', async function() {
+  it('test .element.find().isDisplayed() not displayed', async function () {
+    let elementId;
+
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: false
+      }),
+      onRequest(_, requestData) {
+        elementId = requestData.args[0]['element-6066-11e4-a52e-4f735466cecf'];
+      }
+    }, true);
+
+    const resultPromise = this.client.api.element.find('#signupSection').isVisible();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, false);
+    assert.strictEqual(elementId, '0');
+  });
+
+  it('test .element().isVisible() assert', async function () {
+    let elementId;
+
+    MockServer.addMock({
+      url: '/session/13521-10219-202/execute/sync',
+      method: 'POST',
+      response: JSON.stringify({
+        value: true
+      }),
+      onRequest(_, requestData) {
+        elementId = requestData.args[0]['element-6066-11e4-a52e-4f735466cecf'];
+      }
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').isVisible();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    assert.strictEqual(await resultPromise.assert.equals(true), true);
+    assert.strictEqual(await resultPromise.assert.not.equals(false), true);
+    assert.strictEqual(elementId, '0');
+  });
+
+  it('test .element().isDisplayed() assert', async function () {
     let elementId;
 
     MockServer.addMock({
@@ -148,3 +282,4 @@ describe('element().isVisible() command', function() {
     assert.strictEqual(elementId, '0');
   });
 });
+

--- a/types/tests/webElement.test-d.ts
+++ b/types/tests/webElement.test-d.ts
@@ -142,6 +142,7 @@ describe('new element() api', function () {
     expectType<ElementValue<string | null>>(elem.getValue());
     expectType<ElementValue<boolean>>(elem.isEnabled());
     expectType<ElementValue<boolean>>(elem.isVisible());
+    expectType<ElementValue<boolean>>(elem.isDisplayed());
 
     expectType<ElementValue<ScopedElementRect>>(elem.getRect());
     expectType<ElementValue<ScopedElementRect>>(elem.getSize());

--- a/types/web-element.d.ts
+++ b/types/web-element.d.ts
@@ -194,6 +194,8 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
   isEnabled(): ElementValue<boolean>;
 
   isVisible(): ElementValue<boolean>;
+
+  isDisplayed(): ElementValue<boolean>;
 }
 
 type WaitUntilOptions = {


### PR DESCRIPTION
This PR adds isDisplayed() as an alias command for isVisible() in new Element API.
Fixes #4105 
Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.

- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [x] If you're fixing a bug also create an issue if one doesn't exist yet;
- [x] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [x] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [x] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [x] Do not include changes that are not related to the issue at hand;
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [x] Always add unit tests - PRs without tests are most of the times ignored.
