### PR TITLE
Add `ariaRole()` as alias for `getAriaRole()`

### DIFF
--- a/lib/api/web-element/commands/getAriaRole.js
+++ b/lib/api/web-element/commands/getAriaRole.js
@@ -22,7 +22,6 @@
  * @syntax browser.element(selector).getAriaRole()
  * @see https://www.w3.org/TR/webdriver#dfn-get-computed-role
  * @returns {ScopedValue<string>} The container with computed WAI-ARIA role of an element.
- * @alias ariaRole
  */
 module.exports.command = function() {
   return this.runQueuedCommandScoped('getElementAriaRole');

--- a/lib/api/web-element/commands/getAriaRole.js
+++ b/lib/api/web-element/commands/getAriaRole.js
@@ -22,6 +22,7 @@
  * @syntax browser.element(selector).getAriaRole()
  * @see https://www.w3.org/TR/webdriver#dfn-get-computed-role
  * @returns {ScopedValue<string>} The container with computed WAI-ARIA role of an element.
+ * @alias ariaRole
  */
 module.exports.command = function() {
   return this.runQueuedCommandScoped('getElementAriaRole');

--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -25,7 +25,8 @@ class ScopedWebElement {
       'getRect': ['getSize', 'getLocation', 'rect'],
       'getProperty': ['property'],
       'getCssProperty': ['css'],
-      'isVisible': ['isDisplayed']
+      'isVisible': ['isDisplayed'],
+      'getAriaRole': ['ariaRole']
     };
   }
 

--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -25,8 +25,8 @@ class ScopedWebElement {
       'getRect': ['getSize', 'getLocation', 'rect'],
       'getProperty': ['property'],
       'getCssProperty': ['css'],
-      'isVisible': ['isDisplayed'],
-      'getAriaRole': ['ariaRole']
+      'getAriaRole': ['ariaRole'],
+      'isVisible': ['isDisplayed']
     };
   }
 

--- a/test/src/api/commands/web-element/testGetAriaRole.js
+++ b/test/src/api/commands/web-element/testGetAriaRole.js
@@ -38,6 +38,30 @@ describe('element().getAriaRole() command', function () {
     assert.strictEqual(resultValue, 'signupSection');
   });
 
+  it('test .element().ariaRole()', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/computedrole',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'signupSection'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').ariaRole();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'signupSection');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'signupSection');
+  });
+
   it('test .element().find().getAriaRole()', async function() {
     MockServer.addMock({
       url: '/session/13521-10219-202/element/1/computedrole',

--- a/types/tests/webElement.test-d.ts
+++ b/types/tests/webElement.test-d.ts
@@ -151,6 +151,7 @@ describe('new element() api', function () {
 
     expectType<ElementValue<string>>(elem.getAccessibleName());
     expectType<ElementValue<string>>(elem.getAriaRole());
+    expectType<ElementValue<string>>(elem.ariaRole());
     expectType<ElementValue<string>>(elem.getCssProperty('height'));
     expectType<ElementValue<string>>(elem.takeScreenshot());
 

--- a/types/web-element.d.ts
+++ b/types/web-element.d.ts
@@ -178,7 +178,6 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
   getAccessibleName(): ElementValue<string>;
 
   getAriaRole(): ElementValue<string>;
-
   ariaRole(): ElementValue<string>;
 
   getCssProperty(name: string): ElementValue<string>;

--- a/types/web-element.d.ts
+++ b/types/web-element.d.ts
@@ -179,6 +179,8 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   getAriaRole(): ElementValue<string>;
 
+  ariaRole(): ElementValue<string>;
+
   getCssProperty(name: string): ElementValue<string>;
 
   getValue(): ElementValue<string | null>;


### PR DESCRIPTION
Adds the `ariaRole()` alias for `getAriaRole()` as mentioned in #3901. 

Running an example test: 
![image](https://github.com/nightwatchjs/nightwatch/assets/25991050/789933bb-6c1f-4830-bd03-64e4e432ea52)

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.

- [x] Before marking your PR for review, please test and verify your changes by making appropriate modifications to any of the Nightwatch example tests (present in `examples/tests` directory of the project) and running them. `ecosia.js` and `duckDuckGo.js` are good examples to work with.
- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [x] If you're fixing a bug also create an issue if one doesn't exist yet;
- [x] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [x] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [x] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [x] Do not include changes that are not related to the issue at hand;
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [x] Always add unit tests - PRs without tests are most of the times ignored.
