### PR TITLE
Fix support for BrowserStack TurboScale in Nightwatch.

### DIFF
--- a/lib/transport/factory.js
+++ b/lib/transport/factory.js
@@ -48,8 +48,12 @@ module.exports = class TransportFactory {
     }
   }
 
+  static usingBrowserstackTurboScale(settings) {
+    return settings.webdriver.host && (settings.webdriver.host.endsWith('.browserstack-ats.com') || settings.webdriver.host.startsWith('browserstack-turboscale-grid'));
+  }
+
   static usingBrowserstack(settings) {
-    return settings.webdriver.host && (settings.webdriver.host.endsWith('.browserstack.com') || settings.webdriver.host.endsWith('.browserstack-ats.com') || settings.webdriver.host.startsWith('browserstack-turboscale-grid'));
+    return settings.webdriver.host && (settings.webdriver.host.endsWith('.browserstack.com') || TransportFactory.usingBrowserstackTurboScale(settings));
   }
 
   static getBrowserName(nightwatchInstance) {
@@ -122,6 +126,12 @@ module.exports = class TransportFactory {
         const AppAutomate = require('./selenium-webdriver/browserstack/appAutomate.js');
 
         return new AppAutomate(nightwatchInstance, browserName);
+      }
+
+      if (TransportFactory.usingBrowserstackTurboScale(nightwatchInstance.settings)) {
+        const AutomateTurboScale = require('./selenium-webdriver/browserstack/automateTurboScale.js');
+
+        return new AutomateTurboScale(nightwatchInstance, browserName);
       }
 
       const Automate = require('./selenium-webdriver/browserstack/automate.js');

--- a/lib/transport/selenium-webdriver/browserstack/automateTurboScale.js
+++ b/lib/transport/selenium-webdriver/browserstack/automateTurboScale.js
@@ -1,0 +1,9 @@
+const Automate = require('./automate.js');
+
+class AutomateTurboScale extends Automate {
+  get productNamespace() {
+    return 'automate-turboscale/v1';
+  }
+}
+
+module.exports = AutomateTurboScale;


### PR DESCRIPTION
TODO:
* Fix the APIs for Automate TurboScale by overriding the `getBuildId` and `sendReasonToBrowserstack` methods in the `AutomateTurboScale` class. And add tests.
  
  Automate APIs: https://www.browserstack.com/docs/automate/api-reference/selenium/session
  Automate TurboScale APIs: https://www.browserstack.com/docs/automate-turboscale/api-reference/session
* Add tests.