### PR TITLE
Add null check before rejecting BaseLoader.lastDeferred.

### DIFF
--- a/lib/api/_loaders/_base-loader.js
+++ b/lib/api/_loaders/_base-loader.js
@@ -464,7 +464,12 @@ class BaseLoader extends EventEmitter {
 
         //prevent unhandled rejection.
         node.deferred.promise.catch(err => {
-          BaseLoader.lastDeferred.reject(err);
+          if (BaseLoader.lastDeferred) {
+            // TODO: check in what cases BaseLoader.lastDeferred could be set to null
+            // in between the execution of the test.
+            // issue: #4265; hint: could have something to do with custom commands.
+            BaseLoader.lastDeferred.reject(err);
+          }
         });
 
         if (!this.module?.returnFn) {

--- a/lib/api/_loaders/assertion.js
+++ b/lib/api/_loaders/assertion.js
@@ -17,7 +17,7 @@ class AssertionLoader extends BaseCommandLoader {
 
   static validateAssertClass(instance) {
     Object.keys(AssertionLoader.interfaceMethods).forEach(method => {
-      let type = AssertionLoader.interfaceMethods[method];
+      const type = AssertionLoader.interfaceMethods[method];
       if (!BaseCommandLoader.isTypeImplemented(instance, method, type)) {
         const methodTypes = method.split('|').map(name => `"${name}"`);
 
@@ -113,7 +113,10 @@ class AssertionLoader extends BaseCommandLoader {
 
         // prevent unhandledRejection errors
         node.deferred.promise.catch(err => {
-          return AssertionLoader.lastDeferred.reject(err);
+          // null check, as done for BaseLoader.lastDeferred as well.
+          if (AssertionLoader.lastDeferred) {
+            return AssertionLoader.lastDeferred.reject(err);
+          }
         });
 
         return node.deferred.promise;


### PR DESCRIPTION
In certain cases, `BaseLoader.lastDeferred` is getting set to `null` in between the test execution (see issue #4265).

Although not sure yet why this is the case, it is anyway a good idea to add a null check before rejecting the `BaseLoader.lastDeferred` promise, which represents the last command or assertion added to the Nightwatch queue.