### PR TITLE
Pass BDD describe content down to JUnit reports

### DIFF
--- a/lib/reporter/reporters/junit.js
+++ b/lib/reporter/reporters/junit.js
@@ -46,7 +46,7 @@ class JUnitReporter extends BaseReporter {
     const module = this.results.modules[moduleKey];
     const pathParts = moduleKey.split(path.sep);
     const moduleName = pathParts.pop();
-    let className = moduleName;
+    let className = module.name || moduleName;
     let output_folder = this.options.output_folder;
     let shouldCreateFolder = false;
 

--- a/test/src/runner/testRunnerJunitOutput.js
+++ b/test/src/runner/testRunnerJunitOutput.js
@@ -383,10 +383,10 @@ describe('testRunnerJUnitOutput', function() {
       })
       .then(data => {
         const content = data.toString();
-        assert.match(content, /<testsuite[\s]+name="sample"[\s]/,
+        assert.match(content, /<testsuite[\s]+name="basic describe test"[\s]/,
           'Report does not contain correct testsuite name.');
 
-        assert.match(content, /<testcase[\s]+name="demoTest"[\s]+classname="sample"/,
+        assert.match(content, /<testcase[\s]+name="demoTest"[\s]+classname="basic describe test"/,
           'Report does not contain the correct testcase classname.');
       });
   });

--- a/test/src/runner/testRunnerJunitOutput.js
+++ b/test/src/runner/testRunnerJunitOutput.js
@@ -363,6 +363,33 @@ describe('testRunnerJUnitOutput', function() {
           'Report does not contain the correct testcase element.');
       });
   });
+
+  it('testRun with jUnit output and describe', function() {
+    const testsPath = [
+      path.join(__dirname, '../../sampletests/withdescribe/basic')
+    ];
+
+    return runTests(testsPath, settings({
+      output_folder: 'output',
+      silent: true,
+      globals: {reporter: function() {}}
+    }))
+      .then(_ => {
+        const basicReportFile = 'output/FIREFOX_TEST_firefox__sample.xml';
+
+        assert.ok(fileExistsSync(basicReportFile), 'The basic report file was not created.');
+
+        return readFilePromise(basicReportFile);
+      })
+      .then(data => {
+        const content = data.toString();
+        assert.match(content, /<testsuite[\s]+name="sample"[\s]/,
+          'Report does not contain correct testsuite name.');
+
+        assert.match(content, /<testcase[\s]+name="demoTest"[\s]+classname="sample"/,
+          'Report does not contain the correct testcase classname.');
+      });
+  });
 });
 
 // util to replace deprecated fs.existsSync


### PR DESCRIPTION
Pass BDD describe content down to JUnit reports

Implements #4368

I only tested JUnit reports in this format in GitLab, so additional testing might be required for other JUnit reports consumers.
