### PR TITLE
fix Passed assertion messege of assert.ok & assert.not.ok

### DIFF
--- a/lib/api/_loaders/static.js
+++ b/lib/api/_loaders/static.js
@@ -84,7 +84,7 @@ module.exports = class StaticAssert {
           return StaticAssert.assertOperators[propName] || '';
         }
 
-        const operator = (this.passed && !this.negate) ? StaticAssert.assertOperators[propName][0] : StaticAssert.assertOperators[propName][1];
+        const operator = this.passed  ? StaticAssert.assertOperators[propName][0] : StaticAssert.assertOperators[propName][1];
 
         let message = '';
 
@@ -103,24 +103,25 @@ module.exports = class StaticAssert {
             argument = util.inspect(argument);
           }
 
-          return argument;
+          return String(argument);
         });
 
-        return message + this.args.join(' ');
+        return message + this.args.slice(0, 2).join(' ');
       }
 
       assert(propName) {
+        const customMessage = this.args[1] || 'Testing the value to be';
         try {
           assertModule[propName].apply(null, this.args);
           this.passed = !this.negate;
-          this.message = `${this.negate ? 'Failed' : 'Passed'} [${propName}]: ${this.message || this.getMessage(propName)}`;
+          this.message = `${this.negate ? 'Failed' : 'Passed'} [${propName}]:${customMessage} truthy: (${this.getMessage(propName)})`;
         } catch (ex) {
           this.passed = !!this.negate;
 
           if (!this.passed && (ex instanceof Error) && propName === 'fail') {
             this.message = ex.message;
           } else {
-            this.message = `${this.negate ? 'Passed' : 'Failed'} [${propName}]: (${ex.message || this.message || this.getMessage(propName)})`;
+            this.message = `${this.negate ? 'Passed' : 'Failed'} [not.${propName}]:  ${customMessage} not truthy: (${this.getMessage(propName)})`;
           }
 
           if (Utils.isDefined(ex.showTrace)) {


### PR DESCRIPTION
Fixes Passed issue #4307 - Fix static assertions / node assertion messages

### Previously the passed message of the assertions were less detailed hence it was hard to know what has actually passed , is it a truthy value or falsy value
![Screenshot 2025-01-22 003031](https://github.com/user-attachments/assets/314dc4e3-f6d6-4ef1-b268-cfe96ac4bbbf)


### after the fix the message is more detailed with correct value 
![Screenshot 2025-01-22 002114](https://github.com/user-attachments/assets/bc216511-a5c7-4efc-a41a-8f16a1bef987)
- tested with seperately created file with lots of assertion test 


- [x] Perfectly working the prebuild example tests
@garg3133 Have a look as this, i would love to make any changes if needed 