### PR TITLE
Add selector and error line for "staleElementReferenceError"

### DIFF
--- a/examples/tests/staleElementReferenceError.js
+++ b/examples/tests/staleElementReferenceError.js
@@ -1,0 +1,16 @@
+describe('stale element reference error', function() {
+
+  it('should add selector and error line for stale element reference error', function() {
+    const deletedElement = element(by.id('deleted'));
+    const deleteElement = element(by.id('delete'));
+    browser
+      .navigateTo('https://www.selenium.dev/selenium/web/javascriptPage.html')
+      .click(deletedElement);
+
+    browser.click(deleteElement);
+
+    browser.click(deletedElement);
+  });
+
+  after(browser => browser.end());
+});

--- a/lib/element/command.js
+++ b/lib/element/command.js
@@ -232,7 +232,7 @@ class ElementCommand extends EventEmitter {
       elementId = selector;
     }
 
-    return this.transport.executeProtocolAction({actionName, args: [elementId, ...args], sessionId});
+    return this.transport.executeProtocolAction({actionName, args: [elementId, ...args, {selector: this.selector, stackTrace: this.stackTrace}], sessionId});
   }
 
   async complete(err, response) {

--- a/lib/transport/selenium-webdriver/actions.js
+++ b/lib/transport/selenium-webdriver/actions.js
@@ -2,6 +2,7 @@ const {error} = require('selenium-webdriver');
 
 const {Logger, isObject, isFunction, isString} = require('../../utils');
 const MethodMappings = require('./method-mappings.js');
+const {filterStackTrace} = require('../../utils/stackTrace');
 
 class TransportActions {
   get transport() {
@@ -70,7 +71,8 @@ class TransportActions {
 
         return this.makeResult(result);
       } catch (err) {
-        const error = this.handleError(err, name);
+
+        const error = this.handleError(err, name, args);
 
         return {
           error,
@@ -96,7 +98,7 @@ class TransportActions {
     return result;
   }
 
-  handleError(err, commandName) {
+  handleError(err, commandName, args = undefined) {
     let errorMsg = 'Unknown error';
     try {
       this.transport.handleErrorResponse(err);
@@ -123,7 +125,24 @@ class TransportActions {
     const {shouldRegisterError} = this.transport;
     const {lastError, retriesCount} = this;
     if (shouldRegisterError(err) && (retriesCount < 1 || lastError && err.name !== lastError.name)) {
-      Logger.error(`Error while running .${commandName}() protocol action: ${errorMsg}\n`);
+      err.message = `Error while running .${commandName}() protocol action: ${errorMsg}\n`;
+
+      if (args && args.length > 0) {
+        const lastArg = args[args.length - 1];
+        if (lastArg && typeof lastArg === 'object' && !Array.isArray(lastArg)) {
+          const {selector = null, stackTrace = null} = lastArg;
+
+          if (selector) {
+            err.message += `Selector: ${selector}\n`;
+          }
+
+          if (stackTrace) {
+            err.stack = filterStackTrace(stackTrace);
+          }
+        }
+      }
+
+      Logger.error(err);
       this.lastError = err;
     }
     if (this.lastError && err.name === this.lastError.name) {

--- a/test/src/api/commands/element/testClickAndHold.js
+++ b/test/src/api/commands/element/testClickAndHold.js
@@ -19,12 +19,12 @@ describe('.clickAndHold()', function() {
       
       return Promise.resolve({
         status: 0,
-        value:null
+        value: null
       });
-    }
+    };
     
     this.client.api.clickAndHold('#weblogin', function callback(result) {
-      assert.deepStrictEqual(clickAndHoldArgs.args, ['5cc459b8-36a8-3042-8b4a-258883ea642b'])
+      assert.ok(clickAndHoldArgs.args.includes('5cc459b8-36a8-3042-8b4a-258883ea642b'));
       assert.strictEqual(result.status, 0);
       assert.strictEqual(this, api);
     });
@@ -39,16 +39,16 @@ describe('.clickAndHold()', function() {
       clickAndHoldArgs = args;
 
       return Promise.resolve({
-        status:0,
+        status: 0,
         value: null
-      })
-    }
+      });
+    };
 
     this.client.api.useXpath()
       .clickAndHold('//weblogin', function callback(result) {
-        assert.deepStrictEqual(clickAndHoldArgs.args, ['5cc459b8-36a8-3042-8b4a-258883ea642b'])
+        assert.ok(clickAndHoldArgs.args.includes('5cc459b8-36a8-3042-8b4a-258883ea642b'));
         assert.strictEqual(result.status, 0);
-      })
+      });
      
 
     this.client.start(done);
@@ -60,21 +60,22 @@ describe('.clickAndHold()', function() {
     let clickAndHoldArgs;
     this.client.transport.Actions.session.pressAndHold = function(args) {
       clickAndHoldArgs = args;
+
       return Promise.resolve({
         status: -1,
         value: null,
         error: new Error('Element could not be scrolled into view')
       });
-    }
+    };
 
     this.client.api.clickAndHold({
       retryInterval: 50,
       timeout: 100,
       selector: '#weblogin'
     }, function(result) {
-      assert.deepStrictEqual(clickAndHoldArgs.args,['5cc459b8-36a8-3042-8b4a-258883ea642b'])
+      assert.ok(clickAndHoldArgs.args.includes('5cc459b8-36a8-3042-8b4a-258883ea642b'));
       assert.strictEqual(result.status, -1);
-      assert.strictEqual(result.value.error,'An error occurred while running .clickAndHold() command on <#weblogin>: Element could not be scrolled into view')
+      assert.strictEqual(result.value.error, 'An error occurred while running .clickAndHold() command on <#weblogin>: Element could not be scrolled into view');
     });
 
     this.client.start(done);

--- a/test/src/api/commands/element/testDoubleClick.js
+++ b/test/src/api/commands/element/testDoubleClick.js
@@ -25,7 +25,7 @@ describe('.doubleClick()', function() {
     
     this.client.api.doubleClick('#weblogin', function callback(result) {
       assert.strictEqual(result.status, 0);
-      assert.deepStrictEqual(doubleClickArgs.args, ['5cc459b8-36a8-3042-8b4a-258883ea642b']);
+      assert.ok(doubleClickArgs.args.includes('5cc459b8-36a8-3042-8b4a-258883ea642b'));
       assert.strictEqual(this, api);
     });
 
@@ -46,7 +46,7 @@ describe('.doubleClick()', function() {
 
     this.client.api.useXpath()
       .doubleClick('//weblogin', function callback(result) {
-        assert.deepStrictEqual(doubleClickArgs.args, ['5cc459b8-36a8-3042-8b4a-258883ea642b']);
+        assert.ok(doubleClickArgs.args.includes('5cc459b8-36a8-3042-8b4a-258883ea642b'));
         assert.strictEqual(result.status, 0);
       });
     this.client.start(done);
@@ -70,7 +70,7 @@ describe('.doubleClick()', function() {
       timeout: 100,
       selector: '#weblogin'
     }, function(result) {
-      assert.deepStrictEqual(doubleClickArgs.args, ['5cc459b8-36a8-3042-8b4a-258883ea642b']);
+      assert.ok(doubleClickArgs.args.includes('5cc459b8-36a8-3042-8b4a-258883ea642b'));
       assert.strictEqual(result.status, -1);
       assert.strictEqual(result.value.error, 'An error occurred while running .doubleClick() command on <#weblogin>: Element could not be scrolled into view');
     });

--- a/test/src/api/commands/element/testDragAndDrop.js
+++ b/test/src/api/commands/element/testDragAndDrop.js
@@ -21,7 +21,8 @@ describe('moveToElement', function() {
     };
 
     this.client.api.dragAndDrop('css selector', '#weblogin', {x: 10, y: 10}, function(result) {
-      assert.deepStrictEqual(dragArgs, ['0', {x: 10, y: 10}]);
+      assert.deepEqual(dragArgs[0], '0');
+      assert.deepEqual(dragArgs[1], {x: 10, y: 10});
       assert.strictEqual(result.status, 0);
     });
 
@@ -39,7 +40,8 @@ describe('moveToElement', function() {
     };
 
     this.client.api.dragAndDrop('css selector', '#weblogin', '0', function(result) {
-      assert.deepStrictEqual(dragArgs, ['0', '0']);
+      assert.deepEqual(dragArgs[0], '0');
+      assert.deepEqual(dragArgs[1], '0');
       assert.strictEqual(result.status, 0);
     });
 

--- a/test/src/api/commands/element/testMoveToElement.js
+++ b/test/src/api/commands/element/testMoveToElement.js
@@ -21,16 +21,24 @@ describe('moveToElement', function() {
     };
 
     this.client.api.moveToElement('css selector', '#weblogin', null, null, function(result) {
-      assert.deepStrictEqual(moveToArgs, ['0', null, null]);
+      assert.deepStrictEqual(moveToArgs[0], '0');
+      assert.deepStrictEqual(moveToArgs[1], null);
+      assert.deepStrictEqual(moveToArgs[2], null);
       assert.strictEqual(result.status, 0);
     }).moveToElement('#weblogin', null, null, function(result) {
-      assert.deepStrictEqual(moveToArgs, ['0', null, null]);
+      assert.deepStrictEqual(moveToArgs[0], '0');
+      assert.deepStrictEqual(moveToArgs[1], null);
+      assert.deepStrictEqual(moveToArgs[2], null);
       assert.strictEqual(result.status, 0);
     }).moveTo('0', null, null, function(result) {
-      assert.deepStrictEqual(moveToArgs, ['0', 0, 0]);
+      assert.deepStrictEqual(moveToArgs[0], '0');
+      assert.deepStrictEqual(moveToArgs[1], 0);
+      assert.deepStrictEqual(moveToArgs[2], 0);
       assert.strictEqual(result.status, 0);
     }).moveToElement('#weblogin', 1, 1, function(result) {
-      assert.deepStrictEqual(moveToArgs, ['0', 1, 1]);
+      assert.deepStrictEqual(moveToArgs[0], '0');
+      assert.deepStrictEqual(moveToArgs[1], 1);
+      assert.deepStrictEqual(moveToArgs[2], 1);
       assert.strictEqual(result.status, 0);
     });
 

--- a/test/src/api/commands/element/testRightClick.js
+++ b/test/src/api/commands/element/testRightClick.js
@@ -19,13 +19,13 @@ describe('.rightClick()', function() {
       rightClickArgs = args;
       
       return Promise.resolve({
-        status:0,
+        status: 0,
         value: null
-      })
-    }
+      });
+    };
 
     this.client.api.rightClick('#weblogin', function callback(result) {
-      assert.deepStrictEqual(rightClickArgs.args,['5cc459b8-36a8-3042-8b4a-258883ea642b'])
+      assert.ok(rightClickArgs.args.includes('5cc459b8-36a8-3042-8b4a-258883ea642b'));
       assert.strictEqual(result.status, 0);
       assert.strictEqual(this, api);
     });
@@ -39,16 +39,16 @@ describe('.rightClick()', function() {
       rightClickArgs = args;
       
       return Promise.resolve({
-        status:0,
+        status: 0,
         value: null
-      })
-    }
+      });
+    };
 
     this.client.api.useXpath()
       .rightClick('//weblogin', function callback(result) {
-        assert.deepStrictEqual(rightClickArgs.args, ['5cc459b8-36a8-3042-8b4a-258883ea642b'])
+        assert.ok(rightClickArgs.args.includes('5cc459b8-36a8-3042-8b4a-258883ea642b'));
         assert.strictEqual(result.status, 0);
-      })
+      });
 
     this.client.start(done);
   });
@@ -57,21 +57,22 @@ describe('.rightClick()', function() {
     let rightClickArgs;
     this.client.transport.Actions.session.contextClick = function(args) {
       rightClickArgs = args;
+
       return Promise.resolve({
         status: -1,
         value: null,
         error: new Error('Element could not be scrolled into view')
       });
-    }
+    };
 
     this.client.api.rightClick({
       retryInterval: 50,
       timeout: 100,
       selector: '#weblogin'
     }, function(result) {
-      assert.deepStrictEqual(rightClickArgs.args,['5cc459b8-36a8-3042-8b4a-258883ea642b'])
+      assert.ok(rightClickArgs.args.includes('5cc459b8-36a8-3042-8b4a-258883ea642b'));
       assert.strictEqual(result.status, -1);
-      assert.strictEqual(result.value.error,'An error occurred while running .rightClick() command on <#weblogin>: Element could not be scrolled into view')
+      assert.strictEqual(result.value.error, 'An error occurred while running .rightClick() command on <#weblogin>: Element could not be scrolled into view');
     });
 
     this.client.start(done);


### PR DESCRIPTION
Fixes #4184

Adds selector and error line with proper formatting for "StaleElementReferenceError" and other errors that might occur when working with elements.

Since this updates the logs displayed, adding a test for it is hard. Instead, the PR adds an example to showcase the fix.

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.

- [X] Before marking your PR for review, please test and verify your changes by making appropriate modifications to any of the Nightwatch example tests (present in `examples/tests` directory of the project) and running them. `ecosia.js` and `duckDuckGo.js` are good examples to work with.
- [X] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [X] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;

The changes now display the logs as follows:
![Screenshot 2024-05-30 at 8 12 00 PM](https://github.com/nightwatchjs/nightwatch/assets/10705590/336fb0d6-45e4-49dd-816c-a8d4ef72d09d)

Copy of: #4214