### PR TITLE
Ignore further chained commands for non-existing element in new element API.

### DIFF
--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -280,10 +280,25 @@ class ScopedWebElement {
         });
       }
 
-      return actions[commandName](webElement, ...args).then((result) => {
+      const actionCallback = (result) => {
+        // here, we resolve the node with `result.value` even if the result contains an error and status === -1
+        // which results in the command result to be `null` in test case as well, while the command actually failed.
+        // Is this expected? To return `null` result in case of failure as well?
         // eslint-disable-next-line no-prototype-builtins
         node.deferred.resolve(result.hasOwnProperty('value') ? result.value : result);
-      });
+      };
+
+      if (webElement instanceof Promise) {
+        return webElement.then((resolvedWebElement) => {
+          if (resolvedWebElement || commandName === 'isPresent') {
+            return actions[commandName](webElement, ...args).then(actionCallback);
+          }
+
+          node.deferred.resolve(null); // or throw error ???
+        });
+      }
+
+      return actions[commandName](webElement, ...args).then(actionCallback);
     };
 
     const node = this.queueAction({name: commandName, createAction});


### PR DESCRIPTION
Fixes #4077.