### PR TITLE
Always return `NightwatchClient` instance from `client.initialize()` call.

### DIFF
--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -686,6 +686,8 @@ class NightwatchClient extends EventEmitter {
     if (loadNightwatchApis) {
       return this.loadNightwatchApis();
     }
+
+    return this;
   }
 
   setCurrentTest() {


### PR DESCRIPTION
This is a bug introduced in #4358 (although this does not impact anybody, yet) where if `loadNightwatchApis` is set to `false`, the `.initialize()` method call does not return anything.

Instead, this method should always return a `NightwatchClient` instance, which it did before the changes in #4358.