### PR TITLE
fix .verify not throws custom assertion errors

### DIFF
--- a/lib/testsuite/index.js
+++ b/lib/testsuite/index.js
@@ -836,38 +836,38 @@ class TestSuite {
           testcase: this.reporter.testResults.currentTestName
         });
 
-        return this.handleRunnable(this.testcase.testName, () => this.testcase.run(this.client));
-      })
-      .catch(err => {
-        return err;
-      })
-      .then(possibleError => {
-        this.client.reporter.unmarkHookRun();
+        this.handleRunnable(this.testcase.testName, () => this.testcase.run(this.client)).then(async possibleError => {
+          this.client.reporter.unmarkHookRun();
 
-        NightwatchEventHub.emit(TestSuiteHook.test.finished, {
-          ...this.reporter.testResults.eventDataToEmit,
-          testcase: this.reporter.testResults.currentTestName
-        });
+          NightwatchEventHub.emit(TestSuiteHook.test.finished, {
+            ...this.reporter.testResults.eventDataToEmit,
+            testcase: this.reporter.testResults.currentTestName
+          });
 
-        if (this.transport.driverService && this.reporter.testResults) {
-          this.reporter.testResults.setSeleniumLogFile(this.transport.driverService.getSeleniumOutputFilePath());
-        }
+          if (this.transport.driverService && this.reporter.testResults) {
+            this.reporter.testResults.setSeleniumLogFile(this.transport.driverService.getSeleniumOutputFilePath());
+          }
 
-        // if there was an error in the testcase and skip_testcases_on_fail, we must send it forward, but after we run afterEach and after hooks
-        return this.runHook('afterEach')
-          .then(() => this.testCaseFinished())
-          .then(() => possibleError);
-      })
-      .then(possibleError => {
-        if (this.shouldRetryTestCase()) {
-          return this.retryCurrentTestCase();
-        }
+          // if there was an error in the testcase and skip_testcases_on_fail, we must send it forward, but after we run afterEach and after hooks
+          await this.runHook('afterEach');
+          this.testCaseFinished();
 
-        if ((possibleError instanceof Error) && this.shouldSkipTestsOnFail()) {
-          throw possibleError;
-        }
+          return possibleError;
+        })
+          .then(possibleError => {
 
-        return this.runNextTestCase();
+            if (this.shouldRetryTestCase()) {
+              return this.retryCurrentTestCase();
+            }
+
+            if ((possibleError instanceof Error) && this.shouldSkipTestsOnFail()) {
+              throw possibleError;
+            }
+
+            return this.runNextTestCase();
+          }).catch(err => {
+            return err;
+          });
       });
   }
 


### PR DESCRIPTION
Fixes #4147

`possibleError` becomes undefined for .verify but not for .assert, so i made changes so that we wait before throwing possibleError.
With these changes .verify and .assert throws the error and is visible in the console output.

- [ ] Before marking your PR for review, please test and verify your changes by making appropriate modifications to any of the Nightwatch example tests (present in `examples/tests` directory of the project) and running them. `ecosia.js` and `duckDuckGo.js` are good examples to work with.
- [ ] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [ ] If you're fixing a bug also create an issue if one doesn't exist yet;
- [ ] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [ ] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [ ] Do not include changes that are not related to the issue at hand;
- [ ] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [ ] Always add unit tests - PRs without tests are most of the times ignored.
