### PR TITLE
Add types for custom commands on page object sections.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -68,6 +68,10 @@ export type NightwatchGenericCallback<T> = (
 
 export type Awaitable<T, V> = Omit<T, 'then'> & PromiseLike<V>;
 
+export type KeysFilter<T, U> = {
+  [K in keyof T]-?: T[K] extends U ? K : never;
+}[keyof T];
+
 // tslint:disable-next-line
 type VoidToNull<T> = T extends void ? null : T;
 

--- a/types/page-object.d.ts
+++ b/types/page-object.d.ts
@@ -9,8 +9,8 @@ import {
   ElementCommands,
   ElementFunction,
   Expect,
+  KeysFilter,
   LocateStrategy,
-  NamespacedApi,
   NightwatchAPI,
   NightwatchClient,
   NightwatchComponentTestingCommands,
@@ -147,6 +147,7 @@ export type EnhancedSectionInstance<
   Commands &
   ElementCommands &
   ChromiumClientCommands &
+  Pick<NightwatchCustomCommands, KeysFilter<NightwatchCustomCommands, Function>> & // eslint-disable-line @typescript-eslint/ban-types
   Pick<
     NightwatchComponentTestingCommands,
     'importScript' | 'launchComponentRenderer' | 'mountComponent'

--- a/types/tests/page-object.test-d.ts
+++ b/types/tests/page-object.test-d.ts
@@ -1,21 +1,33 @@
-// Page object file
-import {EnhancedPageObject, PageObjectModel} from '..';
+import {expectError, expectType} from 'tsd';
+import {EnhancedPageObject, PageObjectModel, Awaitable, NightwatchAPI} from '..';
 
+// Page object file
 const fileUploadPageElements = {
   fileUploadInput: 'input#file-upload',
   submitButton: 'input#file-submit',
   uploadFiles: '#uploaded-files'
 };
 
+const menuSection = {
+  selector: 'nav',
+  elements: {
+    home: 'a[href="/"]',
+    about: 'a[href="/about"]'
+  }
+};
+
 const fileUploadPage = {
   url(this: EnhancedPageObject) {
     return `${this.api.launch_url}/upload`;
   },
-  elements: fileUploadPageElements
+  elements: fileUploadPageElements,
+  sections: {
+    menu: menuSection
+  }
 } satisfies PageObjectModel;
 
 export interface FileUploadPage extends
-  EnhancedPageObject<{}, typeof fileUploadPageElements, {}, {}, () => string> {} // eslint-disable-line @typescript-eslint/ban-types
+  EnhancedPageObject<{}, typeof fileUploadPageElements, typeof fileUploadPage.sections, {}, () => string> {} // eslint-disable-line @typescript-eslint/ban-types
 
 export default fileUploadPage;
 
@@ -25,6 +37,13 @@ export default fileUploadPage;
 declare module '..' {
   interface NightwatchCustomPageObjects {
     FileUpload(): FileUploadPage;
+  }
+  interface NightwatchCustomCommands {
+    uploadFile1(selector: string, filePath: string): NightwatchAPI;
+    uploadFile2(selector: string, filePath: string): Awaitable<NightwatchAPI, null>;
+    upload: {
+      file(selector: string, filePath: string): NightwatchAPI;
+    }
   }
 }
 
@@ -41,6 +60,19 @@ describe('File Upload', function() {
       // alternate way of passing an element instead of '@submitButton'
       .click(fileUploadPage.elements.submitButton)
       .expect.element('@uploadFiles').text.to.equal('test.txt');
+
+    // test custom commands over page object
+    expectType<NightwatchAPI>(fileUploadPage.uploadFile1('@fileUploadInput', 'test2.txt'));
+    expectType<Awaitable<NightwatchAPI, null>>(fileUploadPage.uploadFile2('@fileUploadInput', 'test2.txt'));
+    // should fail ideally but succeeding
+    expectType<NightwatchAPI>(fileUploadPage.upload.file('@fileUploadInput', 'test2.txt'));
+
+    // test custom commands over page object sections
+    const menuSection = fileUploadPage.section.menu;
+    expectType<NightwatchAPI>(menuSection.uploadFile1('@fileUploadInput', 'test2.txt'));
+    expectType<Awaitable<NightwatchAPI, null>>(menuSection.uploadFile2('@fileUploadInput', 'test2.txt'));
+    // should fail because the namespaces from custom commands are not loaded directly into the section
+    expectError(menuSection.upload.file('@fileUploadInput', 'test2.txt'));
 
     browser.end();
   });


### PR DESCRIPTION
Fixes: #4292 

This PR adds the types for the custom commands that are made available directly over the page object sections.

It should be noted NOT all custom commands are made available directly on the section object. All the custom commands are only available on the `section.api` object while the `section` object directly contains all the custom commands EXCEPT those having a namespace. This behaviour has been accounted for in the type definition.

For example, let's say the structure of the `custom-commands` folder is as follows:
```
custom-commands/
  - command1.js
  - command2.js
  - namespace1/
      - command.js
```

The above custom commands would be available on the various APIs as follows (assuming a page-object named `myPage` with a `mySection` section):
```js
// all commands are available on the `browser` object
browser.command1();
browser.command2();
browser.namespace1.command(); // WORKS

// only non-namespaced custom commands are available on the `mySection` object directly
const mySection = myPage.section.mySection;

mySection.api.command1();
mySection.command2();
mySection.namespace1.command(); // !!!ERROR

// all commands are available on the `mySection.api` object
mySection.api.command1();
mySection.command2();
mySection.namespace1.command();  // WORKS
```

The above is also true for the page-objects -- only non-namespaced custom commands are made directly available on the page object.

The types for custom commands on page-objects should also be fixed at some later time (after making sure that the newly added type definition is working correctly).