### PR TITLE
Fix TS commands available on page objects.

### DIFF
--- a/types/page-object.d.ts
+++ b/types/page-object.d.ts
@@ -173,10 +173,13 @@ export type EnhancedSectionInstance<
     | 'injectScript'
     | 'isLogAvailable'
     | 'maximizeWindow'
+    | 'pageSource'
     | 'pause'
     | 'perform'
+    | 'registerBasicAuth'
     | 'resizeWindow'
     | 'saveScreenshot'
+    // | 'saveSnapshot' // missing from NightwatchAPI
     | 'setCookie'
     | 'setWindowPosition'
     | 'setWindowRect'
@@ -184,11 +187,7 @@ export type EnhancedSectionInstance<
     | 'urlHash'
     | 'useCss'
     | 'useXpath'
-    | 'registerBasicAuth'
-    | 'setNetworkConditions'
-    | 'clickAndHold'
-    | 'doubleClick'
-    | 'rightClick'
+    // | 'within' // missing from NightwatchAPI
   >;
 
 interface PageObjectSection {

--- a/types/page-object.d.ts
+++ b/types/page-object.d.ts
@@ -13,9 +13,47 @@ import {
   LocateStrategy,
   NightwatchAPI,
   NightwatchClient,
-  NightwatchComponentTestingCommands,
-  SharedCommands
+  NightwatchComponentTestingCommands
 } from './index';
+
+export interface PageObjectClientCommands
+  extends ChromiumClientCommands,
+  Pick<
+    NightwatchAPI,
+    | 'axeInject'
+    | 'axeRun'
+    | 'debug'
+    | 'deleteCookie'
+    | 'deleteCookies'
+    | 'end'
+    | 'getCookie'
+    | 'getCookies'
+    | 'getLog'
+    | 'getLogTypes'
+    | 'getTitle'
+    | 'getWindowPosition'
+    | 'getWindowRect'
+    | 'getWindowSize'
+    | 'init'
+    | 'injectScript'
+    | 'isLogAvailable'
+    | 'maximizeWindow'
+    | 'pageSource'
+    | 'pause'
+    | 'perform'
+    | 'registerBasicAuth'
+    | 'resizeWindow'
+    | 'saveScreenshot'
+    // | 'saveSnapshot' // missing from NightwatchAPI
+    | 'setCookie'
+    | 'setWindowPosition'
+    | 'setWindowRect'
+    | 'setWindowSize'
+    | 'urlHash'
+    | 'useCss'
+    | 'useXpath'
+    // | 'within' // missing from NightwatchAPI
+  > {};
 
 export interface SectionProperties {
   /**
@@ -147,47 +185,11 @@ export type EnhancedSectionInstance<
 > = EnhancedPageObjectSections<Commands, Elements, Sections, Props, Parent> &
   Commands &
   ElementCommands &
-  ChromiumClientCommands &
+  PageObjectClientCommands &
   Pick<NightwatchCustomCommands, KeysFilter<NightwatchCustomCommands, Function>> & // eslint-disable-line @typescript-eslint/ban-types
   Pick<
     NightwatchComponentTestingCommands,
     'importScript' | 'launchComponentRenderer' | 'mountComponent'
-  > &
-  Pick<
-    NightwatchAPI,
-    | 'axeInject'
-    | 'axeRun'
-    | 'debug'
-    | 'deleteCookie'
-    | 'deleteCookies'
-    | 'end'
-    | 'getCookie'
-    | 'getCookies'
-    | 'getLog'
-    | 'getLogTypes'
-    | 'getTitle'
-    | 'getWindowPosition'
-    | 'getWindowRect'
-    | 'getWindowSize'
-    | 'init'
-    | 'injectScript'
-    | 'isLogAvailable'
-    | 'maximizeWindow'
-    | 'pageSource'
-    | 'pause'
-    | 'perform'
-    | 'registerBasicAuth'
-    | 'resizeWindow'
-    | 'saveScreenshot'
-    // | 'saveSnapshot' // missing from NightwatchAPI
-    | 'setCookie'
-    | 'setWindowPosition'
-    | 'setWindowRect'
-    | 'setWindowSize'
-    | 'urlHash'
-    | 'useCss'
-    | 'useXpath'
-    // | 'within' // missing from NightwatchAPI
   >;
 
 interface PageObjectSection {
@@ -504,7 +506,8 @@ export type EnhancedPageObject<
   Sections extends Record<string, PageObjectSection> = {},
   Props = {},
   URL = string
-> = SharedCommands &
+> = PageObjectClientCommands &
+  ElementCommands &
   NightwatchCustomCommands &
   EnhancedPageObjectSharedFields<
     Required<MergeObjectsArray<Commands>>,

--- a/types/page-object.d.ts
+++ b/types/page-object.d.ts
@@ -53,7 +53,7 @@ export interface PageObjectClientCommands
     | 'useCss'
     | 'useXpath'
     // | 'within' // missing from NightwatchAPI
-  > {};
+  > {}
 
 export interface SectionProperties {
   /**

--- a/types/tests/page-object.test-d.ts
+++ b/types/tests/page-object.test-d.ts
@@ -90,11 +90,15 @@ describe('File Upload 2', function() {
     fileUploadPage.rightClick('@fileUploadInput');
     fileUploadPage.doubleClick('@fileUploadInput');
     fileUploadPage.clickAndHold('@fileUploadInput');
+    expectError(fileUploadPage.navigateTo('https://google.com'));
+    expectType<string>(fileUploadPage.url());
 
     // user actions element commands work on sections
     const menuSection = fileUploadPage.section.menu;
     menuSection.rightClick('@fileUploadInput');
     menuSection.doubleClick('@fileUploadInput');
     menuSection.clickAndHold('@fileUploadInput');
+    expectError(menuSection.navigateTo('https://google.com'));
+    expectError(menuSection.url());
   });
 });


### PR DESCRIPTION
The commands shown available directly on the page objects in TS were not consistent with the commands that are actually available on page objects in JS.

Fixes: #4367