### PR TITLE
Increase default timeout for `browserstack` env.

### DIFF
--- a/lib/runner/cli/nightwatch.conf.ejs
+++ b/lib/runner/cli/nightwatch.conf.ejs
@@ -195,7 +195,7 @@ module.exports = {
       disable_error_log: true,
       webdriver: {
         timeout_options: {
-          timeout: 15000,
+          timeout: 60000,
           retry_attempts: 3
         },
         keep_alive: true,

--- a/test/src/cli/testCliRunnerGenerate.js
+++ b/test/src/cli/testCliRunnerGenerate.js
@@ -131,7 +131,7 @@ describe('Test CLI Runner Generate', function() {
           disable_error_log: true,
           webdriver: {
             timeout_options: {
-              timeout: 15000,
+              timeout: 60000,
               retry_attempts: 3
             },
             keep_alive: true,


### PR DESCRIPTION
The default timeout while initiating a session with BrowserStack is not long enough when testing on mobile devices or Turboscale leading to frequent connection reset errors. This PR increases the timeout to handle such cases.
