### PR TITLE
Fix Nightwatch commands in `waitUntil` callback return `NightwatchAPI` instead of a `Promise`

### DIFF
--- a/lib/api/protocol/waitUntil.js
+++ b/lib/api/protocol/waitUntil.js
@@ -65,6 +65,10 @@ module.exports = class WaitUntil extends ProtocolAction {
     return true;
   }
 
+  static get alwaysAsync() {
+    return true;
+  }
+
   //timeMs, retryInterval, message, callback = function(r) {return r}
   async command(conditionFn, ...args) {
     let callback = function(r) {return r};


### PR DESCRIPTION
Fixes #4158 
The problem is that in `waitUntil` if we pass an async callback to `waitUntil` command, Nightwatch commands inside the callback still just return NightwatchAPI and no promise which can be awaited to get the result. While in `perform` command, it works fine and Nightwatch commands return a promise inside async callback passed to perfom command, which this is because the `alwaysAsync` is set `true` for perform which inturn returns the promise in this [code](https://github.com/capGoblin/nightwatch/blob/b08981d494faafb7f541684c5d4ebce5dfb1e2f6/lib/api/_loaders/_base-loader.js#L453) block. Similarly now `waitUntil` returns `promise` instead of the `NightwatchAPI` as expected. Would love to hear any suggestions/opinions.


- [ ] Before marking your PR for review, please test and verify your changes by making appropriate modifications to any of the Nightwatch example tests (present in `examples/tests` directory of the project) and running them. `ecosia.js` and `duckDuckGo.js` are good examples to work with.
- [ ] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [ ] If you're fixing a bug also create an issue if one doesn't exist yet;
- [ ] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [ ] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [ ] Do not include changes that are not related to the issue at hand;
- [ ] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [ ] Always add unit tests - PRs without tests are most of the times ignored.
