### PR TITLE
Fix `waitUntil` not working with async/await.

### DIFF
--- a/lib/api/_loaders/_command-loader.js
+++ b/lib/api/_loaders/_command-loader.js
@@ -34,9 +34,9 @@ class BaseCommandLoader extends BaseLoader {
     const redact = this.module.RedactParams || false;
     const alwaysAsync = this.module.alwaysAsync || false;
     const isTraceable = this.module.isTraceable;
-    const resolveParentNodeWithResult = this.module.resolveParentNodeWithResult && true;
+    const avoidPrematureParentNodeResolution = !!this.module.avoidPrematureParentNodeResolution;
 
-    return {redact, alwaysAsync, isTraceable, resolveParentNodeWithResult};
+    return {redact, alwaysAsync, isTraceable, avoidPrematureParentNodeResolution};
   }
 
   validateMethod(parent) {

--- a/lib/api/_loaders/_command-loader.js
+++ b/lib/api/_loaders/_command-loader.js
@@ -34,8 +34,9 @@ class BaseCommandLoader extends BaseLoader {
     const redact = this.module.RedactParams || false;
     const alwaysAsync = this.module.alwaysAsync || false;
     const isTraceable = this.module.isTraceable;
+    const resolveParentNodeWithResult = this.module.resolveParentNodeWithResult && true;
 
-    return {redact, alwaysAsync, isTraceable};
+    return {redact, alwaysAsync, isTraceable, resolveParentNodeWithResult};
   }
 
   validateMethod(parent) {
@@ -75,7 +76,7 @@ class BaseCommandLoader extends BaseLoader {
   }
 
   getTargetNamespace(parent) {
-    let namespace = this.namespace;
+    const namespace = this.namespace;
 
     if (!parent) {
       return namespace;

--- a/lib/api/protocol/waitUntil.js
+++ b/lib/api/protocol/waitUntil.js
@@ -61,6 +61,10 @@ module.exports = class WaitUntil extends ProtocolAction {
     return true;
   }
 
+  static get resolveParentNodeWithResult() {
+    return false;
+  }
+
   //timeMs, retryInterval, message, callback = function(r) {return r}
   async command(conditionFn, ...args) {
     let callback = function(r) {return r};

--- a/lib/api/protocol/waitUntil.js
+++ b/lib/api/protocol/waitUntil.js
@@ -61,8 +61,8 @@ module.exports = class WaitUntil extends ProtocolAction {
     return true;
   }
 
-  static get resolveParentNodeWithResult() {
-    return false;
+  static get avoidPrematureParentNodeResolution() {
+    return true;
   }
 
   //timeMs, retryInterval, message, callback = function(r) {return r}

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -91,12 +91,16 @@ class AsyncTree extends EventEmitter{
     return parentNode.childNodes.filter(item => item !== node && !item.done).length > 0;
   }
 
-  resolveParentNodeWithResult(node) {
+  shouldAvoidParentNodeResolution(node) {
     const parentNode = node.parent;
-    if (!parentNode || !parentNode.options) {return true}
-    const result = parentNode.options.resolveParentNodeWithResult;
 
-    return result;
+    if (!parentNode || parentNode.isRootNode) {
+      return false;
+    }
+
+    const result = parentNode.options?.avoidPrematureParentNodeResolution;
+
+    return Boolean(result);
   }
 
   shouldRejectNodePromise(err, node = this.currentNode) {
@@ -191,13 +195,13 @@ class AsyncTree extends EventEmitter{
 
     setTimeout(() => {
       const stillInProgress = this.otherChildNodesInProgress(node);
-      const resolveParent = this.resolveParentNodeWithResult(node);
+      const avoidPrematureParentNodeResolution = this.shouldAvoidParentNodeResolution(node);
       if (node.context && node.context instanceof EventEmitter) {
         node.context.emit('complete');
       }
 
       const isAssertion = node.parent && (node.parent.namespace === 'assert' || node.parent.namespace === 'verify');
-      if (node.parent && !node.parent.isRootNode && !isAssertion && !stillInProgress && resolveParent) {
+      if (node.parent && !node.parent.isRootNode && !isAssertion && !stillInProgress && !avoidPrematureParentNodeResolution) {
         node.done = true;
         this.resolveNode(node.parent, result, ++times);
       }

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -189,7 +189,7 @@ class AsyncTree extends EventEmitter{
       }
 
       const isAssertion = node.parent && (node.parent.namespace === 'assert' || node.parent.namespace === 'verify');
-      if (node.parent && !node.parent.isRootNode && !isAssertion && !stillInProgress) {
+      if (node.parent && !node.parent.isRootNode && !isAssertion && !stillInProgress && node.parent.name !== 'waitUntil') {
         node.done = true;
         this.resolveNode(node.parent, result, ++times);
       }

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -95,7 +95,7 @@ class AsyncTree extends EventEmitter{
     const parentNode = node.parent;
 
     if (!parentNode || parentNode.isRootNode) {
-      return false;
+      return true;
     }
 
     const result = parentNode.options?.avoidPrematureParentNodeResolution;

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -91,6 +91,14 @@ class AsyncTree extends EventEmitter{
     return parentNode.childNodes.filter(item => item !== node && !item.done).length > 0;
   }
 
+  resolveParentNodeWithResult(node) {
+    const parentNode = node.parent;
+    if (!parentNode || !parentNode.options) {return true}
+    const result = parentNode.options.resolveParentNodeWithResult;
+
+    return result;
+  }
+
   shouldRejectNodePromise(err, node = this.currentNode) {
     if ((err.isExpect || node.namespace === 'assert') && this.currentNode.isES6Async) {
       return true;
@@ -183,13 +191,13 @@ class AsyncTree extends EventEmitter{
 
     setTimeout(() => {
       const stillInProgress = this.otherChildNodesInProgress(node);
-
+      const resolveParent = this.resolveParentNodeWithResult(node);
       if (node.context && node.context instanceof EventEmitter) {
         node.context.emit('complete');
       }
 
       const isAssertion = node.parent && (node.parent.namespace === 'assert' || node.parent.namespace === 'verify');
-      if (node.parent && !node.parent.isRootNode && !isAssertion && !stillInProgress && node.parent.name !== 'waitUntil') {
+      if (node.parent && !node.parent.isRootNode && !isAssertion && !stillInProgress && resolveParent) {
         node.done = true;
         this.resolveNode(node.parent, result, ++times);
       }

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -196,6 +196,7 @@ class AsyncTree extends EventEmitter{
     setTimeout(() => {
       const stillInProgress = this.otherChildNodesInProgress(node);
       const avoidPrematureParentNodeResolution = this.shouldAvoidParentNodeResolution(node);
+
       if (node.context && node.context instanceof EventEmitter) {
         node.context.emit('complete');
       }


### PR DESCRIPTION
WaitUntil was getting prematurely resolved when used with async await. That is because inside the command queue tree, whenever child nodes are resolved, the parent node is also automatically called to be resolved which was causing pre mature resolution of waitUntil.