### PR TITLE
Keep error's original messages for NoSuchElementError.

### DIFF
--- a/lib/transport/errors/index.js
+++ b/lib/transport/errors/index.js
@@ -155,13 +155,16 @@ module.exports = {
     if (err && (err.name in SeleniumNightwatchErrorCodeMap)) {
       const statusCode = SeleniumNightwatchErrorCodeMap[err.name];
 
+      const error = {
+        ...err,
+        id: statusCode
+      };
+
       for (const [key, value] of Object.entries(Errors[statusCode])) {
-        err[key] ||= value;
+        error[key] ||= value;
       }
 
-      err.id = statusCode;
-
-      return err;
+      return error;
     } else if (err && err.name && (err.stack || err.stackTrace)){
       return err;
     }


### PR DESCRIPTION
For `NoSuchElementError` errors, the error messages always gets overwritten by the default message for such error, but we should instead give preference to the original error message as that would also contain information on the selectors used for the element.
