### PR TITLE
Fix bug that aborts test when waitUntil throws error. #4157

### DIFF
--- a/lib/api/_loaders/_command-loader.js
+++ b/lib/api/_loaders/_command-loader.js
@@ -35,9 +35,9 @@ class BaseCommandLoader extends BaseLoader {
     const alwaysAsync = this.module.alwaysAsync || false;
     const isTraceable = this.module.isTraceable;
     const avoidPrematureParentNodeResolution = !!this.module.avoidPrematureParentNodeResolution;
-    const rejectNodeOnFailure = !!this.module.rejectNodeOnFailure;
+    const rejectNodeOnAbortFailure = !!this.module.rejectNodeOnAbortFailure;
 
-    return {redact, alwaysAsync, isTraceable, avoidPrematureParentNodeResolution, rejectNodeOnFailure};
+    return {redact, alwaysAsync, isTraceable, avoidPrematureParentNodeResolution, rejectNodeOnAbortFailure};
   }
 
   validateMethod(parent) {

--- a/lib/api/_loaders/_command-loader.js
+++ b/lib/api/_loaders/_command-loader.js
@@ -35,9 +35,9 @@ class BaseCommandLoader extends BaseLoader {
     const alwaysAsync = this.module.alwaysAsync || false;
     const isTraceable = this.module.isTraceable;
     const avoidPrematureParentNodeResolution = !!this.module.avoidPrematureParentNodeResolution;
-    const rejectNodePromiseWhenThrownError = !!this.module.rejectNodePromiseWhenThrownError;
+    const rejectNodeOnFailure = !!this.module.rejectNodeOnFailure;
 
-    return {redact, alwaysAsync, isTraceable, avoidPrematureParentNodeResolution, rejectNodePromiseWhenThrownError};
+    return {redact, alwaysAsync, isTraceable, avoidPrematureParentNodeResolution, rejectNodeOnFailure};
   }
 
   validateMethod(parent) {

--- a/lib/api/_loaders/_command-loader.js
+++ b/lib/api/_loaders/_command-loader.js
@@ -35,8 +35,9 @@ class BaseCommandLoader extends BaseLoader {
     const alwaysAsync = this.module.alwaysAsync || false;
     const isTraceable = this.module.isTraceable;
     const avoidPrematureParentNodeResolution = !!this.module.avoidPrematureParentNodeResolution;
+    const rejectNodePromiseWhenThrownError = !!this.module.rejectNodePromiseWhenThrownError;
 
-    return {redact, alwaysAsync, isTraceable, avoidPrematureParentNodeResolution};
+    return {redact, alwaysAsync, isTraceable, avoidPrematureParentNodeResolution, rejectNodePromiseWhenThrownError};
   }
 
   validateMethod(parent) {

--- a/lib/api/protocol/waitUntil.js
+++ b/lib/api/protocol/waitUntil.js
@@ -65,7 +65,7 @@ module.exports = class WaitUntil extends ProtocolAction {
     return true;
   }
 
-  static get rejectNodePromiseWhenThrownError() {
+  static get rejectNodeOnFailure() {
     return true;
   }
 

--- a/lib/api/protocol/waitUntil.js
+++ b/lib/api/protocol/waitUntil.js
@@ -65,7 +65,7 @@ module.exports = class WaitUntil extends ProtocolAction {
     return true;
   }
 
-  static get rejectNodeOnFailure() {
+  static get rejectNodeOnAbortFailure() {
     return true;
   }
 

--- a/lib/api/protocol/waitUntil.js
+++ b/lib/api/protocol/waitUntil.js
@@ -65,6 +65,10 @@ module.exports = class WaitUntil extends ProtocolAction {
     return true;
   }
 
+  static get rejectNodePromiseWhenThrownError() {
+    return true;
+  }
+
   //timeMs, retryInterval, message, callback = function(r) {return r}
   async command(conditionFn, ...args) {
     let callback = function(r) {return r};

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -104,7 +104,8 @@ class AsyncTree extends EventEmitter{
   }
 
   shouldRejectNodePromise(err, node = this.currentNode) {
-    if ((err.isExpect || node.namespace === 'assert') && this.currentNode.isES6Async) {
+    const rejectNodePromise = node.options?.rejectNodePromiseWhenThrownError;
+    if ((err.isExpect || node.namespace === 'assert' || rejectNodePromise) && this.currentNode.isES6Async) {
       return true;
     }
 

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -103,9 +103,8 @@ class AsyncTree extends EventEmitter{
     return Boolean(result);
   }
 
-  shouldRejectNodePromise(err, node = this.currentNode) {
+  shouldRejectNodePromise(err, abortOnFailure, node = this.currentNode) {
     const rejectNodeOnFailure = node.options?.rejectNodeOnFailure;
-    const abortOnFailure = err.abortOnFailure || Utils.isUndefined(err.abortOnFailure);
     if ((err.isExpect || node.namespace === 'assert' || (rejectNodeOnFailure && abortOnFailure)) && this.currentNode.isES6Async) {
       return true;
     }
@@ -148,7 +147,7 @@ class AsyncTree extends EventEmitter{
         err.stack = err.stack.split('\n').slice(1).join('\n');
       }
 
-      if (this.shouldRejectNodePromise(err, node)) {
+      if (this.shouldRejectNodePromise(err, abortOnFailure, node)) {
         node.reject(err);
       } else {
         node.resolve(err);

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -104,8 +104,9 @@ class AsyncTree extends EventEmitter{
   }
 
   shouldRejectNodePromise(err, abortOnFailure, node = this.currentNode) {
-    const rejectNodeOnFailure = node.options?.rejectNodeOnFailure;
-    if ((err.isExpect || node.namespace === 'assert' || (rejectNodeOnFailure && abortOnFailure)) && this.currentNode.isES6Async) {
+    const rejectNodeOnAbortFailure = node.options?.rejectNodeOnAbortFailure;
+
+    if ((err.isExpect || node.namespace === 'assert' || (abortOnFailure && rejectNodeOnAbortFailure)) && this.currentNode.isES6Async) {
       return true;
     }
 

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -105,7 +105,8 @@ class AsyncTree extends EventEmitter{
 
   shouldRejectNodePromise(err, node = this.currentNode) {
     const rejectNodePromise = node.options?.rejectNodePromiseWhenThrownError;
-    if ((err.isExpect || node.namespace === 'assert' || rejectNodePromise) && this.currentNode.isES6Async) {
+    const abortOnFailure = err.abortOnFailure || Utils.isUndefined(err.abortOnFailure);
+    if ((err.isExpect || node.namespace === 'assert' || (rejectNodePromise && abortOnFailure)) && this.currentNode.isES6Async) {
       return true;
     }
 

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -104,9 +104,9 @@ class AsyncTree extends EventEmitter{
   }
 
   shouldRejectNodePromise(err, node = this.currentNode) {
-    const rejectNodePromise = node.options?.rejectNodePromiseWhenThrownError;
+    const rejectNodeOnFailure = node.options?.rejectNodeOnFailure;
     const abortOnFailure = err.abortOnFailure || Utils.isUndefined(err.abortOnFailure);
-    if ((err.isExpect || node.namespace === 'assert' || (rejectNodePromise && abortOnFailure)) && this.currentNode.isES6Async) {
+    if ((err.isExpect || node.namespace === 'assert' || (rejectNodeOnFailure && abortOnFailure)) && this.currentNode.isES6Async) {
       return true;
     }
 


### PR DESCRIPTION
Test case was not aborting when waitUntil was throwing error. The reason for the same is that whenever waitUntil throws error, the resolveNode method inside asyncTree.js just resolves the waitUntil node and thus the execution moves forward by adding new nodes and continuing the execution. To fix this, we need to reject node in case there's an error thrown thus we have introduced a flag which would help in knowing if we want to resolve the node or reject it.