### PR TITLE
Add type for section parent property.

### DIFF
--- a/types/page-object.d.ts
+++ b/types/page-object.d.ts
@@ -142,8 +142,9 @@ export type EnhancedSectionInstance<
   Commands = {},
   Elements = {},
   Sections extends Record<string, PageObjectSection> = {},
-  Props = {}
-> = EnhancedPageObjectSections<Commands, Elements, Sections, Props> &
+  Props = {},
+  Parent = null
+> = EnhancedPageObjectSections<Commands, Elements, Sections, Props, Parent> &
   Commands &
   ElementCommands &
   ChromiumClientCommands &
@@ -202,7 +203,8 @@ export interface EnhancedPageObjectSections<
   Commands = {},
   Elements = {},
   Sections extends Record<string, PageObjectSection> = {},
-  Props = {}
+  Props = {},
+  Parent = null
 > extends EnhancedPageObjectSharedFields<
   Commands,
   Elements,
@@ -229,6 +231,11 @@ export interface EnhancedPageObjectSections<
    * 'css selector'
    */
   locateStrategy: LocateStrategy;
+
+  /**
+   * Parent of the section.
+   */
+  parent: Parent;
 }
 
 interface EnhancedPageObjectSharedFields<
@@ -258,7 +265,8 @@ interface EnhancedPageObjectSharedFields<
       Required<MergeObjectsArray<Sections[Key]['commands']>>,
       Required<MergeObjectsArray<Sections[Key]['elements']>>,
       Required<Sections[Key]['sections']>,
-      Required<Sections[Key]['props']>
+      Required<Sections[Key]['props']>,
+      this
     >;
   };
 

--- a/types/tests/index.test-d.ts
+++ b/types/tests/index.test-d.ts
@@ -538,6 +538,11 @@ const testPage = {
     appSection.expect.element('@myAccount').to.be.visible;
     appSection.expect.element('@youtube').to.be.visible;
 
+    // test for parent property
+    expectType<typeof menuSection>(appSection.parent);
+    expectType<GooglePage>(appSection.parent.parent);
+    expectError(appSection.parent.parent.parent);
+
     const youtubeElement = appSection.elements.youtube;
     expectNotType<any>(youtubeElement);
 


### PR DESCRIPTION
This PR add the missing type for the `parent` property on page object sections.