### PR TITLE
Refactor shouldRejectNodePromise method in AsyncTree class

### DIFF
--- a/nightwatch/custom-assertions/elementHasCount.js
+++ b/nightwatch/custom-assertions/elementHasCount.js
@@ -1,0 +1,45 @@
+/**
+ * A custom Nightwatch assertion. The assertion name is the filename.
+ *
+ * Example usage:
+ *   browser.assert.elementHasCount(selector, count)
+ *
+ * For more information on custom assertions see:
+ *   https://nightwatchjs.org/guide/extending-nightwatch/adding-custom-assertions.html
+ *
+ * @param {string} selector
+ * @param {number} count
+ */
+
+exports.assertion = function elementHasCount(selector, count) {
+  // Message to be displayed on the console while running this assertion.
+  this.message = `Testing if element <${selector}> has count: ${count}`;
+
+  // Expected value of the assertion, to be displayed in case of failure.
+  this.expected = count;
+
+  // Given the result value (from `this.value` below), this function will
+  // evaluate if the assertion has passed.
+  this.evaluate = function(value) {
+    return value === count;
+  };
+
+  // Retrieve the value from the result object we got after running the
+  // assertion command (defined below), which is to be evaluated against
+  // the value passed into the assertion as the second argument.
+  this.value = function(result) {
+    return result.value;
+  };
+
+  // Script to be executed in the browser to find the actual element count.
+  function elementCountScript(_selector) {
+    // eslint-disable-next-line
+    return document.querySelectorAll(_selector).length;
+  }
+
+  // The command to be executed by the assertion runner, to find the actual
+  // result. Nightwatch API is available as `this.api`.
+  this.command = function(callback) {
+    this.api.execute(elementCountScript, [selector], callback);
+  };
+};

--- a/nightwatch/custom-commands/angular/getElementsInList.js
+++ b/nightwatch/custom-commands/angular/getElementsInList.js
@@ -1,0 +1,50 @@
+/**
+ * A class-based custom-command in Nightwatch. The command name is the filename.
+ *
+ * Usage:
+ *   browser.angular.getElementsInList(listName)
+ *
+ * See the example test using this object:
+ *   specs/with-custom-commands/angularTodo.js
+ *
+ * For more information on working with custom-commands see:
+ *   https://nightwatchjs.org/guide/extending-nightwatch/adding-custom-commands.html
+ *
+ * @param {string} listName Name of the list
+ * @param {function} cb Callback to be called with the result returned by the executed script
+ */
+
+module.exports = class AngularCommand {
+
+  async command(listName, cb = function(r) {return r}) {
+    // Script to be executed in the browser
+    const script = function(listName) {
+      // executed in the browser context
+      // eslint-disable-next-line
+      var elements = document.querySelectorAll('*[ng-repeat$="'+listName+'"]');
+
+      if (elements) {return elements}
+
+      return null;
+    };
+
+    // Arguments to be passed to the script function above
+    const args = [listName];
+
+    // Callback to be called when the script finishes its execution,
+    // with the result returned by the script passed as argument.
+    const callback = async function(result) {
+      const cbResult = await cb(result);
+
+      if (cbResult.value) {
+        return cbResult.value;
+      }
+
+      return cbResult;
+    };
+
+    // Execute the script defined above, along with arguments and
+    // the callback function.
+    return this.api.executeScript(script, args, callback);
+  }
+};

--- a/nightwatch/custom-commands/strictClick.js
+++ b/nightwatch/custom-commands/strictClick.js
@@ -1,0 +1,20 @@
+/**
+ * A non-class-based custom-command in Nightwatch. The command name is the filename.
+ *
+ * Usage:
+ *   browser.strictClick(selector)
+ *
+ * This command is not used yet used in any of the examples.
+ *
+ * For more information on working with custom-commands see:
+ *   https://nightwatchjs.org/guide/extending-nightwatch/adding-custom-commands.html
+ *
+ */
+
+module.exports = {
+  command: function(selector) {
+    return this
+      .waitForElementVisible(selector)
+      .click(selector);
+  }
+};

--- a/nightwatch/examples/accessibilty-tests/websiteAccessibility.js
+++ b/nightwatch/examples/accessibilty-tests/websiteAccessibility.js
@@ -1,0 +1,24 @@
+/**
+ * Rules the aXe uses:
+ * https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md
+ *
+ *
+ */
+
+describe('accessibilty tests for nightwatch website', function() {
+
+  before(async function() {
+    browser.navigateTo('https://nightwatchjs.org');
+    await browser.axeInject();
+  });
+
+  after(function() {
+    browser.end();
+  });
+
+  it('Nightwatch website page has accessible headers', function(browser) {
+    browser.axeRun('body', {
+      runOnly: ['empty-heading', 'page-has-heading-one', 'p-as-heading']
+    });
+  });
+});

--- a/nightwatch/examples/basic/duckDuckGo.js
+++ b/nightwatch/examples/basic/duckDuckGo.js
@@ -1,0 +1,11 @@
+describe('duckduckgo example', function() {
+  it('Search Nightwatch.js and check results', function(browser) {
+    browser
+      .navigateTo('https://duckduckgo.com')
+      .waitForElementVisible('input[name=q]')
+      .sendKeys('input[name=q]', ['Nightwatch.js'])
+      .click('*[type="submit"]')
+      .assert.visible('#react-layout')
+      .assert.textContains('#react-layout', 'Nightwatch.js');
+  });
+});

--- a/nightwatch/examples/basic/ecosia.js
+++ b/nightwatch/examples/basic/ecosia.js
@@ -1,0 +1,16 @@
+describe('Ecosia.org Demo', function() {
+  before(browser => browser.navigateTo('https://www.ecosia.org/'));
+
+  it('Demo test ecosia.org', function(browser) {
+    browser
+      .waitForElementVisible('body')
+      .assert.titleContains('Ecosia')
+      .assert.visible('input[type=search]')
+      .setValue('input[type=search]', 'nightwatch')
+      .assert.visible('button[type=submit]')
+      .click('button[type=submit]')
+      .assert.textContains('.layout__content', 'Nightwatch.js');
+  });
+
+  after(browser => browser.end());
+});

--- a/nightwatch/examples/basic/todoList.js
+++ b/nightwatch/examples/basic/todoList.js
@@ -1,0 +1,46 @@
+/**
+ * End-to-end test for the sample Vue3+Vite todo app located at
+ * https://github.com/nightwatchjs-community/todo-vue
+ */
+describe('To-Do List End-to-End Test', function() {
+
+  // using the new element() global utility in Nightwatch 2 to init elements
+  // before tests and use them later
+  const todoElement = element('#new-todo-input');
+  const addButtonEl = element('form button[type="submit"]');
+
+  it('should add a todo using global element()', async function() {
+    ///////////////////////////////////////////////////
+    // browser can now also be accessed as a global   |
+    ///////////////////////////////////////////////////
+
+    // adding a new task to the list
+    await browser
+      .navigateTo('https://todo-vue3-vite.netlify.app/')
+      .sendKeys(todoElement, 'what is nightwatch?')
+      .click(addButtonEl);
+
+    ///////////////////////////////////////////////////
+    // global expect is equivalent to browser.expect  |
+    ///////////////////////////////////////////////////
+
+    // verifying if there are 5 tasks in the list
+    await expect.elements('#todo-list ul li').count.toEqual(5);
+
+    // verifying if the 4th task if the one we have just added
+    const lastElementTask = element({
+      selector: '#todo-list ul li',
+      index: 4
+    });
+
+    await expect(lastElementTask).text.toContain('what is nightwatch?');
+
+    // find our task in the list and mark it as done
+    const inputElement = await lastElementTask.findElement('input[type="checkbox"]');
+    await browser.click(inputElement);
+
+    // verify if there are 3 tasks which are marked as done in the list
+    await expect.elements('#todo-list ul li input:checked').count.toEqual(3);
+  });
+
+});

--- a/nightwatch/examples/with-custom-assertions/todoList.js
+++ b/nightwatch/examples/with-custom-assertions/todoList.js
@@ -1,0 +1,23 @@
+/**
+ * This example is a slight modification of the example already available at:
+ *   specs/basic/todoList.js
+ *
+ * This example demonstrate the use of custom-assertion defined at:
+ *   custom-assertions/elementHasCount.js
+ *
+ * For more information on working with custom-assertions, see:
+ *   https://nightwatchjs.org/guide/extending-nightwatch/adding-custom-assertions.html
+ *
+ */
+
+describe('To-Do List End-to-End Test', function() {
+  it('should add a new todo element', async function() {
+    // adding a new task to the list
+    await browser
+      .navigateTo('https://todo-vue3-vite.netlify.app/')
+      .assert.elementHasCount('#todo-list ul li', 4) // use of custom-assertion
+      .sendKeys('#new-todo-input', 'what is nightwatch?')
+      .click('form button[type="submit"]')
+      .assert.elementHasCount('#todo-list ul li', 5); // use of custom-assertion
+  });
+});

--- a/nightwatch/examples/with-custom-commands/angularTodo.js
+++ b/nightwatch/examples/with-custom-commands/angularTodo.js
@@ -1,0 +1,33 @@
+/**
+ * This example uses the custom-command defined at:
+ *   custom-commands/angular/getElementsInList.js
+ *
+ * For more information on working with custom-commands, see:
+ *   https://nightwatchjs.org/guide/extending-nightwatch/adding-custom-commands.html
+ *
+ */
+
+describe('angularjs homepage todo list', function() {
+  it('should add a todo using custom commands', async function(browser) {
+    // adding a new task to the list
+    const elements = await browser
+      .navigateTo('https://angularjs.org')
+      .sendKeys('[ng-model="todoList.todoText"]', 'what is nightwatch?')
+      .click('[value="add"]')
+      .angular.getElementsInList('todoList.todos'); // use of custom-command
+
+    const taskEl = element(elements[2]);
+
+    // verifying if the third task is the one we have just added
+    // browser.assert.textEquals(taskEl, 'what is nightwatch?');
+
+    await expect(taskEl).text.toEqual('what is nightwatch?');
+
+    // find our task in the list and mark it as done
+    const inputElement = await element(elements[2]).findElement('input');
+    await browser.click(inputElement);
+
+    // verify if there are 2 tasks which are marked as done in the list
+    await expect.elements('*[module=todoApp] li .done-true').count.to.equal(2);
+  });
+});

--- a/nightwatch/examples/with-page-objects/google.js
+++ b/nightwatch/examples/with-page-objects/google.js
@@ -1,0 +1,32 @@
+/**
+ * This example uses the page-objects defined at:
+ *   page-objects/google/search.js
+ *   page-objects/google/searchResults.js
+ *
+ *  For more information on working with page objects, see:
+ *   https://nightwatchjs.org/guide/concepts/page-object-model.html
+ *
+ */
+
+describe('google search with consent form - page objects', function() {
+  const homePage = browser.page.google.search(); // first page-object
+
+  before(async () => homePage.navigate());
+
+  after(async (browser) => browser.quit());
+
+  it('should find nightwatch.js in results', function(browser) {
+    homePage.setValue('@searchBar', 'Nightwatch.js');
+    homePage.submit();
+
+    const resultsPage = browser.page.google.searchResults(); // second page-object
+    resultsPage.expect.element('@results').to.be.present;
+
+    resultsPage.expect.element('@results').text.to.contain('Nightwatch.js');
+
+    resultsPage.expect.section('@menu').to.be.visible;
+
+    const menuSection = resultsPage.section.menu;
+    menuSection.expect.element('@all').to.be.visible;
+  });
+});

--- a/nightwatch/page-objects/google/search.js
+++ b/nightwatch/page-objects/google/search.js
@@ -1,0 +1,42 @@
+/**
+ * A Nightwatch page object. The page object name is the filename.
+ *
+ * Usage:
+ *   browser.page.google.search()
+ *
+ * See the example test using this object:
+ *   specs/with-page-objects/google.js
+ *
+ * For more information on working with page objects, see:
+ *   https://nightwatchjs.org/guide/concepts/page-object-model.html
+ *
+ */
+
+const searchCommands = {
+  submit() {
+    this.waitForElementVisible('@submitButton', 1000)
+      .click('@submitButton');
+
+    this.pause(1000);
+
+    return this; // for command-chaining
+  }
+};
+
+module.exports = {
+  url: 'https://google.no',
+
+  commands: [
+    searchCommands
+  ],
+
+  elements: {
+    searchBar: {
+      selector: 'textarea[name=q]'
+    },
+
+    submitButton: {
+      selector: 'input[value="Google Search"]'
+    }
+  }
+};

--- a/nightwatch/page-objects/google/searchResults.js
+++ b/nightwatch/page-objects/google/searchResults.js
@@ -1,0 +1,62 @@
+/**
+ * A Nightwatch page object. The page object name is the filename.
+ *
+ * Usage:
+ *   browser.page.google.searchResults()
+ *
+ * See the example test using this object:
+ *   specs/with-page-objects/google.js
+ *
+ * For more information on working with page objects, see:
+ *   https://nightwatchjs.org/guide/concepts/page-object-model.html
+ *
+ */
+
+const util = require('util');
+const menuXpath = '//div[contains(@class, "hdtb-mitem")][contains(., "%s")]';
+
+const menuCommands = {
+  productIsSelected: function(product, callback) {
+    var self = this;
+
+    return this.getAttribute(product, 'class', function(result) {
+      const isSelected = result.value.indexOf('hdtb-msel') > -1;
+      callback.call(self, isSelected);
+    });
+  }
+};
+
+module.exports = {
+  elements: {
+    results: {selector: '#rso'}
+  },
+
+  sections: {
+    menu: {
+      selector: '#hdtb-msb',
+      commands: [menuCommands],
+      elements: {
+        all: {
+          selector: util.format(menuXpath, 'All'),
+          locateStrategy: 'xpath',
+          index: 0
+        },
+        video: {
+          selector: util.format(menuXpath, 'Videos'),
+          locateStrategy: 'xpath',
+          index: 0
+        },
+        images: {
+          selector: util.format(menuXpath, 'Images'),
+          locateStrategy: 'xpath',
+          index: 0
+        },
+        news: {
+          selector: util.format(menuXpath, 'News'),
+          locateStrategy: 'xpath',
+          index: 0
+        }
+      }
+    }
+  }
+};

--- a/nightwatch/templates/login.js
+++ b/nightwatch/templates/login.js
@@ -1,0 +1,123 @@
+/**
+ * To learn more about the describe interface, refer to the following link :
+ * https://nightwatchjs.org/guide/writing-tests/test-syntax.html
+ */
+describe('The Login Page', function () {
+
+  /**
+   * This section will always execute before the test suite
+   * Read More : https://nightwatchjs.org/guide/writing-tests/using-test-hooks.html#before-beforeeach-after-aftereach
+   */
+  before(function (browser) {
+    /**
+     * Navigate to a URL :
+     *   - We need to navigate before performing any actions on the page
+     *     Read More : https://nightwatchjs.org/api/navigateTo.html
+     *
+     *   - <LOGIN-PAGE-URL> is a placeholder. Replace it with the actual URL, which you wanted to navigate and login
+     *
+     * Eg: browser.navigateTo('https://the-internet.herokuapp.com/login');
+     */
+
+    browser.navigateTo('<LOGIN-PAGE-URL>');
+  });
+
+
+  /* The following will perform the actual test/assertions */
+  it('To check session cookie after successful login', function(browser) {
+
+    /**
+     * Check if input box with id 'username' is present :
+     *   - Use elementPresent command, to check if the input box is present or not.
+     *     Read More : https://nightwatchjs.org/api/assert/#assert-elementPresent
+     *
+     *   - Pass in the css locator to check if the input box (username) is present.
+     *     Read More: https://www.selenium.dev/documentation/webdriver/elements/locators/
+     *
+     * Eg: browser.assert.elementPresent('input[id=username]');
+     */
+
+    browser.assert.elementPresent('<css locator>');
+
+
+    /**
+    * Enter the USERNAME :
+    *   - Use sendKeys command to fill the username input.
+    *     Read More : https://nightwatchjs.org/api/sendKeys.html
+    *
+    *   - <USERNAME> is a placeholder. Replace it with the actual username
+    *   - <css locator> will be same as above in elementPresent
+    *
+    * Eg: browser.sendKeys('input[id=username]', 'tomsmith');
+    */
+
+    browser.sendKeys('<css locator>', '<USERNAME>');
+
+
+    /**
+     * Check if input box with id 'password' is present :
+     *   - Pass in the css locator to check if the input box (password) is present.
+     *
+     * Eg: browser.assert.elementPresent('input[id=password]');
+     */
+
+    browser.assert.elementPresent('<css locator>');
+
+
+    /**
+      * Enter the Password and form submission :
+      *   - browser.Keys.ENTER is used to press ENTER keystroke after filling the password, to submit the form.
+      *   - <PASSWORD> is a placeholder. Replace it with the actual password
+      *   - <css locator> will be same as above passed for password in elementPresent command
+      *
+      * Eg: browser.sendKeys('input[id=password]', ['SuperSecretPassword!', browser.Keys.ENTER]);
+      */
+
+    browser.sendKeys('<css locator>', ['<PASSWORD>', browser.Keys.ENTER]);
+
+
+    /**
+     * If ENTER doesn't work for you then you can use 'click' command to click on submit button.
+     * Read More : https://nightwatchjs.org/api/click.html
+     *
+     * Eg: browser.click('css selector', 'button[type="submit"]');
+     */
+
+
+    /**
+     * Check the new URL is correct :
+     *   - Use urlContains command to check the URL of the current page.
+     *     Read More : https://nightwatchjs.org/api/assert/#assert-urlMatches
+     *
+     *   - <NEW-REDIRECTED-URL> is a placeholder. Replace it with the actual dashboard/profile URL
+     *
+     * Eg: browser.assert.urlContains('/secure');
+     */
+
+    browser.assert.urlContains('<NEW-REDIRECTED-URL>');
+
+
+    /**
+     * Check session cookie is present after successful login.
+     * Read More: https://nightwatchjs.org/api/getCookie.html
+     *
+     * Eg: browser.getCookie('rack.session', function callback(result) {
+     *       this.assert.equal(result.name, 'rack.session');
+     *       this.assert.equal(result.value.length, 532);
+     *     });
+     */
+
+    browser.getCookie('<cookie-name>', function callback(result) {
+      // add more assertions here to test the result
+      this.assert.equal(result.value, '<cookie-value>');
+      this.assert.equal(result.name, '<cookie-name>');
+    });
+  });
+
+
+  /* The following will always execute after the test suite */
+  after(function (browser) {
+    // This is used to close the browser's session
+    browser.end();
+  });
+});

--- a/nightwatch/templates/titleAssertion.js
+++ b/nightwatch/templates/titleAssertion.js
@@ -1,0 +1,45 @@
+/**
+ * To learn more about the describe interface, refer to the following link:
+ * https://nightwatchjs.org/guide/writing-tests/test-syntax.html
+ */
+describe('Title Assertion', function() {
+
+  /**
+   * This section will always execute before the test suite
+   * Read More : https://nightwatchjs.org/guide/writing-tests/using-test-hooks.html#before-beforeeach-after-aftereach
+   */
+  before(function (browser) {
+    /**
+     * Navigate to a URL :
+     *   - We need to navigate before performing any actions on the page
+     *     Read More : https://nightwatchjs.org/api/navigateTo.html
+     *
+     *   - <PAGE-URL> is a placeholder. Replace it with the actual URL, which you wanted to navigate
+     *
+     * Eg: browser.navigateTo('https://www.github.com/');
+     */
+
+    browser.navigateTo('<PAGE-URL>');
+  });
+
+
+  /* The following will perform the actual test/assertions */
+  it('tests title of the page', function(browser) {
+    /**
+     * Check title :
+     *  - Use title assertion command to check if the title is present or not.
+     *    Read More : https://nightwatchjs.org/api/title.html
+     *
+     * Eg: browser.assert.title('GitHub: Where the world builds software · GitHub');
+     */
+
+    browser.assert.title('<TITLE>');
+  });
+
+
+  /* The following will always execute after the test suite */
+  after(function (browser) {
+    // This is used to close the browser's session
+    browser.end();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "mochawesome-merge": "^4.2.1",
         "mochawesome-report-generator": "^6.2.0",
         "mockery": "~2.1.0",
+        "nightwatch": "^3.5.0",
         "nock": "^13.2.9",
         "nyc": "^15.1.0",
         "react": "^18.2.0",
@@ -6268,6 +6269,68 @@
       "dependencies": {
         "node-addon-api": "^3.0.0",
         "node-gyp-build": "^4.2.2"
+      }
+    },
+    "node_modules/nightwatch": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-3.5.0.tgz",
+      "integrity": "sha512-gUIlA8T10lKbdPJY7cOAY4hEdyFG3RdhAuklN52J44DrlTS9PbwlH33GnePrrW0H/77+Mxo4cpXGYXi+scONDA==",
+      "dev": true,
+      "dependencies": {
+        "@nightwatch/chai": "5.0.3",
+        "@nightwatch/html-reporter-template": "^0.3.0",
+        "@nightwatch/nightwatch-inspector": "^1.0.1",
+        "@types/chai": "^4.3.5",
+        "@types/selenium-webdriver": "^4.1.14",
+        "ansi-to-html": "0.7.2",
+        "aria-query": "5.1.3",
+        "assertion-error": "1.1.0",
+        "boxen": "5.1.2",
+        "chai-nightwatch": "^0.5.3",
+        "chalk": "^4.1.2",
+        "ci-info": "3.3.0",
+        "cli-table3": "^0.6.3",
+        "devtools-protocol": "^0.0.1140464",
+        "didyoumean": "^1.2.2",
+        "dotenv": "16.3.1",
+        "ejs": "3.1.8",
+        "envinfo": "7.11.0",
+        "glob": "7.2.3",
+        "jsdom": "^23.1.0",
+        "lodash": "^4.17.21",
+        "minimatch": "3.1.2",
+        "minimist": "1.2.6",
+        "mocha": "10.2.0",
+        "nightwatch-axe-verbose": "^2.3.0",
+        "open": "8.4.2",
+        "ora": "5.4.1",
+        "piscina": "^4.3.1",
+        "selenium-webdriver": "4.16.0",
+        "semver": "7.5.4",
+        "stacktrace-parser": "0.1.10",
+        "strip-ansi": "6.0.1",
+        "untildify": "4.0.0",
+        "uuid": "8.3.2"
+      },
+      "bin": {
+        "nightwatch": "bin/nightwatch"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "@cucumber/cucumber": "*"
+      },
+      "peerDependenciesMeta": {
+        "@cucumber/cucumber": {
+          "optional": true
+        },
+        "chromedriver": {
+          "optional": true
+        },
+        "geckodriver": {
+          "optional": true
+        }
       }
     },
     "node_modules/nightwatch-axe-verbose": {
@@ -13739,6 +13802,48 @@
       "requires": {
         "node-addon-api": "^3.0.0",
         "node-gyp-build": "^4.2.2"
+      }
+    },
+    "nightwatch": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-3.5.0.tgz",
+      "integrity": "sha512-gUIlA8T10lKbdPJY7cOAY4hEdyFG3RdhAuklN52J44DrlTS9PbwlH33GnePrrW0H/77+Mxo4cpXGYXi+scONDA==",
+      "dev": true,
+      "requires": {
+        "@nightwatch/chai": "5.0.3",
+        "@nightwatch/html-reporter-template": "^0.3.0",
+        "@nightwatch/nightwatch-inspector": "^1.0.1",
+        "@types/chai": "^4.3.5",
+        "@types/selenium-webdriver": "^4.1.14",
+        "ansi-to-html": "0.7.2",
+        "aria-query": "5.1.3",
+        "assertion-error": "1.1.0",
+        "boxen": "5.1.2",
+        "chai-nightwatch": "^0.5.3",
+        "chalk": "^4.1.2",
+        "ci-info": "3.3.0",
+        "cli-table3": "^0.6.3",
+        "devtools-protocol": "^0.0.1140464",
+        "didyoumean": "^1.2.2",
+        "dotenv": "16.3.1",
+        "ejs": "3.1.8",
+        "envinfo": "7.11.0",
+        "glob": "7.2.3",
+        "jsdom": "^23.1.0",
+        "lodash": "^4.17.21",
+        "minimatch": "3.1.2",
+        "minimist": "1.2.6",
+        "mocha": "10.2.0",
+        "nightwatch-axe-verbose": "^2.3.0",
+        "open": "8.4.2",
+        "ora": "5.4.1",
+        "piscina": "^4.3.1",
+        "selenium-webdriver": "4.16.0",
+        "semver": "7.5.4",
+        "stacktrace-parser": "0.1.10",
+        "strip-ansi": "6.0.1",
+        "untildify": "4.0.0",
+        "uuid": "8.3.2"
       }
     },
     "nightwatch-axe-verbose": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "mochawesome-merge": "^4.2.1",
     "mochawesome-report-generator": "^6.2.0",
     "mockery": "~2.1.0",
+    "nightwatch": "^3.5.0",
     "nock": "^13.2.9",
     "nyc": "^15.1.0",
     "react": "^18.2.0",


### PR DESCRIPTION
This commit modifies the shouldRejectNodePromise method in the AsyncTree class to correctly access the properties of the node argument passed to the method, rather than relying on the this.currentNode property. Specifically, the isES6Async property is now accessed from the node parameter, ensuring accurate checks for ES6 async functions. This change improves the correctness and flexibility of promise rejection conditions in the AsyncTree class.

Affected method:
- shouldRejectNodePromise(err, node = this.currentNode)

Changes:
- Changed access to isES6Async property from this.currentNode to node.