### PR TITLE
Fix unhandledRejection on error inside function-based custom commands.

### DIFF
--- a/lib/api/_loaders/command.js
+++ b/lib/api/_loaders/command.js
@@ -183,7 +183,16 @@ class CommandLoader extends BaseCommandLoader {
           })
           .catch(err => {
             if (instance instanceof EventEmitter) {
-              instance.emit('error', err);
+              if (instance.needsPromise) {
+                // if the instance has `needsPromise` set to `true`, the `error` event is listened
+                // on the `context` object, not on the `instance` object (in `treenode.js`).
+                this.emit('error', err);
+              } else {
+                // most probably a dead code because all `instance` objects with `EventEmitter`
+                // superclass are expected to be function-style commands which will always have
+                // the `needsPromise` property set to `true`. But, not taking chances here.
+                instance.emit('error', err);
+              }
 
               return;
             }

--- a/lib/api/_loaders/command.js
+++ b/lib/api/_loaders/command.js
@@ -188,9 +188,9 @@ class CommandLoader extends BaseCommandLoader {
                 // on the `context` object, not on the `instance` object (in `treenode.js`).
                 this.emit('error', err);
               } else {
-                // most probably a dead code because all `instance` objects with `EventEmitter`
-                // superclass are expected to be function-style commands which will always have
-                // the `needsPromise` property set to `true`. But, not taking chances here.
+                // for class-based commands that inherit from EventEmitter.
+                // Since the `needsPromise` is set to `false` in this case, the `complete` and `error`
+                // events are listened on the `instance` object.
                 instance.emit('error', err);
               }
 

--- a/lib/core/treenode.js
+++ b/lib/core/treenode.js
@@ -206,6 +206,9 @@ class TreeNode {
       commandResult = this.instance;
       if (this.instance.needsPromise) {
         this.needsPromise = true;
+        // this change was done because the only way function-styled custom commands could be resolved
+        // is if they contain another NW API command, which could call `node.context.emit('complete')`
+        // inside `asynctree.js > resolveNode` method for the custom command node.
         commandResult = this.context;
       }
     } else if (this.context instanceof EventEmitter) { // Chai assertions


### PR DESCRIPTION
Right now, if a custom command is written in function-style and some error occurs during the execution of that custom command, it leads to an `unhandledRejection`, leading to the closure of Nightwatch process without ending the webdriver session.

This PR fixes that behaviour by handling the error thrown inside the custom command correctly.