### PR TITLE
added thrown error for duplicate testcases in describe instance

### DIFF
--- a/lib/testsuite/context.js
+++ b/lib/testsuite/context.js
@@ -316,9 +316,13 @@ class Context extends EventEmitter {
       throw new Error(`The "${testName}" test script must be a function. "${typeof testFn}" given.`);
     }
 
-    // TODO: warn if test name already exists
     if (!skipTest) {
-      this.tests.push(testName);
+      if(this.tests.includes(testName)) {
+        throw new Error(`${testName} step already exists, testcases must have unique names in the test suite.`);
+      }
+      else {
+        this.tests.push(testName);
+      }
     } else {
       this.skippedTests.push(testName);
     }


### PR DESCRIPTION
## Description
duplicate testcases inside describe instance that have same testName runs only the second test function for each time, this behavior should not be allowed so the user should have a thrown error explaining this to make test names inside the describe suite unique

## Proof of work
here it shows the error when you write two tests with the same name inside the describe test suite
![Screenshot 2024-11-16 140401](https://github.com/user-attachments/assets/aa570e24-e611-40a4-ae77-fd8d86e4ac38)

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with reviewing it quicker.

- [x] Before marking your PR for review, please test and verify your changes by making appropriate modifications to any of the Nightwatch example tests (present in `examples/tests` directory of the project) and running them. `ecosia.js` and `duckDuckGo.js` are good examples to work with.
- [x] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`);
- [x] If you're fixing a bug also create an issue if one doesn't exist yet;
- [x] If it's a new feature explain why do you think it's necessary. Please check with the maintainers beforehand to make sure it is something that we will accept. Usually we only accept new features if we feel that they will benefit the entire community;
- [x] Please avoid sending PRs which contain drastic or low level changes. If you are certain that the changes are needed, please discuss them beforehand and indicate what the impact will be;
- [x] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will most likely be ignored;
- [x] Do not include changes that are not related to the issue at hand;
- [x] Follow the same coding style with regards to spaces, semicolons, variable naming etc.;
- [x] Always add unit tests - PRs without tests are most of the times ignored.