### PR TITLE
Fix `id` redefined issue in JUnit reports.

### DIFF
--- a/lib/reporter/reporters/junit.xml.ejs
+++ b/lib/reporter/reporters/junit.xml.ejs
@@ -4,7 +4,7 @@
             tests="<%= module.tests %>">
 
   <testsuite name="<%= className %>" id="<%= suiteKey %>"
-    errors="<%= module.errors %>" failures="<%= module.failures %>" hostname="" id="" package="<%= module.group || moduleName %>" skipped="<%= (Array.isArray(module.skippedAtRuntime)) ? module.skippedAtRuntime.length : 0 %>"
+    errors="<%= module.errors %>" failures="<%= module.failures %>" hostname="" package="<%= module.group || moduleName %>" skipped="<%= (Array.isArray(module.skippedAtRuntime)) ? module.skippedAtRuntime.length : 0 %>"
     tests="<%= module.tests %>" time="<%= module.time %>" timestamp="<%= module.timestamp %>">
   <% for (var item in module.completed) {
     var testcase = module.completed[item];

--- a/test/src/runner/testRunnerJunitOutput.js
+++ b/test/src/runner/testRunnerJunitOutput.js
@@ -356,7 +356,7 @@ describe('testRunnerJUnitOutput', function() {
       })
       .then(data => {
         const content = data.toString();
-        assert.ok(/<testsuite[\s]+name="simple\.sample"[\s]+id="simple\.sample"[\s]+errors="0"[\s]+failures="0"[\s]+hostname=""[\s]+id=""[\s]+package="simple"[\s]+skipped="0"[\s]+tests="1"/.test(content),
+        assert.ok(/<testsuite[\s]+name="simple\.sample"[\s]+id="simple\.sample"[\s]+errors="0"[\s]+failures="0"[\s]+hostname=""[\s]+package="simple"[\s]+skipped="0"[\s]+tests="1"/.test(content),
           'Report does not contain correct testsuite information.');
 
         assert.ok(/<testcase[\s]+name="simpleDemoTest"[\s]+classname="simple\.sample"[\s]+time="[.\d]+"[\s]+assertions="1">/.test(content),


### PR DESCRIPTION
A bug was introduced in JUnit reports in the last release. This PR fixes that.

Resolves: #4391. Thanks, @robertgorecki for raising the issue.