### PR TITLE
Display `describe` name in HTML report.

### DIFF
--- a/lib/reporter/reporters/html.js
+++ b/lib/reporter/reporters/html.js
@@ -99,6 +99,7 @@ class HtmlReporter extends BaseReporter {
   }
 
   aggregateEnvironments(testEnv, moduleKey, module) {
+    const moduleName = module.name ? `${module.name} (${moduleKey})` : moduleKey;
 
     if (!this.environments[testEnv]) {
       this.environments[testEnv] = this.createInitialResult(module);
@@ -117,7 +118,7 @@ class HtmlReporter extends BaseReporter {
       this.environments[testEnv].metadata.browserVersion = this.environments[testEnv].metadata.browserVersion || sessionCapabilities.browserVersion;
     }
 
-    this.environments[testEnv].modules[moduleKey] = this.adaptModule(module);
+    this.environments[testEnv].modules[moduleName] = this.adaptModule(module);
   }
 
   aggregateStats() {


### PR DESCRIPTION
Currently, the text present inside the `describe` block in a test suite is not displayed anywhere in the HTML report, while the test suites should be majorly identified by this text only.

This PR fixes that by adding the `describe` name as a prefix in the left-side bar of the HTML report.

This is how it looks now:
![image](https://github.com/user-attachments/assets/ae0a36d5-36e2-4eeb-a16c-ae5a214d5298)


compared to this before:
![image](https://github.com/user-attachments/assets/16b3d55f-6d47-4edd-b7f4-d5f342a398af)
