### PR TITLE
Expose HttpRequest and cdp modules as utils.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@ const ElementGlobal = require('./api/_loaders/element-global.js');
 const NightwatchClient = require('./core/client.js');
 const namespacedApi = require('./core/namespaced-api.js');
 const {NightwatchEventHub} = require('./runner/eventHub');
+const HttpRequest = require('./http/request.js');
+const cdp = require('./transport/selenium-webdriver/cdp.js');
 
 const {Logger} = Utils;
 
@@ -483,3 +485,9 @@ const globalBrowserDescriptor = {
 };
 Object.defineProperty(Nightwatch, 'browser', globalBrowserDescriptor);
 Object.defineProperty(Nightwatch, 'app', globalBrowserDescriptor);
+
+// expose some internal modules for direct use
+module.exports.utils = {
+  HttpRequest,
+  cdp
+};


### PR DESCRIPTION
This PR exposes a few internal modules like `HttpRequest` and `cdp` as `utils` so that these modules can be imported and used directly inside test suites.

`HttpRequest` module is useful for modifying the settings of HTTP requests as and when required. For example, we can modify the HTTP timeout and retry attempts for a particular command by calling the `updateGlobalSettings` static method just before that command:
```js
HttpRequest.updateGlobalSettings({timeout: 10000, retry_attempts: 5});
```
Note: The above command would change the `HttpRequest` settings globally for the entirety of the test run. It should ideally be reset back to the original settings once the requirement is over.

Note 2: The initial values of `timeout` and `retry_attempts` can be set using the `timeout_options` property of `webdriver` config in `nightwatch.conf.js`.

`cdp` module is useful when working with CDP commands in Nightwatch -- there could be situations when users want to reset the CDP connection or reset the network mocks. They would also need this module when implementing their own custom CDP commands.