### PR TITLE
Add `CustomCommandInstance` interface for `this` in custom commands.

### DIFF
--- a/types/custom-command.d.ts
+++ b/types/custom-command.d.ts
@@ -5,14 +5,14 @@ export interface NightwatchCustomCommandsModel {
    * @example
    * class LogMessage implements NightwatchCustomCommandsModel {
    *   command() {
-   *     
+   *
    *     return Promise.resolve();
    *   }
    * }
    *
    * @see https://nightwatchjs.org/guide/extending-nightwatch/adding-custom-commands.html#define-a-custom-command
    */
-  command: (...args: any) => unknown | Promise<unknown>;
+  command: (...args: any[]) => unknown | Promise<unknown>;
 }
 
 /**

--- a/types/custom-command.d.ts
+++ b/types/custom-command.d.ts
@@ -1,3 +1,7 @@
+import {CommandInstance} from './index';
+
+export interface CustomCommandInstance extends CommandInstance {}
+
 export interface NightwatchCustomCommandsModel {
   /**
    * Define a custom command

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1221,7 +1221,7 @@ export interface CommandInstance {
   httpRequest(options: HttpRequestOptions): Promise<unknown>;
 
   toString(): string;
-  complete(...args: unknown[]): void; // test the args are working fine.
+  complete(...args: unknown[]): void;
 }
 
 export interface CreateClientParams {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1153,6 +1153,77 @@ export interface NightwatchClientObject {
   sessionId: string | null;
 }
 
+export interface HttpRequestOptions {
+  /**
+   * The pathname of the endpoint to call. Ex: `'/session/:sessionId/url'`.
+   *
+   * Alternatively, url property could be provided with the full URL.
+   */
+  path?: string;
+  data?: unknown;
+
+  /**
+   * For custom-commands, set to `this.api.sessionId`.
+   */
+  sessionId: string;
+
+  method: 'POST' | 'GET' | 'DELETE' | 'PUT';
+  use_ssl?: boolean;
+  host?: string;
+  port?: number;
+
+  /**
+   * The full URL to call. Ex: `http://localhost:4444/session/:sessionId/url`.
+   */
+  url?: string;
+
+  auth?: {
+    user: string;
+    pass: string;
+  }
+}
+
+export interface CommandInstance {
+  get api(): NightwatchAPI;
+  get client(): NightwatchClient;
+  get commandArgs(): unknown[];
+  get commandFileName(): string;
+  get driver(): WebDriver;
+  get isES6AsyncCommand(): boolean;
+  get reuseBrowser(): boolean;
+
+  /**
+   * Direct access to methods present in the `lib/transport/selenium-webdriver/method-mappings.js` file
+   * of Nightwatch code.
+   *
+   * TODO: complete the type definition.
+   *
+   * For now, you would need to create custom interface to use this property, like below:
+   * ```ts
+   * interface TransportActions {
+   *   getCurrentUrl(): Promise<NightwatchCallbackResult<string>>;
+   * }
+   * ```
+   * then use it inside your custom command like:
+   * ```ts
+   * const currentUrl = await (this.transportActions as TransportActions).getCurrentUrl();
+   * ```
+   */
+  get transportActions(): unknown;
+
+  /**
+   * Directly call the HTTP endpoints of the Selenium/WebDriver server.
+   *
+   * This is useful when you need to call a command that is not directly supported by Nightwatch API.
+   *
+   * @see https://nightwatchjs.org/guide/extending-nightwatch/adding-custom-commands.html#postdoc-directly-calling-seleniumwebdriver-endpoints
+   */
+  httpRequest(options: HttpRequestOptions): Promise<unknown>;
+
+  toString(): string;
+  complete(...args: unknown[]): void; // test the args are working fine.
+}
+
 export interface CreateClientParams {
   browserName?: string | null;
   headless?: boolean;

--- a/types/tests/customCommands.test-d.ts
+++ b/types/tests/customCommands.test-d.ts
@@ -1,0 +1,58 @@
+import {expectType} from 'tsd';
+import {CommandInstance, NightwatchCallbackResult, NightwatchCustomCommandsModel} from '..';
+
+export class AngularCommand implements NightwatchCustomCommandsModel {
+  async command(this: CommandInstance, listName: string, cb = function<T>(r: T) {return r}) {
+    // Script to be executed in the browser
+    const script = function(listName: string) {
+      // executed in the browser context
+      // eslint-disable-next-line
+      var elements = document.querySelectorAll('*[ng-repeat$="'+listName+'"]');
+
+      if (elements) {return elements}
+
+      return null;
+    };
+
+    // Arguments to be passed to the script function above
+    const args: [string] = [listName];
+
+    // Callback to be called when the script finishes its execution,
+    // with the result returned by the script passed as argument.
+    const callback = async function(result: any) {
+      const cbResult = await cb(result);
+
+      if (cbResult.value) {
+        return cbResult.value;
+      }
+
+      return cbResult;
+    };
+
+    // Execute the script defined above, along with arguments and
+    // the callback function.
+    await this.api.executeScript(script, args, callback);
+
+
+    // CUSTOM COMMAND WITH `this.httpRequest` EXAMPLE
+    const response = await this.httpRequest({
+      path: '/session/:sessionId/url',
+      sessionId: this.api.sessionId,
+      method: 'POST',
+      data: {
+        url: 'https://nightwatchjs.org'
+      }
+    });
+    expectType<unknown>(response);
+
+    // CUSTOM COMMAND WITH `this.transportActions` EXAMPLE (still incomplete)
+    const currentUrl = await (this.transportActions as TransportActions).getCurrentUrl();
+    expectType<NightwatchCallbackResult<string>>(currentUrl);
+
+    this.complete('hello', 1, true, {value: null});
+  }
+}
+
+interface TransportActions {
+  getCurrentUrl(): Promise<NightwatchCallbackResult<string>>;
+}

--- a/types/tests/customCommands.test-d.ts
+++ b/types/tests/customCommands.test-d.ts
@@ -1,8 +1,8 @@
 import {expectType} from 'tsd';
-import {CommandInstance, NightwatchCallbackResult, NightwatchCustomCommandsModel} from '..';
+import {CustomCommandInstance, NightwatchCallbackResult, NightwatchCustomCommandsModel} from '..';
 
 export class AngularCommand implements NightwatchCustomCommandsModel {
-  async command(this: CommandInstance, listName: string, cb = function<T>(r: T) {return r}) {
+  async command(this: CustomCommandInstance, listName: string, cb = function<T>(r: T) {return r}) {
     // Script to be executed in the browser
     const script = function(listName: string) {
       // executed in the browser context


### PR DESCRIPTION
An appliable type for `this` was missing while writing class-styled custom commands. This PR fixes that by adding a new `CommandInstance` interface that could be used while writing custom commands for `this` (as shown in the types/tests/customCommands.test-d.ts` file).
