### PR TITLE
Fix #4223: Restrict suppressNotFoundErrors to NoSuchElementError

### DIFF
--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -180,14 +180,14 @@ class ScopedWebElement {
 
         return await this.findElement({parentElement, selector: condition, index, timeout, retryInterval});
       } catch (error) {
+        const narrowedError = createNarrowedError({error, condition, timeout});
         if (
           this.suppressNotFoundErrors &&
-          error.name === 'NoSuchElementError'
+          narrowedError.name === 'NoSuchElementError'
         ) {
           return null;
         }
 
-        const narrowedError = createNarrowedError({error, condition, timeout});
         Logger.error(narrowedError);
 
         if (abortOnFailure) {
@@ -355,6 +355,16 @@ function createNarrowedError({error, condition, timeout}) {
   if (error.name === 'TimeoutError') {
     const err = new Error(`Timed out while waiting for element "${condition}" to be present for ${timeout} milliseconds.`);
     err.name = 'NoSuchElementError';
+
+    return err;
+  }
+
+  if (error.name === 'InvalidSelectorError') {
+    const err = new Error(
+      `Invalid selector encountered: "${condition}". ` +
+      'Please check the selector syntax and ensure it matches the DOM structure.'
+    );
+    err.name = 'InvalidSelectorError';
 
     return err;
   }

--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -180,7 +180,10 @@ class ScopedWebElement {
 
         return await this.findElement({parentElement, selector: condition, index, timeout, retryInterval});
       } catch (error) {
-        if (this.suppressNotFoundErrors) {
+        if (
+          this.suppressNotFoundErrors &&
+          error.name === 'NoSuchElementError'
+        ) {
           return null;
         }
 

--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -359,15 +359,7 @@ function createNarrowedError({error, condition, timeout}) {
     return err;
   }
 
-  if (error.name === 'InvalidSelectorError') {
-    const err = new Error(
-      `Invalid selector encountered: "${condition}". ` +
-      'Please check the selector syntax and ensure it matches the DOM structure.'
-    );
-    err.name = 'InvalidSelectorError';
-
-    return err;
-  }
+  error.message = `Error occurred while trying to locate element "${condition}": ${error.message || 'unknown error'}`;
 
   return error;
 }

--- a/test/sampletests/webelement/findWithSuppressNotFoundErrors.js
+++ b/test/sampletests/webelement/findWithSuppressNotFoundErrors.js
@@ -1,0 +1,8 @@
+describe('test', function () {
+  test('test find with suppressNotFoundErrors', async (browser) => {
+    browser.element.find({
+      selector: browser.globals.selector,
+      suppressNotFoundErrors: browser.globals.suppressNotFoundErrors
+    });
+  });
+});

--- a/test/src/api/commands/web-element/testFindOnErrors.js
+++ b/test/src/api/commands/web-element/testFindOnErrors.js
@@ -1,0 +1,171 @@
+const assert = require('assert');
+const path = require('path');
+const MockServer  = require('../../../../lib/mockserver.js');
+const Mocks = require('../../../../lib/command-mocks.js');
+const CommandGlobals = require('../../../../lib/globals/commands-w3c.js');
+const common = require('../../../../common.js');
+const NightwatchClient = common.require('index.js');
+const {settings} = common;
+
+describe('element().isPresent() command', function() {
+  before(function (done) {
+    CommandGlobals.beforeEach.call(this, done);
+
+  });
+
+  after(function (done) {
+    CommandGlobals.afterEach.call(this, done);
+  });
+
+  it('test .element.find(suppressNotFoundErrors: true) suppresses NoSuchElementError', async function() {
+    Mocks.createNewW3CSession();
+    MockServer.addMock({
+      url: '/session/13521-10219-202/elements',
+      method: 'POST',
+      postdata: JSON.stringify({using: 'css selector', value: '#wrong'}),
+      response: JSON.stringify({
+        value: []
+      })
+    });
+
+    let globalReporterCalled = false;
+
+    const globals = {
+      reporter(results) {
+        globalReporterCalled = true;
+        if (Object.prototype.hasOwnProperty.call(results, 'lastError')) {
+          assert.notStrictEqual(results.lastError.name, 'NoSuchElementError');
+        }
+      },
+      waitForConditionTimeout: 100,
+      selector: '#wrong',
+      suppressNotFoundErrors: true
+    };
+    const testsPath = [
+      path.join(__dirname, '../../../../sampletests/webelement/findWithSuppressNotFoundErrors.js')
+    ];
+
+    await NightwatchClient.runTests(testsPath, settings({
+      globals,
+      output_folder: 'output',
+      selenium_host: null
+    }));
+
+    assert.strictEqual(globalReporterCalled, true);
+  });
+
+  it('test .element.find(suppressNotFoundErrors: false) does not suppress NoSuchElementError', async function() {
+    Mocks.createNewW3CSession();
+    MockServer.addMock({
+      url: '/session/13521-10219-202/elements',
+      method: 'POST',
+      postdata: JSON.stringify({using: 'css selector', value: '#wrong'}),
+      response: JSON.stringify({
+        value: []
+      })
+    });
+
+    let globalReporterCalled = false;
+
+    const globals = {
+      reporter(results) {
+        globalReporterCalled = true;
+        assert.strictEqual(results.lastError.name, 'NoSuchElementError');
+      },
+      waitForConditionTimeout: 100,
+      selector: '#wrong',
+      suppressNotFoundErrors: false
+    };
+    const testsPath = [
+      path.join(__dirname, '../../../../sampletests/webelement/findWithSuppressNotFoundErrors.js')
+    ];
+
+    await NightwatchClient.runTests(testsPath, settings({
+      globals,
+      output_folder: 'output',
+      selenium_host: null
+    }));
+
+    assert.strictEqual(globalReporterCalled, true);
+  });
+
+  it('test .element.find(suppressNotFoundErrors: true) does not suppress other errors', async function() {
+    Mocks.createNewW3CSession();
+    MockServer.addMock({
+      url: '/session/13521-10219-202/elements',
+      method: 'POST',
+      postdata: JSON.stringify({using: 'css selector', value: '@wrong'}),
+      response: {
+        value: {
+          error: 'invalid selector',
+          message: 'invalid selector',
+          stacktrace: ''
+        }
+      },
+      statusCode: 400
+    });
+
+    let globalReporterCalled = false;
+
+    const globals = {
+      reporter(results) {
+        globalReporterCalled = true;
+        assert.strictEqual(results.lastError.name, 'InvalidSelectorError');
+      },
+      waitForConditionTimeout: 100,
+      selector: '@wrong',
+      suppressNotFoundErrors: true
+    };
+    const testsPath = [
+      path.join(__dirname, '../../../../sampletests/webelement/findWithSuppressNotFoundErrors.js')
+    ];
+
+    await NightwatchClient.runTests(testsPath, settings({
+      globals,
+      output_folder: 'output',
+      selenium_host: null
+    }));
+
+    assert.strictEqual(globalReporterCalled, true);
+  });
+
+  it('test .element.find(suppressNotFoundErrors: false) does not suppress other errors', async function() {
+    Mocks.createNewW3CSession();
+    MockServer.addMock({
+      url: '/session/13521-10219-202/elements',
+      method: 'POST',
+      postdata: JSON.stringify({using: 'css selector', value: '@wrong'}),
+      response: {
+        value: {
+          error: 'invalid selector',
+          message: 'invalid selector',
+          stacktrace: ''
+        }
+      },
+      statusCode: 400
+    });
+
+    let globalReporterCalled = false;
+
+    const globals = {
+      reporter(results) {
+        globalReporterCalled = true;
+        assert.strictEqual(results.lastError.name, 'InvalidSelectorError');
+      },
+      waitForConditionTimeout: 100,
+      selector: '@wrong',
+      suppressNotFoundErrors: false
+    };
+    const testsPath = [
+      path.join(__dirname, '../../../../sampletests/webelement/findWithSuppressNotFoundErrors.js')
+    ];
+
+    await NightwatchClient.runTests(testsPath, settings({
+      globals,
+      output_folder: 'output',
+      selenium_host: null
+    }));
+
+    assert.strictEqual(globalReporterCalled, true);
+  });
+});


### PR DESCRIPTION
## Description
This pull request addresses issue #4223. The suppressNotFoundErrors property in the new Element API previously suppressed all errors encountered by the WebDriver, including errors like InvalidSelectorError. This behavior was unintended, as suppressNotFoundErrors should ideally only suppress NoSuchElementError.

## Changes Made

Updated scoped-element.js to catch and handle NoSuchElementError specifically when suppressNotFoundErrors is enabled.
Modified the logic to allow other errors, like InvalidSelectorError, to propagate as expected.

## Steps to Reproduce the Issue
Use an invalid selector in a test command:
await browser.element.find({
    selector: '@something',
    suppressNotFoundErrors: true
});
Observe that InvalidSelectorError is no longer suppressed and propagates as intended.

## Proof of Work

Terminal Output
The attached screenshot shows the updated terminal output, where an InvalidSelectorError is correctly thrown when an invalid selector is provided.
<img width="1064" alt="Screenshot 2024-11-09 at 1 04 26 AM" src="https://github.com/user-attachments/assets/c30dba9a-6571-4988-b6c1-6f8770ddcce7">

Unit Test
A unit test was added to ecosia.js to validate this behavior. The test checks that an invalid selector throws InvalidSelectorError instead of suppressing it.
<img width="777" alt="Screenshot 2024-11-09 at 1 04 50 AM" src="https://github.com/user-attachments/assets/7836cf51-c5a6-4fa9-8cdd-aa98dbc24494">

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.

- [x ] Before marking your PR for review, please test and verify your changes by making appropriate modifications to any of the Nightwatch example tests (present in `examples/tests` directory of the project) and running them. `ecosia.js` and `duckDuckGo.js` are good examples to work with.
- [ x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [x ] If you're fixing a bug also create an issue if one doesn't exist yet;
- [x ] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [x ] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [x ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [x] Do not include changes that are not related to the issue at hand;
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [x] Always add unit tests - PRs without tests are most of the times ignored.
