### PR TITLE
Fix command args showing as '[object Object]' in reporter.

### DIFF
--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -238,7 +238,17 @@ class Reporter extends SimplifiedReporter {
 
   static stringifyArgs(args) {
     if (Array.isArray(args)) {
-      return args.map((arg) => arg && arg.toString());
+      return args.map((arg) => {
+        let stringifiedArg;
+
+        try {
+          stringifiedArg = JSON.stringify(arg);
+        } catch {
+          stringifiedArg = arg && arg.toString();
+        }
+
+        return stringifiedArg;
+      });
     }
 
     return args;

--- a/test/src/runner/testReporter.js
+++ b/test/src/runner/testReporter.js
@@ -324,7 +324,7 @@ describe('testReporter', function() {
             assert.ok(Object.keys(command).includes('endTime'));
             assert.ok(Object.keys(command).includes('elapsedTime'));
             assert.ok(Object.keys(command).includes('result'));
-            assert.deepEqual(command.args, ['http://localhost']);
+            assert.deepEqual(command.args, ['"http://localhost"']);
             assert.strictEqual(command.status, 'pass');
           }
         },


### PR DESCRIPTION
Right now, if the command arg is of type object, it gets stringified as '[object Object]' in the reporter.

![image](https://github.com/nightwatchjs/nightwatch/assets/39924567/6d81ab4f-a5f4-490b-8e38-3fbfb27fa03f)

This PR fixes this by stringifying the args correctly using `JSON.stringify`.