### PR TITLE
Fix TypeError while using assert.present() in new Elem API.

### DIFF
--- a/lib/api/web-element/assert/element-assertions.js
+++ b/lib/api/web-element/assert/element-assertions.js
@@ -90,7 +90,7 @@ module.exports.create = function createAssertions(scopedElement, {negated = fals
       value(message) {
         return instance.assert(async (assertApi, element) => {
           const el = await element;
-          const id = await el.getId();
+          const id = await el?.getId();
 
           return assertApi.ok(el instanceof WebElement, message || `Testing if the element <WebElement: ${id}> is present.`);
         });


### PR DESCRIPTION
When using the `.assert.present()` assertion on the new Element API, if the element is not present, the following error is thrown instead of the normal assertion failure.

![image](https://github.com/user-attachments/assets/9409abbe-25be-4fb2-884d-b9d6892d4e97)

This PR fixes the cause of this error so that a normal assertion failure occurs.