### PR TITLE
Add getComputedLabel() and getComputedRole() alias commands.

### DIFF
--- a/lib/api/web-element/commands/getAccessibleName.js
+++ b/lib/api/web-element/commands/getAccessibleName.js
@@ -20,9 +20,11 @@
  * @method getAccessibleName
  * @memberof ScopedWebElement
  * @instance
- * @syntax browser.element(selector).getAccessibleName()
+ * @syntax browser.element.find(selector).getAccessibleName()
+ * @syntax browser.element.find(selector).getComputedLabel()
  * @link /#get-computed-label
  * @returns {ScopedValue<string>} A container with accessible name of an element.
+ * @alias getComputedLabel
  */
 module.exports.command = function() {
   return this.runQueuedCommandScoped('getElementAccessibleName');

--- a/lib/api/web-element/commands/getAriaRole.js
+++ b/lib/api/web-element/commands/getAriaRole.js
@@ -19,9 +19,11 @@
  * @method getAriaRole
  * @memberof ScopedWebElement
  * @instance
- * @syntax browser.element(selector).getAriaRole()
+ * @syntax browser.element.find(selector).getAriaRole()
+ * @syntax browser.element.find(selector).getComputedRole()
  * @link /#get-computed-role
  * @returns {ScopedValue<string>} The container with computed WAI-ARIA role of an element.
+ * @alias getComputedRole
  */
 module.exports.command = function() {
   return this.runQueuedCommandScoped('getElementAriaRole');

--- a/lib/api/web-element/scoped-element.js
+++ b/lib/api/web-element/scoped-element.js
@@ -27,9 +27,9 @@ class ScopedWebElement {
       'getProperty': ['property', 'prop'],
       'getText': ['text'],
       'getTagName': ['tagName'],
-      'getAccessibleName': ['accessibleName'],
+      'getAccessibleName': ['accessibleName', 'getComputedLabel'],
       'getCssProperty': ['css', 'getCssValue'],
-      'getAriaRole': ['ariaRole'],
+      'getAriaRole': ['ariaRole', 'getComputedRole'],
       'isVisible': ['isDisplayed']
     };
   }

--- a/test/src/api/commands/web-element/testGetAccessibleName.js
+++ b/test/src/api/commands/web-element/testGetAccessibleName.js
@@ -65,6 +65,31 @@ describe('element().getAccessibleName() command', function () {
     assert.strictEqual(resultValue, 'Signup');
   });
 
+  it('test .element().getComputedLabel() alias', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/computedlabel',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'Signup'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getComputedLabel();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+    assert.strictEqual(typeof resultPromise.value, 'object');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'Signup');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'Signup');
+  });
+
   it('test .element().find().getAccessibleName()', async function() {
     MockServer.addMock({
       url: '/session/13521-10219-202/element/1/computedlabel',

--- a/test/src/api/commands/web-element/testGetAriaRole.js
+++ b/test/src/api/commands/web-element/testGetAriaRole.js
@@ -38,7 +38,7 @@ describe('element().getAriaRole() command', function () {
     assert.strictEqual(resultValue, 'signupSection');
   });
 
-  it('test .element().ariaRole()', async function() {
+  it('test .element().ariaRole() alias', async function() {
     MockServer.addMock({
       url: '/session/13521-10219-202/element/0/computedrole',
       method: 'GET',
@@ -48,6 +48,30 @@ describe('element().getAriaRole() command', function () {
     }, true);
 
     const resultPromise = this.client.api.element('#signupSection').ariaRole();
+    assert.strictEqual(resultPromise instanceof Element, false);
+    assert.strictEqual(typeof resultPromise.find, 'undefined');
+
+    assert.strictEqual(resultPromise instanceof Promise, false);
+    assert.strictEqual(typeof resultPromise.then, 'function');
+
+    const result = await resultPromise;
+    assert.strictEqual(result instanceof WebElement, false);
+    assert.strictEqual(result, 'signupSection');
+
+    const resultValue = await resultPromise.value;
+    assert.strictEqual(resultValue, 'signupSection');
+  });
+
+  it('test .element().getComputedRole() alias', async function() {
+    MockServer.addMock({
+      url: '/session/13521-10219-202/element/0/computedrole',
+      method: 'GET',
+      response: JSON.stringify({
+        value: 'signupSection'
+      })
+    }, true);
+
+    const resultPromise = this.client.api.element('#signupSection').getComputedRole();
     assert.strictEqual(resultPromise instanceof Element, false);
     assert.strictEqual(typeof resultPromise.find, 'undefined');
 

--- a/types/tests/webElement.test-d.ts
+++ b/types/tests/webElement.test-d.ts
@@ -171,8 +171,10 @@ describe('new element() api', function () {
 
     expectType<ElementValue<string>>(elem.getAccessibleName());
     expectType<ElementValue<string>>(elem.accessibleName());
+    expectType<ElementValue<string>>(elem.getComputedLabel());
     expectType<ElementValue<string>>(elem.getAriaRole());
     expectType<ElementValue<string>>(elem.ariaRole());
+    expectType<ElementValue<string>>(elem.getComputedRole());
     expectType<ElementValue<string>>(elem.getCssProperty('height'));
     expectType<ElementValue<string>>(elem.css('height'));
     expectType<ElementValue<string>>(elem.getCssValue('height'));

--- a/types/web-element.d.ts
+++ b/types/web-element.d.ts
@@ -188,9 +188,11 @@ export interface ScopedElement extends Element, PromiseLike<WebElement> {
 
   getAccessibleName(): ElementValue<string>;
   accessibleName(): ElementValue<string>;
+  getComputedLabel(): ElementValue<string>;
 
   getAriaRole(): ElementValue<string>;
   ariaRole(): ElementValue<string>;
+  getComputedRole(): ElementValue<string>;
 
   getCssProperty(name: string): ElementValue<string>;
   css(name: string): ElementValue<string>;


### PR DESCRIPTION
This PR adds the following aliases to the new Element API:
- `getComputedLabel()` for `getAccessibleName()` command.
- `getComputedRole()` for `getAriaRole()` command.
