### PR TITLE
Fix test not aborting when waitFor commands used with async/await.

### DIFF
--- a/lib/api/element-commands/_waitFor.js
+++ b/lib/api/element-commands/_waitFor.js
@@ -13,6 +13,10 @@ class WaitForElement extends ElementCommand {
     return false;
   }
 
+  static get rejectNodeOnAbortFailure() {
+    return true;
+  }
+
   static get isTraceable() {
     return true;
   }


### PR DESCRIPTION
Right now, the `waitFor` commands (like `waitForElementVisible`) when used with `async/await` syntax do not abort the test on failure, even when `abortOnFailure` is set to `true`.

This PR fixes that by rejecting the command node upon failure when `abortOnFailure` is set to `true`, and thus aborting the test.

The implementation around this was merged recently in #4161.
