### PR TITLE
type: Add `driver` property to NightwatchAPI.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,6 +23,7 @@ import {
   Actions,
   Capabilities,
   WebElement,
+  WebDriver,
   RelativeBy,
   locateWith as seleniumLocateWith
 } from 'selenium-webdriver';
@@ -559,6 +560,11 @@ export interface NightwatchAPI
   currentTest: NightwatchTestSuite;
 
   globals: NightwatchGlobals;
+
+  /**
+   * https://www.selenium.dev/selenium/docs/api/javascript/WebDriver.html
+   */
+  driver: WebDriver;
 
   launchUrl: string;
   launch_url: string;

--- a/types/tests/describe.test-d.ts
+++ b/types/tests/describe.test-d.ts
@@ -1,4 +1,5 @@
 import { ExtendDescribeThis } from '..';
+import {FileDetector} from 'selenium-webdriver/remote';
 
 describe('Ecosia', () => {
   before((browser) => browser.url('https://www.ecosia.org/'));
@@ -11,6 +12,9 @@ describe('Ecosia', () => {
       download_throughput: 500 * 1024, // Maximal aggregated download throughput.
       upload_throughput: 500 * 1024, // Maximal aggregated upload throughput.
     });
+
+    // https://www.selenium.dev/selenium/docs/api/javascript/WebDriver.html#setFileDetector
+    browser.driver.setFileDetector(new FileDetector());
 
     browser
       .waitForElementVisible('body')


### PR DESCRIPTION
This PR fixes the missing type for the `driver` property available on the `NightwatchAPI` instance.
