### PR TITLE
Use `NoSuchElementError` when element not found in new Element API.

### DIFF
--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -328,9 +328,14 @@ class ScopedWebElement {
 }
 
 function createNarrowedError({error, condition, timeout}) {
-  return error.name === 'TimeoutError'
-    ? new Error(`Timed out while waiting for element "${condition}" to be present for ${timeout} milliseconds.`)
-    : error;
+  if (error.name === 'TimeoutError') {
+    const err = new Error(`Timed out while waiting for element "${condition}" to be present for ${timeout} milliseconds.`);
+    err.name = 'NoSuchElementError';
+
+    return err;
+  }
+
+  return error;
 }
 
 module.exports = ScopedWebElement;

--- a/lib/transport/errors/index.js
+++ b/lib/transport/errors/index.js
@@ -155,16 +155,13 @@ module.exports = {
     if (err && (err.name in SeleniumNightwatchErrorCodeMap)) {
       const statusCode = SeleniumNightwatchErrorCodeMap[err.name];
 
-      const error = {
-        ...err,
-        id: statusCode
-      };
-
       for (const [key, value] of Object.entries(Errors[statusCode])) {
-        error[key] ||= value;
+        err[key] ||= value;
       }
 
-      return error;
+      err.id = statusCode;
+
+      return err;
     } else if (err && err.name && (err.stack || err.stackTrace)){
       return err;
     }


### PR DESCRIPTION
Fixes: #4078 

Right now, whenever the new Element API is unable to find an element, it throws a very generic `Error`. Instead, it should throw a `NoSuchElementError` with proper information and help text with the error message.

<img width="951" alt="image" src="https://github.com/nightwatchjs/nightwatch/assets/39924567/b75b32fb-d158-4ddc-be69-63d665c2078d">

