### PR TITLE
Bump selenium-webdriver to 4.20.0

### DIFF
--- a/lib/transport/selenium-webdriver/options.js
+++ b/lib/transport/selenium-webdriver/options.js
@@ -333,8 +333,14 @@ module.exports = class SeleniumCapabilities {
   }
 
   addHeadlessOption({options}) {
-    if (this.argv.headless && (options instanceof Capabilities) && (this.isChrome || options.headless)) {
-      this.isChrome ? options.addArguments('headless=new') : options.headless();
+    if (this.argv.headless && (options instanceof Capabilities) && options.addArguments) {
+      // For other Chromium-based browsers, `options` wouldn't be an instance of Capabilities
+      // because it is never made so above (not officially supported by Selenium).
+      if (this.isChrome || this.isEdge) {
+        options.addArguments('headless=new');
+      } else if (this.isFirefox) {
+        options.addArguments('-headless');
+      }
     }
 
     return this;

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "open": "8.4.2",
         "ora": "5.4.1",
         "piscina": "^4.3.1",
-        "selenium-webdriver": "4.16.0",
+        "selenium-webdriver": "^4.19.0",
         "semver": "7.5.4",
         "stacktrace-parser": "0.1.10",
         "strip-ansi": "6.0.1",
@@ -7568,6 +7568,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7652,13 +7653,13 @@
       "dev": true
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.16.0.tgz",
-      "integrity": "sha512-IbqpRpfGE7JDGgXHJeWuCqT/tUqnLvZ14csSwt+S8o4nJo3RtQoE9VR4jB47tP/A8ArkYsh/THuMY6kyRP6kuA==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.19.0.tgz",
+      "integrity": "sha512-8XHW8m9V2XN2/SC1kr4bWzMtGvjmKUEZ6S0UBoDBqonhmwEIzKOLbzhanBd08HCOg1s1O0XrDWCD71NnA8Zt0g==",
       "dependencies": {
         "jszip": "^3.10.1",
-        "tmp": "^0.2.1",
-        "ws": ">=8.14.2"
+        "tmp": "^0.2.3",
+        "ws": ">=8.16.0"
       },
       "engines": {
         "node": ">= 14.20.0"
@@ -8436,14 +8437,11 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-fast-properties": {
@@ -14742,6 +14740,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -14803,13 +14802,13 @@
       "dev": true
     },
     "selenium-webdriver": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.16.0.tgz",
-      "integrity": "sha512-IbqpRpfGE7JDGgXHJeWuCqT/tUqnLvZ14csSwt+S8o4nJo3RtQoE9VR4jB47tP/A8ArkYsh/THuMY6kyRP6kuA==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.19.0.tgz",
+      "integrity": "sha512-8XHW8m9V2XN2/SC1kr4bWzMtGvjmKUEZ6S0UBoDBqonhmwEIzKOLbzhanBd08HCOg1s1O0XrDWCD71NnA8Zt0g==",
       "requires": {
         "jszip": "^3.10.1",
-        "tmp": "^0.2.1",
-        "ws": ">=8.14.2"
+        "tmp": "^0.2.3",
+        "ws": ">=8.16.0"
       }
     },
     "semver": {
@@ -15395,12 +15394,9 @@
       }
     },
     "tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "requires": {
-        "rimraf": "^3.0.0"
-      }
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "open": "8.4.2",
         "ora": "5.4.1",
         "piscina": "^4.3.1",
-        "selenium-webdriver": "^4.19.0",
+        "selenium-webdriver": "4.20.0",
         "semver": "7.5.4",
         "stacktrace-parser": "0.1.10",
         "strip-ansi": "6.0.1",
@@ -7653,9 +7653,9 @@
       "dev": true
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.19.0.tgz",
-      "integrity": "sha512-8XHW8m9V2XN2/SC1kr4bWzMtGvjmKUEZ6S0UBoDBqonhmwEIzKOLbzhanBd08HCOg1s1O0XrDWCD71NnA8Zt0g==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.20.0.tgz",
+      "integrity": "sha512-s/G44lGQ1xB3tmtX6NNPomlkpL6CxLdmAvp/AGWWwi4qv5Te1+qji7tPSyr6gyuoPpdYiof1rKnWe3luy0MrYA==",
       "dependencies": {
         "jszip": "^3.10.1",
         "tmp": "^0.2.3",
@@ -14802,9 +14802,9 @@
       "dev": true
     },
     "selenium-webdriver": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.19.0.tgz",
-      "integrity": "sha512-8XHW8m9V2XN2/SC1kr4bWzMtGvjmKUEZ6S0UBoDBqonhmwEIzKOLbzhanBd08HCOg1s1O0XrDWCD71NnA8Zt0g==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.20.0.tgz",
+      "integrity": "sha512-s/G44lGQ1xB3tmtX6NNPomlkpL6CxLdmAvp/AGWWwi4qv5Te1+qji7tPSyr6gyuoPpdYiof1rKnWe3luy0MrYA==",
       "requires": {
         "jszip": "^3.10.1",
         "tmp": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "open": "8.4.2",
     "ora": "5.4.1",
     "piscina": "^4.3.1",
-    "selenium-webdriver": "^4.19.0",
+    "selenium-webdriver": "4.20.0",
     "semver": "7.5.4",
     "stacktrace-parser": "0.1.10",
     "strip-ansi": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "open": "8.4.2",
     "ora": "5.4.1",
     "piscina": "^4.3.1",
-    "selenium-webdriver": "4.16.0",
+    "selenium-webdriver": "^4.19.0",
     "semver": "7.5.4",
     "stacktrace-parser": "0.1.10",
     "strip-ansi": "6.0.1",

--- a/test/src/core/testCreateSession.js
+++ b/test/src/core/testCreateSession.js
@@ -157,7 +157,7 @@ describe('test Request With Credentials', function () {
         headless: true
       }
     });
-
+    
     assert.deepStrictEqual(session, {
       sessionId: '1352110219202',
       host: 'localhost',
@@ -255,7 +255,7 @@ describe('test Request With Credentials', function () {
       capabilities: {browserName: 'MicrosoftEdge', version: 'TEST', platform: 'TEST'}
     });
 
-    assert.deepStrictEqual(sessionOptions.get('ms:edgeOptions'), {args: ['headless']});
+    assert.deepStrictEqual(sessionOptions.get('ms:edgeOptions'), {args: ['headless=new']});
   });
 
   it('Test create session with headless mode in Chrome with existing args', async function () {
@@ -347,7 +347,7 @@ describe('test Request With Credentials', function () {
     assert.deepStrictEqual(sessionOptions.get('ms:edgeOptions'), {
       args: [
         '--no-sandbox',
-        'headless'
+        'headless=new'
       ]
     });
   });

--- a/test/src/index/transport/testChromeOptions.js
+++ b/test/src/index/transport/testChromeOptions.js
@@ -3,10 +3,10 @@ const Nightwatch = require('../../../lib/nightwatch.js');
 const ChromeOptions = require('selenium-webdriver/chrome').Options;
 
 describe('Test chrome options', function () {
-
   it('Chrome option object with headless', function(){
     const capabilities = new ChromeOptions();
-    capabilities.headless();
+    capabilities.addArguments('headless=new');
+
     const client = Nightwatch.createClient({
       capabilities
     });

--- a/test/src/index/transport/testEdgeOptions.js
+++ b/test/src/index/transport/testEdgeOptions.js
@@ -6,7 +6,7 @@ describe('Test edge option', function(){
   
   it('Edge option object with headless', function(){
     const edgeoptions = new EdgeOptions();
-    edgeoptions.headless();
+    edgeoptions.addArguments('headless=new');
 
     const client = Nightwatch.createClient({
       capabilities: edgeoptions
@@ -75,7 +75,7 @@ describe('Test edge option', function(){
     const options = client.transport.createSessionOptions({headless: true});
 
     assert.strictEqual(options instanceof EdgeOptions, true);
-    assert.deepStrictEqual(options.options_.args, ['headless']);
+    assert.deepStrictEqual(options.options_.args, ['headless=new']);
   });
 
   it('window size option', function(){

--- a/test/src/index/transport/testFirefoxOptions.js
+++ b/test/src/index/transport/testFirefoxOptions.js
@@ -6,7 +6,8 @@ describe('Firefox driver options', function(){
 
   it('Firefox option object with headless', function(){
     const firefoxOptions =  new FirefoxOptions();
-    firefoxOptions.headless();
+    firefoxOptions.addArguments('-headless');
+
     const client = Nightwatch.createClient({
       capabilities: firefoxOptions
     });


### PR DESCRIPTION
`.headless()` method was [removed](https://github.com/SeleniumHQ/selenium/commit/5a97adf9864a346fdd8914cdb1b601c05dd837ac) in selenium-webdriver v4.17.0, so this PR handles that as well.
