### PR TITLE
fix: assertion failure in new Elem API leads to unhandledRejection.

### DIFF
--- a/lib/api/web-element/assert/element-assertions.js
+++ b/lib/api/web-element/assert/element-assertions.js
@@ -7,12 +7,24 @@ class ScopedElementAssertions {
     this.nightwatchInstance = nightwatchInstance;
   }
 
-  async assert(callback) {
-    const assert = this.nightwatchInstance.api.assert;
+  assert(callback) {
+    const assertPromise = new Promise((resolve, reject) => {
+      const assert = this.nightwatchInstance.api.assert;
 
-    await callback(this.negated ? assert.not : assert, this.scopedElement.webElement);
+      callback(this.negated ? assert.not : assert, this.scopedElement.webElement)
+        .then(() => {
+          resolve(this.scopedElement);
+        })
+        .catch(err => {
+          reject(err);
+        });
+    });
 
-    return this.scopedElement;
+    // prevent unhandledRejection errors, while also making sure
+    // that the exception passes to the actual test case.
+    assertPromise.catch(() => {});
+
+    return assertPromise;
   }
 
   async executeScript(scriptFn, args) {

--- a/lib/api/web-element/assert/element-assertions.js
+++ b/lib/api/web-element/assert/element-assertions.js
@@ -11,13 +11,18 @@ class ScopedElementAssertions {
     const assertPromise = new Promise((resolve, reject) => {
       const assert = this.nightwatchInstance.api.assert;
 
-      callback(this.negated ? assert.not : assert, this.scopedElement.webElement)
-        .then(() => {
-          resolve(this.scopedElement);
-        })
-        .catch(err => {
-          reject(err);
-        });
+      const callbackResult = callback(this.negated ? assert.not : assert, this.scopedElement.webElement);
+      if (callbackResult instanceof Promise) {
+        callbackResult
+          .then(() => {
+            resolve(this.scopedElement);
+          })
+          .catch(err => {
+            reject(err);
+          });
+      } else {
+        resolve(this.scopedElement);
+      }
     });
 
     // prevent unhandledRejection errors, while also making sure

--- a/lib/api/web-element/assert/value-assertions.js
+++ b/lib/api/web-element/assert/value-assertions.js
@@ -8,11 +8,23 @@ module.exports.create = function createAssertions(scopedValue, {negated, nightwa
       this.scopedValue = scopedValue;
     }
 
-    async _assert(callback) {
-      const assert = nightwatchInstance.api.assert;
-      await callback(this.negated ? assert.not : assert, this.scopedValue.value);
+    _assert(callback) {
+      const assertPromise = new Promise((resolve, reject) => {
+        const assert = nightwatchInstance.api.assert;
+        callback(this.negated ? assert.not : assert, this.scopedValue.value)
+          .then(() => {
+            resolve(this.scopedValue);
+          })
+          .catch(err => {
+            reject(err);
+          });
+      });
 
-      return this.scopedValue;
+      // prevent unhandledRejection errors, while also making sure
+      // that the exception passes to the actual test case.
+      assertPromise.catch(() => {});
+
+      return assertPromise;
     }
 
     get not() {

--- a/lib/api/web-element/assert/value-assertions.js
+++ b/lib/api/web-element/assert/value-assertions.js
@@ -11,18 +11,23 @@ module.exports.create = function createAssertions(scopedValue, {negated, nightwa
     _assert(callback) {
       const assertPromise = new Promise((resolve, reject) => {
         const assert = nightwatchInstance.api.assert;
-        callback(this.negated ? assert.not : assert, this.scopedValue.value)
-          .then(() => {
-            resolve(this.scopedValue);
-          })
-          .catch(err => {
-            reject(err);
-          });
+        const callbackResult = callback(this.negated ? assert.not : assert, this.scopedValue.value);
+        if (callbackResult instanceof Promise) {
+          callbackResult
+            .then(() => {
+              resolve(this.scopedValue);
+            })
+            .catch(err => {
+              reject(err);
+            });
+        } else {
+          resolve(this.scopedValue);
+        }
       });
 
       // prevent unhandledRejection errors, while also making sure
       // that the exception passes to the actual test case.
-      assertPromise.catch(() => {});
+      assertPromise.catch((err) => {});
 
       return assertPromise;
     }


### PR DESCRIPTION
Right now, if we create a test case using an async callback but do not use `await` anywhere inside the test case, failure of the newly introduced assertions in the new Element API leads to `unhandledRejection`:
```js
it('asserts using newly introduced assertions', async function(browser) {
    browser.navigateTo('https://duckduckgo.com');

    browser.element('input[name=q]').assert.not.visible(); // it should fail normally but leads to unhandledRejection
    browser.element('input[name=q]').getText().assert.contains('Search');
});
```

With this PR, assertion failures will gracefully end the test instead of raising `unhandledRejection` which abruptly ends the test run.


#### Caveat

If we use `then()` with the assertion promises, assertion failure leads to `unhandledRejection`. But using `then()` inside an async function is not common, nor is using `then()` on any normal Nightwatch command or assertion.
```js
it('asserts using newly introduced assertions', async function(browser) {
    browser.navigateTo('https://duckduckgo.com');

    // using `then()` on NW commands/assertions is not recommended
    browser.element('input[name=q]').assert.not.visible().then((res) => console.log(res));
    
    // use like below instead
    const res = await browser.element('input[name=q]').assert.not.visible();
    console.log(res);
});
```