### PR TITLE
Fix double entry of test case run times in reports.

### DIFF
--- a/lib/reporter/results.js
+++ b/lib/reporter/results.js
@@ -481,8 +481,6 @@ module.exports = class Results {
     const elapsedTime = endTime - startTime;
     this.endTimestamp = endTime;
 
-    this.time += elapsedTime;
-
     if (currentTest) {
       this.currentTestResult.time = (elapsedTime / 1000).toPrecision(4);
       this.currentTestResult.timeMs = elapsedTime;


### PR DESCRIPTION
Right now, the execution time for test cases is being considered twice in the reports, which leads to individual test suites being shown as taking more time than the global run time of Nightwatch tests.

![image](https://github.com/user-attachments/assets/b05226f1-2fc8-4c47-87f3-91e97d74af7a)

This PR fixes the same. The run time for test cases is already being considered [here](https://github.com/nightwatchjs/nightwatch/blob/0ab3004a1b2e5e65b895a4c235c04c6f2c6a2432/lib/reporter/results.js#L504) as part of sections and the consideration [here](https://github.com/nightwatchjs/nightwatch/blob/0ab3004a1b2e5e65b895a4c235c04c6f2c6a2432/lib/reporter/results.js#L484) is a duplicate.

![image](https://github.com/user-attachments/assets/b3e1e193-d8b2-4c7f-aee7-5ff9f17efe28)

Fixes: #4183 