### PR TITLE
Enforce BrowserStack build requests to use port 443.

### DIFF
--- a/lib/transport/selenium-webdriver/browserstack/browserstack.js
+++ b/lib/transport/selenium-webdriver/browserstack/browserstack.js
@@ -103,6 +103,7 @@ class Browserstack extends AppiumBaseServer {
         url: `${this.ApiUrl}/builds.json?status=running`,
         method: 'GET',
         use_ssl: true,
+        port: 443,
         auth: {
           user: this.username,
           pass: this.accessKey
@@ -124,6 +125,7 @@ class Browserstack extends AppiumBaseServer {
       url: `${this.ApiUrl}/sessions/${this.sessionId}.json`,
       method: 'GET',
       use_ssl: true,
+      port: 443,
       auth: {
         user: this.username,
         pass: this.accessKey
@@ -141,6 +143,7 @@ class Browserstack extends AppiumBaseServer {
       url: `${this.ApiUrl}/sessions/${this.sessionId}.json`,
       method: 'PUT',
       use_ssl: true,
+      port: 443,
       data: {
         status: isFailure ? 'failed' : 'passed',
         reason


### PR DESCRIPTION
When using Nightwatch with BrowserStack, the following error occurred in certain cases when trying to get builds data from BrowserStack or send the test results at the end of the test run:
```
Error                                                                      
   GET https://api.browserstack.com:4444                                      
   /automate/builds.json?status=running - ETIMEDOUT                           
   AggregateError                                                             
   at internalConnectMultiple (node:net:1122:18)                              
   at internalConnectMultiple (node:net:1190:5)                               
   at Timeout.internalConnectMultipleTimeout (node:net:1716:5)
```

### Error Reproduction

As I was trying to reproduce this, when I changed the port at which we connect to the Selenium grid from 443 to 4444, the build-related requests to BrowserStack started failing for me as well, but with a different error:
```
TypeError [ERR_INVALID_PROTOCOL]: Protocol "https:" not supported. Expected "http:"
```

On investigating this further, while still trying to reproduce the original error, I found that the above `ERR_INVALID_PROTOCOL` error was occurring because of the user-agent being set for the requests -- Nightwatch only sets the user-agent protocol as `https` if the request is being made to the port `443`, otherwise the protocol is always set to `http` (something we should fix), and due to this mismatch (`https` request being sent with `http` user-agent), the above error was being encountered.

Also, I found that the user-agent was getting set only if the `keep-alive` property was set to `true`. So, as soon as I switched the `keep-alive` property to `false`, I was able to reproduce the original error.

### Fix

The root cause of the original error is that the `https://api.browserstack.com` website does not listen on any port other than `443`. So, this PR enforces all the BrowserStack build-related requests to be made to the port `443` instead of the port used for communicating with BrowserStack Selenium grid.