### PR TITLE
Passing globals to persist in parallel test runs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -277,6 +277,8 @@ Nightwatch.cli = function(callback) {
 Nightwatch.runTests = async function(testSource, settings) {
   let argv;
 
+  settings.globals = testSource.globals;
+  delete testSource.globals;
   if (arguments.length <= 1) {
     settings = arguments[0] || {};
     argv = {};

--- a/lib/runner/concurrency/worker-task.js
+++ b/lib/runner/concurrency/worker-task.js
@@ -2,7 +2,7 @@ const boxen = require('boxen');
 const {MessageChannel} = require('worker_threads');
 const {Logger, symbols} = require('../../utils');
 const EventEmitter = require('events');
-const {isString} = require('../../utils');
+const {isString, SafeJSON} = require('../../utils');
 
 let prevIndex = 0;
 
@@ -96,6 +96,7 @@ class WorkerTask extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       setTimeout(() => {
+        this.argv.globals = JSON.parse(SafeJSON.stringify(this.settings.globals));
         this.piscina.run({argv: this.argv, port1}, {transferList: [port1]})
           .catch(err => err)
           .then(failures => {


### PR DESCRIPTION
In order to persist globals in parallel test runs In these changes, I have passed `globals` to `argv` like we did to config settings, as an object. 
- [ ] Before marking your PR for review, please test and verify your changes by making appropriate modifications to any of the Nightwatch example tests (present in `examples/tests` directory of the project) and running them. `ecosia.js` and `duckDuckGo.js` are good examples to work with.
- [ ] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [ ] If you're fixing a bug also create an issue if one doesn't exist yet;
- [ ] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [ ] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [ ] Do not include changes that are not related to the issue at hand;
- [ ] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [ ] Always add unit tests - PRs without tests are most of the times ignored.
