### PR TITLE
Add option to not load Nightwatch APIs while launching browser.

### DIFF
--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -680,10 +680,12 @@ class NightwatchClient extends EventEmitter {
   // Initialize the APIs
   //////////////////////////////////////////////////////////////////////////////////////////
 
-  async initialize() {
+  async initialize(loadNightwatchApis = true) {
     this.loadKeyCodes();
 
-    return this.loadNightwatchApis();
+    if (loadNightwatchApis) {
+      return this.loadNightwatchApis();
+    }
   }
 
   setCurrentTest() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,10 +142,10 @@ module.exports.createClient = function({
       return cliRunner.globals.runGlobalHook('after', [client.settings]);
     },
 
-    launchBrowser() {
+    launchBrowser({loadNightwatchApis = true} = {}) {
       const {argv} = cliRunner;
 
-      return client.initialize()
+      return client.initialize(loadNightwatchApis)
         .then(() => {
           return client.createSession({argv});
         })


### PR DESCRIPTION
If we try to quit and relaunch the browser in between a testsuite while using Cucumber runner or Nightwatch's programmatic APIs, we cannot do so because of the below error:

```
TypeError: Error while loading the API commands: the command .acceptAlert() is already defined.
    at CommandLoader.validateMethod (/Users/priyansh/Projects/nightwatch/lib/api/_loaders/_command-loader.js:54:19)
    at CommandLoader.define (/Users/priyansh/Projects/nightwatch/lib/api/_loaders/_base-loader.js:330:10)
    at ApiLoader.addCommandDefinitionSync (/Users/priyansh/Projects/nightwatch/lib/api/index.js:338:8)
    at /Users/priyansh/Projects/nightwatch/lib/api/index.js:457:20
    at /Users/priyansh/Projects/nightwatch/lib/utils/index.js:407:7
    at Array.forEach (<anonymous>)
    at Utils.readFolderRecursively (/Users/priyansh/Projects/nightwatch/lib/utils/index.js:391:15)
    at ApiLoader.__loadCommandsSync (/Users/priyansh/Projects/nightwatch/lib/api/index.js:456:13)
    at /Users/priyansh/Projects/nightwatch/lib/api/index.js:312:14
    at Array.forEach (<anonymous>) {
  displayed: false,
  detailedErr: 'Source: /Users/priyansh/Projects/nightwatch/lib/api/protocol/acceptAlert.js',
  showTrace: false
}
```

This happens because whenever we try to call `.launchBrowser()` on the existing client, it tries to load all the Nightwatch APIs onto the client again. But since the APIs are already loaded, Nightwatch throws the above error.

To solve this, we've added a new param (`loadNightwatchApis`) that can be passed to the `.launchBrowser()` set as `false` if we don't want to load the APIs while launching the browser.

Fixes: #4357 

## Usage

```js
// load Nightwatch APIs like normal
client.launchBrowser(); // no need to pass any param
client.launchBrowser({loadNightwatchApis: true});

// do not load Nightwatch APIs while launching the browser
client.launchBrowser({loadNightwatchApis: false});
```
