### PR TITLE
Fix error in Cucumber when session is closed in a test case itself.

### DIFF
--- a/lib/runner/test-runners/cucumber/_setup_cucumber_runner.js
+++ b/lib/runner/test-runners/cucumber/_setup_cucumber_runner.js
@@ -75,7 +75,8 @@ After(async function(testCase) {
     await this.client.transport.testSuiteFinished(error);
   }
 
-  if (this.browser) {
+  // close session if not done yet
+  if (this.browser?.sessionId) {
     await this.browser.quit();
   }
 });

--- a/lib/runner/test-runners/cucumber/_setup_cucumber_runner.js
+++ b/lib/runner/test-runners/cucumber/_setup_cucumber_runner.js
@@ -75,7 +75,6 @@ After(async function(testCase) {
     await this.client.transport.testSuiteFinished(error);
   }
 
-  // close session if not done yet
   if (this.browser?.sessionId) {
     await this.browser.quit();
   }


### PR DESCRIPTION
Fixes: #3332.

Right now, even if the session is already closed inside a test case, Nightwatch still tries to close the session again in the `After` hook of Cucumber, resulting in an error.

With this PR, the session will only be closed in the `After` hook if it is not closed already.