### PR TITLE
Reject custom commands node promise on abortOnFailure.

### DIFF
--- a/lib/api/_loaders/command.js
+++ b/lib/api/_loaders/command.js
@@ -113,10 +113,6 @@ class CommandLoader extends BaseCommandLoader {
         return this.client.transport.driver;
       }
 
-      get rejectNodeOnAbortFailure() {
-        return true;
-      }
-
       httpRequest(requestOptions) {
         return this.client.transport.runProtocolAction(requestOptions);
       }
@@ -155,6 +151,13 @@ class CommandLoader extends BaseCommandLoader {
 
   createWrapper() {
     if (this.module) {
+      // this place is only reached by client-commands, protocol commands and custom-commands (no assertions or element-commands).
+      if (this.isUserDefined) {
+        // only custom-commands will reach here.
+        // later extend this to client-commands and protocol commands as well.
+        this.module.rejectNodeOnAbortFailure = true;
+      }
+
       this.commandFn = function commandFn({args, stackTrace}) {
         const instance = CommandLoader.createInstance(this.nightwatchInstance, this.module, {
           stackTrace,

--- a/lib/api/_loaders/command.js
+++ b/lib/api/_loaders/command.js
@@ -113,6 +113,10 @@ class CommandLoader extends BaseCommandLoader {
         return this.client.transport.driver;
       }
 
+      get rejectNodeOnAbortFailure() {
+        return true;
+      }
+
       httpRequest(requestOptions) {
         return this.client.transport.runProtocolAction(requestOptions);
       }

--- a/lib/api/_loaders/command.js
+++ b/lib/api/_loaders/command.js
@@ -155,7 +155,12 @@ class CommandLoader extends BaseCommandLoader {
       if (this.isUserDefined) {
         // only custom-commands will reach here.
         // later extend this to client-commands and protocol commands as well.
-        this.module.rejectNodeOnAbortFailure = true;
+        Object.defineProperty(this.module, 'rejectNodeOnAbortFailure', {
+          configurable: true,
+          get() {
+            return true;
+          }
+        });
       }
 
       this.commandFn = function commandFn({args, stackTrace}) {

--- a/lib/core/asynctree.js
+++ b/lib/core/asynctree.js
@@ -106,7 +106,7 @@ class AsyncTree extends EventEmitter{
   shouldRejectNodePromise(err, abortOnFailure, node = this.currentNode) {
     const rejectNodeOnAbortFailure = node.options?.rejectNodeOnAbortFailure;
 
-    if ((err.isExpect || node.namespace === 'assert' || (abortOnFailure && rejectNodeOnAbortFailure)) && this.currentNode.isES6Async) {
+    if ((err.isExpect || node.namespace === 'assert' || (abortOnFailure && rejectNodeOnAbortFailure)) && node.isES6Async) {
       return true;
     }
 
@@ -134,7 +134,6 @@ class AsyncTree extends EventEmitter{
     this.emit('asynctree:command:start', {node});
 
     const result = await node.run();
-    const {parent} = this.currentNode;
 
     let abortOnFailure = false;
     let err;
@@ -155,7 +154,7 @@ class AsyncTree extends EventEmitter{
       }
 
       if (this.shouldRejectParentNodePromise(err, node)) {
-        parent.reject(err);
+        node.parent.reject(err);
       }
     } else {
       node.resolveValue = result;

--- a/test/extra/commands/customCommandWithFailureClass.js
+++ b/test/extra/commands/customCommandWithFailureClass.js
@@ -1,0 +1,5 @@
+module.exports = class CustomCommandWithFailureClass{
+  async command() {
+    await this.api.waitForElementPresent('#badElement', 100);
+  }
+};

--- a/test/sampletests/withcustomcommands/sampleWithAsyncFailures.js
+++ b/test/sampletests/withcustomcommands/sampleWithAsyncFailures.js
@@ -1,0 +1,15 @@
+module.exports = {
+  before(client) {
+    client.globals.increment++;
+  },
+
+  async demoTestAsync(client) {
+    await client.url('http://localhost').customCommandWithFailureClass();
+    // below statement should be unreachable because the custom command should be rejected
+    client.globals.increment++;
+  },
+
+  after(client) {
+    client.globals.increment++;
+  }
+};

--- a/test/src/runner/testRunWithCustomCommands.js
+++ b/test/src/runner/testRunWithCustomCommands.js
@@ -34,14 +34,14 @@ describe('testRunWithCustomCommands', function() {
   });
 
   it('testRunner with custom command which has failures', function() {
-    let testsPath = path.join(__dirname, '../../sampletests/withcustomcommands');
-    let globals = {
+    const testsPath = path.join(__dirname, '../../sampletests/withcustomcommands');
+    const globals = {
       increment: 0,
       retryAssertionTimeout: 0,
       waitForConditionPollInterval: 10,
       waitForConditionTimeout: 20,
       reporter(results, cb) {
-        assert.strictEqual(globals.increment, 4);
+        assert.strictEqual(globals.increment, 6);
         cb();
       }
     };
@@ -55,12 +55,12 @@ describe('testRunWithCustomCommands', function() {
   });
 
   it('testRunner with ES6 Async custom commands', function() {
-    let testsPath = path.join(__dirname, '../../sampletests/withes6asynccommands');
+    const testsPath = path.join(__dirname, '../../sampletests/withes6asynccommands');
     let testResults;
     const origExit = process.exit;
     process.exit = function() {};
 
-    let globals = {
+    const globals = {
       increment: 0,
       logResult: null,
       retryAssertionTimeout: 0,
@@ -101,12 +101,12 @@ describe('testRunWithCustomCommands', function() {
   });
 
   it('testRunner with ES6 Async custom commands', function() {
-    let testsPath = path.join(__dirname, '../../sampletests/withes6asynccommands');
+    const testsPath = path.join(__dirname, '../../sampletests/withes6asynccommands');
     let testResults;
     const origExit = process.exit;
     process.exit = function() {};
 
-    let globals = {
+    const globals = {
       increment: 0,
       logResult: null,
       retryAssertionTimeout: 0,
@@ -147,12 +147,12 @@ describe('testRunWithCustomCommands', function() {
   });
 
   it('testRunner custom command which extends built-in command', function() {
-    let testsPath = path.join(__dirname, '../../sampletests/withcustomcommands/element');
+    const testsPath = path.join(__dirname, '../../sampletests/withcustomcommands/element');
     let testResults;
     const origExit = process.exit;
     process.exit = function() {};
 
-    let globals = {
+    const globals = {
       increment: 0,
       logResult: null,
       retryAssertionTimeout: 0,
@@ -229,12 +229,12 @@ describe('testRunWithCustomCommands', function() {
   });
 
   it('testRunner custom command path as glob pattern', function() {
-    let testsPath = path.join(__dirname, '../../sampletests/withcustomcommands/element');
+    const testsPath = path.join(__dirname, '../../sampletests/withcustomcommands/element');
     let testResults;
     const origExit = process.exit;
     process.exit = function() {};
 
-    let globals = {
+    const globals = {
       increment: 0,
       logResult: null,
       retryAssertionTimeout: 0,


### PR DESCRIPTION
If a command results in an error with `abortOnFailure` set to `true`, the node promise of the command inside the test case still gets resolved instead of getting rejected, while the queue is anyway cleared because of `abortOnFailure`.

This leads to a situation where if we chain some more commands after this command in the test case, the test would get stuck (because the queue is emptied) and hence will abort successfully. But, if the await is directly used on the command, that await will resolve and the test will continue normally since the following commands will be added to the queue after the queue is cleared.

The command promise inside the test case should instead be rejected so that the test case throws an error and thus aborting itself instead of continuing normally.

### Impact

Only affects custom-commands, which will now reject inside testcase on abort failures instead of getting resolved.

### Future TODOs
* If a command chain ends with an assert command and some command in mid gets failed, the assertion gets resolved, resulting in the testcase continuing instead of getting stuck or failing.
  Moreover, since the queue is emptied on a command failure, the commands between the failed command and resolved assertion never get executed but the commands after resolved assertion will start to run normally.
* Extend this functionality to all `client-commands` and `protocol` commands while making sure that commands like `.getTitle()` also work correctly if there's an abort failure inside the `title()` command (child-command of the `.getTitle()` command).
* (Low Priority) On failure of a custom-command, `done()` function of queue is reached before the main command could be resolved, leading to runnable getting resolved/rejected before the testcase is actually wrapped up. So, resolve the custom command treenode in testcase before moving to `done()` or delay the call of `done()`.
  ^ `done()` is being called earlier due to the failure of a sub-command of the custom-command.
  The main issue this causes is when inside the test case the custom-command gets resolved (after the call of `done()` and hence resolution/rejection of the runnable), the following commands in the testcase get added to the queue which then overlap with the commands of further tests (like saveScreenshot, afterEach) because the runnable was settled earlier.
  ^ This main issue should be resolved in this PR because we are now rejecting the custom command node inside the test instead of resolving it.
  
Note: On the third point, even when this PR solves the issue partially, if the user decides to use `try/catch` to catch the custom command error inside the testcase, the `done()` would have still been called earlier due to which the following commands inside the test case will start to overlap with future runnables. So, to fix this fully, we should probably not call `done()` for the sub-command failure. On doing this, the main command will get rejected in the testcase before the call of queue `done()` (arising from the custom-command failure), it will be caught and other commands will be added to the queue. This would result in the queue `done()` call getting skipped in this case because at that point there will be some nodes existing inside the tree.