### PR TITLE
fix: frame command overlapping with subsequent NW commands.

### DIFF
--- a/lib/api/protocol/frame.js
+++ b/lib/api/protocol/frame.js
@@ -41,6 +41,10 @@ const findElement = function(selector) {
 };
 
 module.exports = class Session extends ProtocolAction {
+  static get avoidPrematureParentNodeResolution() {
+    return true;
+  }
+
   async command(frameId, callback) {
     if (arguments.length === 1 && typeof frameId === 'function') {
       callback = frameId;


### PR DESCRIPTION
When the `.frame()` command is used with `await` (as shown below), the command promise resolves early before the command can even find the target frame element. Due to this, the subsequent Nightwatch commands start running parallelly with the `.frame()` command.

```js
await browser.frame('frame_a_simple_iframe');
await browser.waitForElementVisible('.example');
```

This PR solves this issue by ensuring that the `frame()` command promise is only resolved once the command has completed its execution so that the subsequent commands only run after that.