### PR TITLE
Fix `debug()` allowing only one command run in async/await mode.

### DIFF
--- a/lib/api/client-commands/debug.js
+++ b/lib/api/client-commands/debug.js
@@ -1,15 +1,16 @@
-const util = require('util');
 const EventEmitter = require('events');
 const NightwatchRepl = require('../../testsuite/repl');
 const Debuggability = require('../../utils/debuggability.js');
 
 /**
  * This command halts the test execution and provides users with a REPL interface where they can type
- * any of the available Nightwatch commands and the command will be executed in the running browser
+ * any of the available Nightwatch commands or assertions and it will be executed in the running browser
  * in real-time.
  *
- * This can be used to debug why a certain command in not working as expected, find the correct
- * locators for your assertions or just play around with the available Nightwatch commands.
+ * This can be used to debug why a certain command in not working as expected or a certain assertion is
+ * failing by trying out the commands and assertions in different ways (trying an assertion with different
+ * locators until the correct one if found), or just play around with the available Nightwatch commands
+ * and assertions.
  *
  * @example
  * // async function is required while using the debug
@@ -26,52 +27,51 @@ const Debuggability = require('../../utils/debuggability.js');
  * };
  *
  * @method debug
- * @param {object} config Config options for the REPL interface.
+ * @param {object} [config] Config options for the REPL interface.
  * @param {function} [callback] Optional callback function to be called when the command finishes.
  * @api protocol.utilities
  */
-
-function Debug() {
-  EventEmitter.call(this);
-}
-
-util.inherits(Debug, EventEmitter);
-
-Debug.prototype.command = function(config, cb) {
-  const repl = new NightwatchRepl(config);
-
-  // eslint-disable-next-line
-  console.log(NightwatchRepl.introMessage());
-
-  // Create context for vm
-  const context = {
-    browser: this.api,
-    app: this.api
-  };
-  if (config?.selector) {
-    this.api.executeScript('console.log("Element ' + config.selector + ':", document.querySelector("' + config.selector + '"))');
+class Debug extends EventEmitter {
+  static get avoidPrematureParentNodeResolution() {
+    return true;
   }
-  // Before starting REPL server, Set debugMode to true
-  Debuggability.debugMode = true;
-  // Set isES6AsyncTestcase to true in debugmode
-  const isES6AsyncTestcase = this.client.isES6AsyncTestcase;
-  this.client.isES6AsyncTestcase = true;
-  repl.startServer(context);
 
-  repl.onExit(() => {
-    // On exit, Set debugMode to false
-    Debuggability.debugMode = false;
-    this.client.isES6AsyncTestcase = isES6AsyncTestcase;
+  command(config, callback) {
+    const repl = new NightwatchRepl(config);
 
-    // if we have a callback, call it right before the complete event
-    if (cb) {
-      cb.call(this.client.api);
+    // eslint-disable-next-line
+    console.log(NightwatchRepl.introMessage());
+
+    // Create context for vm
+    const context = {
+      browser: this.api,
+      app: this.api
+    };
+    if (config?.selector) {
+      this.api.executeScript('console.log("Element ' + config.selector + ':", document.querySelector("' + config.selector + '"))');
     }
+    // Before starting REPL server, Set debugMode to true
+    Debuggability.debugMode = true;
+    // Set isES6AsyncTestcase to true in debugmode
+    const isES6AsyncTestcase = this.client.isES6AsyncTestcase;
+    this.client.isES6AsyncTestcase = true;
+    repl.startServer(context);
 
-    this.emit('complete');
-  });
+    repl.onExit(() => {
+      // On exit, Set debugMode to false
+      Debuggability.debugMode = false;
+      this.client.isES6AsyncTestcase = isES6AsyncTestcase;
 
-  return this;
-};
+      // if we have a callback, call it right before the complete event
+      if (callback) {
+        callback.call(this.client.api);
+      }
+
+      this.emit('complete');
+    });
+
+    return this;
+  }
+}
 
 module.exports = Debug;

--- a/lib/api/client-commands/pause.js
+++ b/lib/api/client-commands/pause.js
@@ -1,7 +1,5 @@
-const util = require('util');
 const EventEmitter = require('events');
 const readline = require('readline');
-const tty = require('tty');
 const Debuggability = require('../../utils/debuggability.js');
 
 /**
@@ -31,65 +29,63 @@ const Debuggability = require('../../utils/debuggability.js');
  * @param {function} [callback] Optional callback function to be called when the command finishes.
  * @api protocol.utilities
  */
+class Pause extends EventEmitter {
 
-function Pause() {
-  EventEmitter.call(this);
-}
+  command(ms, callback) {
+    // If we don't pass the milliseconds, the client will
+    // be suspended indefinitely, until the user presses some
+    // key in the terminal to resume it.
+    if (ms === undefined) {
+      // eslint-disable-next-line
+      console.log(`Paused...
+    Press <space> or F10 to step over to the next test command and pause again.
+    Press Ctrl+C to exit.
+    Press any other key to RESUME.`);
 
-util.inherits(Pause, EventEmitter);
-
-Pause.prototype.command = function(ms, cb) {
-  // If we don't pass the milliseconds, the client will
-  // be suspended indefinitely, until the user presses some
-  // key in the terminal to resume it.
-  if (ms === undefined) {
-    // eslint-disable-next-line
-    console.log(`Paused...
-  Press <space> or F10 to step over to the next test command and pause again.
-  Press Ctrl+C to exit.
-  Press any other key to RESUME.`);
-
-    readline.emitKeypressEvents(process.stdin);
-    process.stdin.resume();
-    if (process.stdin.isTTY) {
-      process.stdin.setRawMode(true);
-    }
-    process.stdin.once('keypress', (str, key) => {
-      if (key.ctrl && key.name === 'c') {
-        this.api.end(function() {
-          process.exit(0);
-        });
-      } else if (key.name === 'space' || key.name === 'f10') {
-        Debuggability.stepOverAndPause = true;
-      }
-
+      readline.emitKeypressEvents(process.stdin);
+      process.stdin.resume();
       if (process.stdin.isTTY) {
-        process.stdin.setRawMode(false);
+        process.stdin.setRawMode(true);
       }
-      process.stdin.pause();
+      process.stdin.once('keypress', (str, key) => {
+        if (key.ctrl && key.name === 'c') {
+          this.api.end(function() {
+            process.exit(0);
+          });
+        } else if (key.name === 'space' || key.name === 'f10') {
+          Debuggability.stepOverAndPause = true;
+        } else if (key.name === 'd') {
+          this.api.debug();
+        }
 
-      // Remove the logged paused... information above
-      readline.moveCursor(process.stdout, 0, -4);
-      readline.clearScreenDown(process.stdout);
+        if (process.stdin.isTTY) {
+          process.stdin.setRawMode(false);
+        }
+        process.stdin.pause();
 
-      if (cb) {
-        cb.call(this.client.api);
-      }
+        // Remove the logged paused... information above
+        readline.moveCursor(process.stdout, 0, -4);
+        readline.clearScreenDown(process.stdout);
 
-      this.emit('complete');
-    });
-  } else {
-    setTimeout(() => {
-      // if we have a callback, call it right before the complete event
-      if (cb) {
-        cb.call(this.client.api);
-      }
+        if (callback) {
+          callback.call(this.client.api);
+        }
 
-      this.emit('complete');
-    }, ms);
+        this.emit('complete');
+      });
+    } else {
+      setTimeout(() => {
+        // if we have a callback, call it right before the complete event
+        if (callback) {
+          callback.call(this.client.api);
+        }
+
+        this.emit('complete');
+      }, ms);
+    }
+
+    return this;
   }
-
-  return this;
-};
+}
 
 module.exports = Pause;

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -196,7 +196,6 @@ class AsyncTree extends EventEmitter{
     setTimeout(() => {
       const stillInProgress = this.otherChildNodesInProgress(node);
       const avoidPrematureParentNodeResolution = this.shouldAvoidParentNodeResolution(node);
-
       if (node.context && node.context instanceof EventEmitter) {
         node.context.emit('complete');
       }

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -196,6 +196,7 @@ class AsyncTree extends EventEmitter{
     setTimeout(() => {
       const stillInProgress = this.otherChildNodesInProgress(node);
       const avoidPrematureParentNodeResolution = this.shouldAvoidParentNodeResolution(node);
+
       if (node.context && node.context instanceof EventEmitter) {
         node.context.emit('complete');
       }


### PR DESCRIPTION
Debug command similar to WaitUntil was getting prematurely resolved when used with async await. That is because inside the command queue tree, whenever child nodes are resolved, the parent node is also automatically called to be resolved which was causing pre mature resolution of debug.