### PR TITLE
Add types for Appium-specific locate strategies.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1298,7 +1298,12 @@ export type LocateStrategy =
   | 'link text'
   | 'partial link text'
   | 'tag name'
-  | 'xpath';
+  | 'xpath'
+  // Appium-specific strategies
+  | 'accessibility id'
+  | '-android uiautomator'
+  | '-ios predicate string'
+  | '-ios class chain';
 
 export type NightwatchLogTypes =
   | 'client'

--- a/types/tests/webElement.test-d.ts
+++ b/types/tests/webElement.test-d.ts
@@ -20,6 +20,9 @@ describe('new element() api', function () {
     // accepts ElementProperties
     expectType<ScopedElement>(browser.element({selector: 'selector', locateStrategy: 'css selector', abortOnFailure: false}));
 
+    // accepts ElementProperties with Appium-specific locate strategies
+    expectType<ScopedElement>(browser.element({selector: 'selector', locateStrategy: '-android uiautomator', abortOnFailure: false}));
+
     // accepts Element (ScopedElement is also assignable to Element)
     expectType<ScopedElement>(browser.element(elem));
 

--- a/types/tests/webdriverProtocolCommands.test-d.ts
+++ b/types/tests/webdriverProtocolCommands.test-d.ts
@@ -450,7 +450,7 @@ describe('acceptAlert command demo', function () {
   before((browser) => browser.url('https://nightwatchjs.org/__e2e/window/alerts.html/'));
 
   test('demo test', function (browser) {
-    browser.click('#show-alert').acceptAlert(function (result) {
+    browser.click({selector: '#show-alert', locateStrategy: 'accessibility id'}).acceptAlert(function (result) {
       expectType<NightwatchAPI>(this);
       expectType<NightwatchCallbackResult<null>>(result);
     });


### PR DESCRIPTION
A few Appium-specific locate strategies have been missing from the types.