### PR TITLE
fix: HTTP request agent not changes on protocol change.

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -64,12 +64,17 @@ class HttpRequest extends EventEmitter {
   }
 
   static getAgent({secure, keepAliveMsecs, maxSockets}) {
-    if (__httpKeepAliveAgent__) {
+    const expectedProtocol = secure ? 'https:' : 'http:';
+    if (__httpKeepAliveAgent__ && __httpKeepAliveAgent__.protocol === expectedProtocol) {
       return __httpKeepAliveAgent__;
     }
 
     const protocol = secure ? https : http;
 
+    // might also consider storing http and https user agents separately
+    // and use the same agent for the entirety of test instead of creating
+    // a new user-agent every time the protocol changes.
+    // 1st commit: https://github.com/nightwatchjs/nightwatch/pull/3748
     return __httpKeepAliveAgent__ =  new protocol.Agent({
       keepAlive: true,
       keepAliveMsecs,
@@ -160,8 +165,9 @@ class HttpRequest extends EventEmitter {
       }
 
       if (enabled) {
+        const port = reqOptions.port || this.httpOpts.port;
         reqOptions.agent = HttpRequest.getAgent({
-          secure: this.httpOpts.port === 443,
+          secure: port === 443,
           keepAliveMsecs,
           maxSockets: 1
         });


### PR DESCRIPTION
When the `keep-alive` property of the `webdriver` config is set to `true`, Nightwatch uses the same HTTP agent for all the requests made during the entirety of the test run (a feature that was added in PR #3748).

This led to an issue where if we needed to switch to a different protocol (between `https` and `https`) for certain requests during the test run, those requests would fail due to an invalid agent and gave out the following error:

```
✖ TypeError
   Error while trying to create HTTP request for "/wd/hub/session/765c4e2a8c629d29ce778b2886bfef5d6634e050/url": Protocol "http:" not supported. Expected "https:"
```

This PR fixes this by allowing the agent to be changed whenever the protocol for the request changes.