### PR TITLE
Suppressing error for further chained `.find()` commands

### DIFF
--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -160,9 +160,9 @@ class ScopedWebElement {
       const parentElement = args[0];
 
       // Check if parentElement is valid or not.
-      if (parentElement && parentElement.webElement){
+      if (parentElement && parentElement.webElement) {
         const parent = await parentElement.webElement;
-        if (parent === null){
+        if (parent === null) {
           // The parent was of type WebElement but was not resolved.
           // Supress further errors from find element commands.
           suppressNotFoundErrors = true;

--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -159,6 +159,16 @@ class ScopedWebElement {
 
       const parentElement = args[0];
 
+      // Check if parentElement is valid or not.
+      if (parentElement && parentElement.webElement){
+        const parent = await parentElement.webElement;
+        if (parent === null){
+          // The parent was of type WebElement but was not resolved.
+          // Supress further errors from find element commands.
+          suppressNotFoundErrors = true;
+        }
+      }
+
       try {
         if (condition.usingRecursion) {
           return await this.findElementUsingRecursion({parentElement, recursiveElement: condition, timeout, retryInterval});

--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -159,14 +159,8 @@ class ScopedWebElement {
 
       const parentElement = args[0];
 
-      // Check if parentElement is valid or not.
-      if (parentElement && parentElement.webElement) {
-        const parent = await parentElement.webElement;
-        if (parent === null) {
-          // The parent was of type WebElement but was not resolved.
-          // Supress further errors from find element commands.
-          suppressNotFoundErrors = true;
-        }
+      if (parentElement?.webElement && await parentElement.webElement === null) {
+        return null;
       }
 
       try {


### PR DESCRIPTION
Fixes: #4079 

Fixes: https://github.com/dikwickley/gsoc24/issues/1

Solves the third point from this comment (https://github.com/nightwatchjs/nightwatch/issues/3991#issuecomment-1969444042)
> Further chained .find() commands should not throw the Timeout or any other error again. Ex. in browser.element('.invalid-selector').find('selector').getText();, there should only be one error due to browser.element()  and .find() should not throw an error again (suppress the error for it).

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.


- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [x] If you're fixing a bug also create an issue if one doesn't exist yet;
- [x] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [x] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [x] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [x] Do not include changes that are not related to the issue at hand;
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [ ] Always add unit tests - PRs without tests are most of the times ignored.
