### PR TITLE
Fix `.perform()` command node promise getting resolve early.

### DIFF
--- a/lib/api/client-commands/perform.js
+++ b/lib/api/client-commands/perform.js
@@ -62,9 +62,13 @@ class Perform extends EventEmitter {
     return true;
   }
 
+  static get avoidPrematureParentNodeResolution() {
+    return true;
+  }
+
   command(callback = function() {}) {
     let doneCallback;
-    let asyncHookTimeout = this.client.settings.globals.asyncHookTimeout;
+    const asyncHookTimeout = this.client.settings.globals.asyncHookTimeout;
 
     this.timeoutId = setTimeout(() => {
       this.emit('error', new Error(`Timeout while waiting (${asyncHookTimeout}ms) for the .perform() command callback to be called.`));
@@ -99,7 +103,7 @@ class Perform extends EventEmitter {
       };
     } else {
       doneCallback = () => {
-        let args = [(result) => {
+        const args = [(result) => {
           clearTimeout(this.timeoutId);
           this.emit('complete', result);
         }];


### PR DESCRIPTION
When the `.perform()` command is used with `async/await` inside a test case (`await browser.perform()`) and the callback passed to the `.perform()` command contains more than 1 Nightwatch command, the node promise returned by the `.perform()` command get resolved early (after the execution of the first Nightwatch command inside the callback).

This leads to a situation where the rest of the command inside the callback starts to overlap with the commands following the `.perform()` command inside the test case, which could give unexpected results.