### PR TITLE
Fix test section stats and status in reports.

### DIFF
--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -64,6 +64,7 @@ class Reporter extends SimplifiedReporter {
    * @param {Context} context
    */
   setCurrentTest(testcase, context) {
+    // called for every test case (not for hooks)
     this.currentContext = context;
 
     this.setCurrentSection(testcase);
@@ -71,6 +72,9 @@ class Reporter extends SimplifiedReporter {
   }
 
   setCurrentSection(testcase) {
+    // called for all global hooks, testsuite before/after hooks,
+    // and for all test cases but NOT for before_each/after_each hooks
+    // separately (considered part of the test case itself)
     this.testResults.setCurrentSection(testcase);
   }
 

--- a/lib/reporter/results.js
+++ b/lib/reporter/results.js
@@ -3,6 +3,8 @@ const uuid = require('uuid');
 const Utils = require('../utils');
 const {Logger} = Utils;
 
+// ALL THE NON-STATIC METHODS IN `Results` CLASS
+// REPRESENT SUITE LEVEL RESULTS.
 module.exports = class Results {
   static get TEST_FAIL() {
     return 'fail';
@@ -36,6 +38,9 @@ module.exports = class Results {
     this.currentTestName = '';
     this.currentSectionName = '';
     this.__currentTest = null;
+
+    // __initialResult is updated whenever there is no testcase result
+    // to update, so that results are not lost.
     this.__initialResult = {
       errors: 0,
       failed: 0,
@@ -44,6 +49,7 @@ module.exports = class Results {
       commands: [],
       tests: 0
     };
+
     // Adding sessionInfo to reporter
     const {capabilities = {}, desiredCapabilities = {}} = settings;
     this.sessionCapabilities = capabilities || desiredCapabilities;
@@ -61,8 +67,14 @@ module.exports = class Results {
   }
 
   markHookRun(hookName) {
+    // called for beforeEach, testcase, and afterEach (with the same name as `hookName`)
+    // all three above are considered to be hooks during test case execution.
     this.isHookRunning = true;
-    this.currentHookName = hookName;
+    this.currentTestCaseHookName = hookName;
+
+    // `testName` below would take values like: `Demo test ecosia.org__beforeEach`,
+    // `Demo test ecosia.org__testcase`, and `Demo test ecosia.org__afterEach`
+    // as `currentSectionName` would represent the test case name.
     this.testSectionHook = this.createTestCaseResults({testName: `${this.currentSectionName}__${hookName}`});
 
     // reset test hooks output
@@ -70,12 +82,20 @@ module.exports = class Results {
   }
 
   unmarkHookRun() {
+    // called for beforeEach, testcase, and afterEach during test case execution.
     this.isHookRunning = false;
-    if (!this.currentHookName) {
+    if (!this.currentTestCaseHookName) {
       throw new Error('Hook run not started yet');
     }
 
-    const currentSection = this.getTestSection(this.currentSectionName);
+    // below currentSection would contain the result data for the complete
+    // test case run, including beforeEach & afterEach.
+    // Ex. for `Demo test ecosia.org` test case.
+    const currentSection = this.currentSection;
+
+    // hookdata would contain the result data for the individual
+    // beforeEach/testcase/afterEach hook run inside the current
+    // section (test case).
     const hookdata = this.testSectionHook;
 
     const startTime = hookdata.startTimestamp;
@@ -92,14 +112,18 @@ module.exports = class Results {
       hookdata.status = Results.TEST_FAIL;
     }
 
-    currentSection[this.currentHookName] = hookdata;
+    currentSection[this.currentTestCaseHookName] = hookdata;
   }
 
   get initialResult() {
     return this.__initialResult;
   }
 
+  // currentTest --> current or most recently run test case
   get currentTestResult() {
+    // `this.currentTest.name` is only set after first test case is run.
+    // before that, `this.currentTest.name` is '', so `this.initialResult`
+    // is returned by this getter.
     const testName = this.currentTest.name;
 
     return this.getTestResult(testName, {returnFullResult: true});
@@ -126,6 +150,7 @@ module.exports = class Results {
     if (returnFullResult) {
       currentTest.steps = this.skippedAtRuntime;
       currentTest.stackTrace = this.stackTrace;
+      // adds details of all test cases ran till now to the current test case result.
       currentTest.testcases = Object.keys(this.testcases).reduce((prev, key) => {
         prev[key] = Object.keys(this.testcases[key]).reduce((prevVal, prop) => {
           if (prop !== 'testcases') {
@@ -157,10 +182,12 @@ module.exports = class Results {
    * @return {TestCase}
    */
   getCurrentTest() {
+    // returns the current/most recent testcase object (not testcase result)
     return this.__currentTest;
   }
 
   get currentTest() {
+    // returns the current/most recent testcase object (not testcase result)
     if (!this.__currentTest) {
       return null;
     }
@@ -177,11 +204,14 @@ module.exports = class Results {
   }
 
   get currentSection() {
+    // returns the current/most recently run test section result.
+    // this will only return `this.initialResult` if called before the global
+    // beforeEach hook is run because we never reset `this.currentSectionName`.
     return this.getTestSection(this.currentSectionName);
   }
 
-  hasFailures() {
-    return this.currentTestResult.errors > 0 || this.currentTestResult.failed > 0;
+  testSectionHasFailures(testSection) {
+    return testSection.errors > 0 || testSection.failed > 0;
   }
 
   ////////////////////////////////////////////////////////////
@@ -227,6 +257,11 @@ module.exports = class Results {
     return this.currentTestResult.errors === 0 && this.currentTestResult.failed === 0;
   }
 
+  get currentTestCaseHasFailures() {
+    // 'currentTestCase' represents current or most recently run test case.
+    return this.currentTestResult.errors > 0 || this.currentTestResult.failed > 0;
+  }
+
   /**
    * Exports the complete results for the entire testsuite
    *
@@ -242,6 +277,9 @@ module.exports = class Results {
       results: {
         uuid: this.uuid,
         reportPrefix,
+        // if no this.currentTestName is present at the time (which happens
+        // before any test cases started running or after all test cases are
+        // done running), all executed assertions are saved to `this.initialResult`.
         assertionsCount: this.initialResult.assertions.length
       }
     };
@@ -304,6 +342,8 @@ module.exports = class Results {
   }
 
   resetCurrentTestName() {
+    // called after all test cases in a test suite are executed.
+
     // FIXME: in v2, this needs to be this.__currentTest.testName, but it isn't desirable now because will make
     //  client.currentTest.name empty in the after() hook and potentially introduce breaking changes
     //this.__currentTest.testName = '';
@@ -312,6 +352,8 @@ module.exports = class Results {
   }
 
   resetCurrentSectionName() {
+    // never called, which helps `this.currentSection` always return
+    // a valid test section result.
     this.currentSectionName = '';
   }
 
@@ -405,6 +447,15 @@ module.exports = class Results {
     const result = this.getTestResult(this.currentTestName);
     result.errors++;
 
+    // also increment errors count for the current section
+    this.currentSection.errors++;
+
+    if (this.isHookRunning) {
+      // A test case's beforeEach/testcase/afterEach hook is running,
+      // not a before/after hook or global beforeEach/afterEach hook.
+      this.testSectionHook.errors++;
+    }
+
     return this;
   }
 
@@ -420,6 +471,13 @@ module.exports = class Results {
     const result = this.getTestResult(this.currentTestName);
     result.failed++;
 
+    // also increment failed count for the current section
+    this.currentSection.failed++;
+
+    if (this.isHookRunning) {
+      this.testSectionHook.failed++;
+    }
+
     return this;
   }
 
@@ -428,6 +486,13 @@ module.exports = class Results {
 
     const result = this.getTestResult(this.currentTestName);
     result.passed++;
+
+    // also increment passed count for the current section
+    this.currentSection.passed++;
+
+    if (this.isHookRunning) {
+      this.testSectionHook.passed++;
+    }
 
     return this;
   }
@@ -453,10 +518,12 @@ module.exports = class Results {
   }
 
   logCommand(command) {
-    const result = this.getTestSection(this.currentSectionName);
+    const result = this.currentSection;
     result.commands.push(command);
 
     if (this.isHookRunning) {
+      // A test case's beforeEach/testcase/afterEach hook is running,
+      // not a before/after hook or global beforeEach/afterEach hook.
       this.testSectionHook.commands.push(command);
     }
 
@@ -488,15 +555,14 @@ module.exports = class Results {
       this.currentTestResult.timeMs = elapsedTime;
       this.currentTestResult.startTimestamp = new Date(startTime).toUTCString();
       this.currentTestResult.endTimestamp = new Date(endTime).toUTCString();
-
     }
 
     return this;
   }
 
   setTestSectionElapsedTime() {
-    const currentSection = this.getTestSection(this.currentSectionName);
-    const startTime = currentSection ? currentSection.startTimestamp : this.globalStartTime;
+    const currentSection = this.currentSection;
+    const startTime = currentSection?.startTimestamp || this.globalStartTime;
     const endTime = new Date().getTime();
     const elapsedTime = endTime - startTime;
     this.endTimestamp = endTime;
@@ -515,23 +581,30 @@ module.exports = class Results {
   }
 
   setTestStatus() {
+    // run for all test cases and hooks (except for [before|after]_each hooks)
+    // ^ [before|after]_each hooks are considered part of the test case itself
     const currentTest = this.getCurrentTest();
-    const currentSection = this.getTestSection(this.currentSectionName);
     if (!currentTest) {
       return;
     }
 
-    if (this.hasFailures()) {
+    if (this.currentTestCaseHasFailures) {
       this.currentTestResult.status = Results.TEST_FAIL;
-      currentSection.status = Results.TEST_FAIL;
     } else {
       this.currentTestResult.status = Results.TEST_PASS;
+    }
+
+    // also set status for the current section
+    const currentSection = this.currentSection;
+    if (this.testSectionHasFailures(currentSection)) {
+      currentSection.status = Results.TEST_FAIL;
+    } else {
       currentSection.status = Results.TEST_PASS;
     }
   }
 
   collectTestSectionOutput() {
-    const currentSection = this.getTestSection(this.currentSectionName);
+    const currentSection = this.currentSection;
     if (!currentSection) {
       return;
     }
@@ -553,6 +626,8 @@ module.exports = class Results {
    * @return {Results}
    */
   setCurrentTest(testcase) {
+    // we set this during `runCurrentTest` method call in `testsuite/index.js`
+    // only called for test cases (not for hooks)
     this.currentTest = testcase;
 
     const testName = testcase.testName;
@@ -571,6 +646,8 @@ module.exports = class Results {
   }
 
   setCurrentSection(testcase) {
+    // set for all tests and hooks (except [before|after]_each hooks)
+    // ^ [before|after]_each hooks are considered part of the test case itself
     this.currentSectionName = testcase.testName;
     this.testSections[testcase.testName] = this.createTestCaseResults(testcase);
   }
@@ -594,6 +671,7 @@ module.exports = class Results {
   }
 
   getTestStatus() {
+    // returns suite level test status.
     if (this.failedCount > 0 || this.errorsCount > 0) {
       return Results.TEST_FAIL;
     }

--- a/lib/testsuite/index.js
+++ b/lib/testsuite/index.js
@@ -629,6 +629,8 @@ class TestSuite {
   }
 
   onTestSectionFinished() {
+    // called for all test cases and hooks (except for [before|after]_each hooks)
+    // ^ [before|after]_each hooks are considered part of the test case itself
     this.reporter.setTestStatus();
     this.reporter.setTestSectionElapsedTime();
     this.reporter.collectTestSectionOutput();
@@ -784,6 +786,7 @@ class TestSuite {
   }
 
   setReporterCurrentTest() {
+    // called for every test case (not for hooks)
     this.reporter.setCurrentTest(this.testcase, this.context);
     this.client.setCurrentTest();
 

--- a/test/sampletests/sampleforreport/sample.js
+++ b/test/sampletests/sampleforreport/sample.js
@@ -1,0 +1,19 @@
+module.exports = {
+  '@desiredCapabilities': {
+    name: 'test-Name'
+  },
+  demoTest: function (client) {
+    client.assert.equal(client.options.desiredCapabilities.name, 'test-Name');
+
+    client.url('http://localhost')
+      .assert.elementPresent('#weblogin');
+  },
+
+  afterEach: function (client) {
+    client.assert.equal(client.options.desiredCapabilities.name, 'test-Name');
+  },
+
+  after: function (client) {
+    client.end();
+  }
+};

--- a/test/sampletests/sampleforreport/sampleWithFailure.js
+++ b/test/sampletests/sampleforreport/sampleWithFailure.js
@@ -1,0 +1,20 @@
+module.exports = {
+  '@desiredCapabilities': {
+    name: 'test-Name'
+  },
+  demoTest: function (client) {
+    client.assert.equal(client.options.desiredCapabilities.name, 'test-Name');
+
+    client.url('http://localhost')
+      .assert.elementPresent('#badElement');
+  },
+
+  afterEach: function (client) {
+    client.assert.equal(client.options.desiredCapabilities.name, 'test-Name');
+  },
+
+  after: function (client) {
+    client.assert.equal(client.options.desiredCapabilities.name, 'test-Name');
+    client.end();
+  }
+};


### PR DESCRIPTION
Right now, `passed`, `failed`, and `errors` count was not being saved in the `"completedSections"` part of JSON reports due to which wrong `pass/fail` status was saved and shown for certain hooks run (like `after` and global `afterEach`) irrespective of whether the commands in these hooks passed or failed.

This had a major impact on the HTML reporter and other 3rd party reporters that use "completedSections" part of report to show the status and commands run in individual secitons.

`after` hook is marked as passed even though the command failed
![image](https://github.com/user-attachments/assets/34329623-7e29-44bd-9e95-d6d907cfaba4)

`after` hook marked as failed even though all commands passed
![image](https://github.com/user-attachments/assets/15649216-7fd1-423b-9f52-7d1d1581ec84)


This PR fixes this undesired behaviour in reports.