### PR TITLE
Fix/4157 Abort test on `waitUntil`failure when using it standalone with async/await

### DIFF
--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -104,7 +104,7 @@ class AsyncTree extends EventEmitter{
   }
 
   shouldRejectNodePromise(err, node = this.currentNode) {
-    if ((err.isExpect || node.namespace === 'assert') && this.currentNode.isES6Async) {
+    if ((err.isExpect || node.namespace === 'assert' || err.name === 'TimeoutError') && this.currentNode.isES6Async) {
       return true;
     }
 


### PR DESCRIPTION
Fixes: #4157 
Currently, when using the `waitUntil` command standalone with async/await, the test continues execution even after a timeout occurs. Here, I altered the condition inside `shouldNodeRejectPromise` to reject waitUntil's promise eventually aborting the test in case of an error(TimeoutError). And would love to hear any suggestions/opinions 

- [ ] Before marking your PR for review, please test and verify your changes by making appropriate modifications to any of the Nightwatch example tests (present in `examples/tests` directory of the project) and running them. `ecosia.js` and `duckDuckGo.js` are good examples to work with.
- [ ] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [ ] If you're fixing a bug also create an issue if one doesn't exist yet;
- [ ] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [ ] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be; 
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [ ] Do not include changes that are not related to the issue at hand;
- [ ] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [ ] Always add unit tests - PRs without tests are most of the times ignored.
