### PR TITLE
Save command result values in Json Report.

### DIFF
--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -287,18 +287,22 @@ class ScopedWebElement {
 
     const createAction = (actions, webElement) => function () {
       if (isFunction(commandName)) {
-        return commandName(webElement, ...args).then((result) => {
-          node.deferred.resolve(result);
-        });
+        return commandName(webElement, ...args);
       }
 
-      return actions[commandName](webElement, ...args).then((result) => {
-        // eslint-disable-next-line no-prototype-builtins
-        node.deferred.resolve(result.hasOwnProperty('value') ? result.value : result);
-      });
+      return actions[commandName](webElement, ...args);
     };
 
     const node = this.queueAction({name: commandName, createAction});
+
+    // TODO: check what changes if we keep the original `getResult` instead of below.
+    node.getResult = function(result) {
+      // here, we resolve the node with `result.value` even if the result contains an error and status === -1
+      // which results in the command result to be `null` in test case as well, while the command actually failed.
+      // Is this expected? To return `null` result in case of failure as well?
+      // eslint-disable-next-line no-prototype-builtins
+      return result.hasOwnProperty('value') ? result.value : result;
+    };
 
     return node;
   }

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const Utils = require('../utils');
 const TestResults = require('./results.js');
 const SimplifiedReporter = require('./simplified.js');
@@ -217,6 +218,17 @@ class Reporter extends SimplifiedReporter {
           stack,
           beautifiedStack
         };
+
+        if (this.settings.reporter_options.save_command_result_value) {
+          if (Utils.isString(result.value) && result.value.length > 500) {
+            const filepath = path.join(this.settings.output_folder || '', 'tmp', this.testResults.uuid, `${node.full_name}_${Date.now()}.txt`);
+            commandResult.valuePath = filepath;
+
+            Utils.writeToFile(filepath, result.value);
+          } else {
+            commandResult.value = result.value;
+          }
+        }
       }
 
       if (this.shouldLogCommand(node)) {

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -221,7 +221,7 @@ class Reporter extends SimplifiedReporter {
 
         if (this.settings.reporter_options.save_command_result_value) {
           if (Utils.isString(result.value) && result.value.length > 500) {
-            const filepath = path.join(this.settings.output_folder || '', 'tmp', this.testResults.uuid, `${node.full_name}_${Date.now()}.txt`);
+            const filepath = path.join(this.settings.output_folder || '', 'tmp', this.testResults.uuid, `${node.fullName}_${Date.now()}.txt`);
             commandResult.valuePath = filepath;
 
             Utils.writeToFile(filepath, result.value);

--- a/lib/reporter/results.js
+++ b/lib/reporter/results.js
@@ -1,4 +1,5 @@
 const lodashMerge = require('lodash/merge');
+const uuid = require('uuid');
 const Utils = require('../utils');
 const {Logger} = Utils;
 
@@ -54,6 +55,7 @@ module.exports = class Results {
     this.name = opts.suiteName || '';
     this.tags = opts.tags || [];
     this.__retryTest = false;
+    this.__uuid = uuid.v4();
 
     this.initCount(allScreenedTests);
   }
@@ -101,6 +103,10 @@ module.exports = class Results {
     const testName = this.currentTest.name;
 
     return this.getTestResult(testName, {returnFullResult: true});
+  }
+
+  get uuid() {
+    return this.__uuid;
   }
 
   /**
@@ -234,6 +240,7 @@ module.exports = class Results {
       moduleKey,
       hasFailures: !this.testsPassed(),
       results: {
+        uuid: this.uuid,
         reportPrefix,
         assertionsCount: this.initialResult.assertions.length
       }

--- a/lib/settings/defaults.js
+++ b/lib/settings/defaults.js
@@ -148,7 +148,10 @@ module.exports = {
     // The file name formatting to use while saving HTML report
     filename_format: null,
 
-    minimal_report_file_path: 'tests_output/minimal_report.json'
+    minimal_report_file_path: 'tests_output/minimal_report.json',
+
+    // Save command result values in Json report (inline or in separate file).
+    save_command_result_value: false
   },
 
   // A string or array of folders (excluding subfolders) where the tests are located.


### PR DESCRIPTION
Currently, the result values for the Nightwatch commands are not saved in the JSON report, only the result status is saved.

This PR allows users to save the command result values as well in the JSON report by setting the `save_command_result_value` config to `true` in the Nightwatch configuration file.

For large result values, a new file is created to put the result value and the path of that file is saved in the JSON report instead of the actual value.

cc: @sauravdas1997