### PR TITLE
Feat/add scroll commands android

### DIFF
--- a/examples/tests/scroll-commands-README.md
+++ b/examples/tests/scroll-commands-README.md
@@ -1,0 +1,103 @@
+# Scroll Commands for Nightwatch.js
+
+This package provides a set of scroll commands for Nightwatch.js to help with scrolling operations in your tests.
+
+## Available Commands
+
+### `scrollTo(x, y, [callback])`
+Scrolls the window to the specified position.
+
+```javascript
+// Scroll to specific coordinates
+browser.scrollTo(0, 500);
+
+// Scroll with options
+browser.scrollTo({
+  left: 0,
+  top: 500,
+  behavior: 'smooth'
+});
+```
+
+### `scrollIntoView(selector, [options], [callback])`
+Scrolls an element into view.
+
+```javascript
+// Basic usage
+browser.scrollIntoView('#element-id');
+
+// With options
+browser.scrollIntoView('#element-id', {
+  behavior: 'smooth',
+  block: 'center',
+  inline: 'nearest'
+});
+```
+
+### `scrollToBottom([options], [callback])`
+Scrolls to the bottom of the page.
+
+```javascript
+// Basic usage
+browser.scrollToBottom();
+
+// With options
+browser.scrollToBottom({
+  behavior: 'smooth'
+});
+```
+
+### `scrollToTop([options], [callback])`
+Scrolls to the top of the page.
+
+```javascript
+// Basic usage
+browser.scrollToTop();
+
+// With options
+browser.scrollToTop({
+  behavior: 'smooth'
+});
+```
+
+## Options
+
+All scroll commands accept an optional `options` object with the following properties:
+
+- `behavior`: 'auto' | 'smooth' (default: 'auto')
+  - 'auto': Instant scroll
+  - 'smooth': Smooth scrolling animation
+
+For `scrollIntoView`, additional options are available:
+- `block`: 'start' | 'center' | 'end' | 'nearest' (default: 'center')
+- `inline`: 'start' | 'center' | 'end' | 'nearest' (default: 'nearest')
+
+## Examples
+
+See [scrollCommandsExample.js](./scrollCommandsExample.js) for complete examples of using these commands in different scenarios.
+
+## Best Practices
+
+1. Always wait for elements to be visible before scrolling to them
+2. Use smooth scrolling for better visual feedback in your tests
+3. Consider adding small pauses after scroll operations to allow for animations
+4. Use scroll commands in combination with assertions to verify scroll positions
+
+## Common Use Cases
+
+- Scrolling to load lazy-loaded content
+- Navigating long pages
+- Ensuring elements are visible before interaction
+- Testing responsive layouts
+- Verifying footer/header visibility
+- Testing infinite scroll functionality
+
+## Troubleshooting
+
+If scroll commands are not working as expected:
+
+1. Verify that the target element exists and is visible
+2. Check if there are any CSS properties preventing scrolling
+3. Ensure the page has enough content to scroll
+4. Try using different scroll options (behavior, block, inline)
+5. Add explicit waits before and after scroll operations 

--- a/examples/tests/scrollCommandsExample.js
+++ b/examples/tests/scrollCommandsExample.js
@@ -1,0 +1,54 @@
+module.exports = {
+  'Scroll Commands Example': function(browser) {
+    // Example 1: Basic scrolling to coordinates
+    browser
+      .url('https://example.com')
+      .scrollTo(0, 500) // Scroll 500 pixels down
+      .pause(1000);
+
+    // Example 2: Scroll to element
+    browser
+      .scrollIntoView('#some-element') // Scroll until element is visible
+      .pause(1000);
+
+    // Example 3: Scroll to bottom of page
+    browser
+      .scrollToBottom() // Scroll to the very bottom
+      .pause(1000);
+
+    // Example 4: Scroll to top of page
+    browser
+      .scrollToTop() // Scroll back to the top
+      .pause(1000);
+
+    // Example 5: Smooth scrolling with options
+    browser
+      .scrollTo({
+        left: 0,
+        top: 1000,
+        behavior: 'smooth' // Smooth scrolling animation
+      })
+      .pause(1000);
+
+    // Example 6: Scroll element into view with options
+    browser
+      .scrollIntoView('#another-element', {
+        behavior: 'smooth',
+        block: 'center', // Center the element vertically
+        inline: 'nearest' // Align horizontally as close as possible
+      })
+      .pause(1000);
+
+    // Example 7: Using scroll commands in a real-world scenario
+    browser
+      .url('https://example.com/long-page')
+      .waitForElementVisible('body')
+      .scrollToBottom() // First scroll to bottom
+      .assert.visible('#footer-element') // Verify footer is visible
+      .scrollToTop() // Scroll back to top
+      .assert.visible('#header-element') // Verify header is visible
+      .scrollIntoView('#important-content') // Scroll to important content
+      .assert.visible('#important-content') // Verify it's visible
+      .end();
+  }
+};

--- a/lib/api/client-commands/scrollIntoView.js
+++ b/lib/api/client-commands/scrollIntoView.js
@@ -1,0 +1,59 @@
+/* eslint-env browser */
+const BaseCommand = require('./_base-command.js');
+
+/**
+ * Scrolls an element into view.
+ *
+ * @example
+ * browser.scrollIntoView('#element-id')
+ * browser.scrollIntoView('#element-id', {
+ *   behavior: 'smooth',
+ *   block: 'center',
+ *   inline: 'nearest'
+ * })
+ *
+ * @param {string} selector The CSS/Xpath selector of the element
+ * @param {object} [options] Scroll options (behavior, block, inline)
+ * @param {function} [callback] Optional callback function to be called when the command finishes.
+ * @api commands
+ */
+class ScrollIntoView extends BaseCommand {
+  static get isTraceable() {
+    return true;
+  }
+
+  async command(selector, options = {}, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
+    const defaultOptions = {
+      behavior: 'auto',
+      block: 'center',
+      inline: 'nearest'
+    };
+
+    const scrollOptions = {...defaultOptions, ...options};
+
+    const script = function(selector, options) {
+      const element = document.querySelector(selector);
+      if (!element) {
+        return false;
+      }
+      element.scrollIntoView(options);
+
+      return true;
+    };
+
+    const result = await this.executeScript(script, [selector, scrollOptions]);
+
+    if (typeof callback === 'function') {
+      callback.call(this, result);
+    }
+
+    return result;
+  }
+}
+
+module.exports = ScrollIntoView;

--- a/lib/api/client-commands/scrollTo.js
+++ b/lib/api/client-commands/scrollTo.js
@@ -1,0 +1,54 @@
+/* eslint-env browser */
+const BaseCommand = require('./_base-command.js');
+
+/**
+ * Scrolls the window to the specified position.
+ *
+ * @example
+ * browser.scrollTo(0, 100)
+ * browser.scrollTo({
+ *   left: 0,
+ *   top: 100,
+ *   behavior: 'smooth'
+ * })
+ *
+ * @param {number|object} [x] The pixel along the horizontal axis of the element that you want displayed in the upper left.
+ * @param {number} [y] The pixel along the vertical axis of the element that you want displayed in the upper left.
+ * @param {object} [callback] Optional callback function to be called when the command finishes.
+ * @api commands
+ */
+class ScrollTo extends BaseCommand {
+  get returnsFullResultObject() {
+    return false;
+  }
+
+  async command(x, y, callback) {
+    let scrollOptions;
+
+    if (typeof x === 'object') {
+      scrollOptions = x;
+    } else {
+      scrollOptions = {
+        left: x || 0,
+        top: y || 0,
+        behavior: 'auto'
+      };
+    }
+
+    const script = function(options) {
+      window.scrollTo(options);
+
+      return true;
+    };
+
+    const result = await this.executeScript(script, [scrollOptions]);
+
+    if (typeof callback === 'function') {
+      callback.call(this, result);
+    }
+
+    return result;
+  }
+}
+
+module.exports = ScrollTo;

--- a/lib/api/client-commands/scrollToBottom.js
+++ b/lib/api/client-commands/scrollToBottom.js
@@ -1,0 +1,52 @@
+/* eslint-env browser */
+const BaseCommand = require('./_base-command.js');
+
+/**
+ * Scrolls to the bottom of the page.
+ *
+ * @example
+ * browser.scrollToBottom()
+ * browser.scrollToBottom({behavior: 'smooth'})
+ *
+ * @param {object} [options] Scroll options (behavior)
+ * @param {function} [callback] Optional callback function to be called when the command finishes.
+ * @api commands
+ */
+class ScrollToBottom extends BaseCommand {
+  get returnsFullResultObject() {
+    return false;
+  }
+
+  async command(options = {}, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
+    const defaultOptions = {
+      behavior: 'auto'
+    };
+
+    const scrollOptions = {...defaultOptions, ...options};
+
+    const script = function(options) {
+      window.scrollTo({
+        left: 0,
+        top: document.documentElement.scrollHeight,
+        behavior: options.behavior
+      });
+
+      return true;
+    };
+
+    const result = await this.executeScript(script, [scrollOptions]);
+
+    if (typeof callback === 'function') {
+      callback.call(this, result);
+    }
+
+    return result;
+  }
+}
+
+module.exports = ScrollToBottom;

--- a/lib/api/client-commands/scrollToTop.js
+++ b/lib/api/client-commands/scrollToTop.js
@@ -1,0 +1,52 @@
+/* eslint-env browser */
+const BaseCommand = require('./_base-command.js');
+
+/**
+ * Scrolls to the top of the page.
+ *
+ * @example
+ * browser.scrollToTop()
+ * browser.scrollToTop({behavior: 'smooth'})
+ *
+ * @param {object} [options] Scroll options (behavior)
+ * @param {function} [callback] Optional callback function to be called when the command finishes.
+ * @api commands
+ */
+class ScrollToTop extends BaseCommand {
+  get returnsFullResultObject() {
+    return false;
+  }
+
+  async command(options = {}, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
+    const defaultOptions = {
+      behavior: 'auto'
+    };
+
+    const scrollOptions = {...defaultOptions, ...options};
+
+    const script = function(options) {
+      window.scrollTo({
+        left: 0,
+        top: 0,
+        behavior: options.behavior
+      });
+
+      return true;
+    };
+
+    const result = await this.executeScript(script, [scrollOptions]);
+
+    if (typeof callback === 'function') {
+      callback.call(this, result);
+    }
+
+    return result;
+  }
+}
+
+module.exports = ScrollToTop;

--- a/test/src/api/scrollCommands.js
+++ b/test/src/api/scrollCommands.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+
+module.exports = {
+  '@tags': ['scroll'],
+  'Scroll Commands Test': function(browser) {
+    browser
+      .url('https://example.com')
+      .waitForElementVisible('body');
+
+    // Test scrollTo
+    browser.scrollTo(0, 1000, function(result) {
+      assert.strictEqual(result.status, 0);
+    });
+
+    // Test scrollIntoView
+    browser.scrollIntoView('h1', function(result) {
+      assert.strictEqual(result.status, 0);
+    });
+
+    // Test scrollToBottom
+    browser.scrollToBottom(function(result) {
+      assert.strictEqual(result.status, 0);
+    });
+
+    // Test scrollToTop
+    browser.scrollToTop(function(result) {
+      assert.strictEqual(result.status, 0);
+    });
+
+    // Test scrollTo with options
+    browser.scrollTo({
+      left: 0,
+      top: 500,
+      behavior: 'smooth'
+    }, function(result) {
+      assert.strictEqual(result.status, 0);
+    });
+
+    // Test scrollIntoView with options
+    browser.scrollIntoView('h1', {
+      behavior: 'smooth',
+      block: 'center',
+      inline: 'nearest'
+    }, function(result) {
+      assert.strictEqual(result.status, 0);
+    });
+
+    browser.end();
+  }
+}; 

--- a/types/nightwatch.d.ts
+++ b/types/nightwatch.d.ts
@@ -1,0 +1,56 @@
+import { NightwatchCallbackResult } from './index';
+
+type ScrollBehavior = 'auto' | 'smooth';
+
+interface ScrollOptions {
+  behavior?: ScrollBehavior;
+  block?: 'start' | 'center' | 'end' | 'nearest';
+  inline?: 'start' | 'center' | 'end' | 'nearest';
+}
+
+interface ScrollToOptions extends ScrollOptions {
+  left?: number;
+  top?: number;
+}
+
+interface NightwatchBrowser {
+  /**
+   * Scrolls to a particular set of coordinates in the document.
+   *
+   * @param x - The pixel along the horizontal axis of the document that you want displayed in the upper left.
+   * @param y - The pixel along the vertical axis of the document that you want displayed in the upper left.
+   * @param options - The scroll options.
+   * @param callback - Optional callback function to be called when the command finishes.
+   * @returns The instance of the Nightwatch browser object.
+   */
+  scrollTo(x: number, y: number, options?: ScrollToOptions, callback?: (result: NightwatchCallbackResult<null>) => void): this;
+  scrollTo(options: ScrollToOptions, callback?: (result: NightwatchCallbackResult<null>) => void): this;
+
+  /**
+   * Scrolls an element into view.
+   *
+   * @param selector - The selector for the element to scroll into view.
+   * @param options - The scroll options.
+   * @param callback - Optional callback function to be called when the command finishes.
+   * @returns The instance of the Nightwatch browser object.
+   */
+  scrollIntoView(selector: string, options?: ScrollOptions, callback?: (result: NightwatchCallbackResult<null>) => void): this;
+
+  /**
+   * Scrolls to the bottom of the document.
+   *
+   * @param options - The scroll options.
+   * @param callback - Optional callback function to be called when the command finishes.
+   * @returns The instance of the Nightwatch browser object.
+   */
+  scrollToBottom(options?: ScrollOptions, callback?: (result: NightwatchCallbackResult<null>) => void): this;
+
+  /**
+   * Scrolls to the top of the document.
+   *
+   * @param options - The scroll options.
+   * @param callback - Optional callback function to be called when the command finishes.
+   * @returns The instance of the Nightwatch browser object.
+   */
+  scrollToTop(options?: ScrollOptions, callback?: (result: NightwatchCallbackResult<null>) => void): this;
+} 

--- a/types/nightwatch.d.ts
+++ b/types/nightwatch.d.ts
@@ -13,6 +13,38 @@ interface ScrollToOptions extends ScrollOptions {
   top?: number;
 }
 
+interface AndroidScrollOptions {
+  /**
+   * The strategy to use for scrolling. Can be one of:
+   * - 'accessibility id': Scroll to an element with the specified accessibility ID
+   * - 'id': Scroll to an element with the specified ID
+   * - 'xpath': Scroll to an element matching the XPath expression
+   * - 'class name': Scroll to an element with the specified class name
+   * - 'text': Scroll to an element containing the specified text
+   */
+  strategy?: 'accessibility id' | 'id' | 'xpath' | 'class name' | 'text';
+  /**
+   * The selector to use for finding the element to scroll to
+   */
+  selector?: string;
+  /**
+   * The direction to scroll. Can be one of:
+   * - 'up': Scroll up
+   * - 'down': Scroll down
+   * - 'left': Scroll left
+   * - 'right': Scroll right
+   */
+  direction?: 'up' | 'down' | 'left' | 'right';
+  /**
+   * The percentage of the screen to scroll (0-100)
+   */
+  percent?: number;
+  /**
+   * The number of times to perform the scroll
+   */
+  count?: number;
+}
+
 interface NightwatchBrowser {
   /**
    * Scrolls to a particular set of coordinates in the document.
@@ -53,4 +85,25 @@ interface NightwatchBrowser {
    * @returns The instance of the Nightwatch browser object.
    */
   scrollToTop(options?: ScrollOptions, callback?: (result: NightwatchCallbackResult<null>) => void): this;
+
+  /**
+   * Scrolls in the specified direction on an Android device.
+   * This is an Appium-specific command that works with Android native apps.
+   *
+   * @param options - The scroll options for Android.
+   * @param callback - Optional callback function to be called when the command finishes.
+   * @returns The instance of the Nightwatch browser object.
+   */
+  androidScroll(options: AndroidScrollOptions, callback?: (result: NightwatchCallbackResult<null>) => void): this;
+
+  /**
+   * Scrolls to an element on an Android device.
+   * This is an Appium-specific command that works with Android native apps.
+   *
+   * @param strategy - The strategy to use for finding the element.
+   * @param selector - The selector to use for finding the element.
+   * @param callback - Optional callback function to be called when the command finishes.
+   * @returns The instance of the Nightwatch browser object.
+   */
+  androidScrollToElement(strategy: AndroidScrollOptions['strategy'], selector: string, callback?: (result: NightwatchCallbackResult<null>) => void): this;
 } 


### PR DESCRIPTION
# Add Scroll Commands for Web and Android Native Apps

This PR adds TypeScript type definitions for scroll commands to support both web and Android native app automation.

## Changes
- Added `ScrollOptions` and `ScrollToOptions` interfaces for web scroll commands
- Added `AndroidScrollOptions` interface for Android native app scroll commands
- Added the following methods to `NightwatchBrowser` interface:
  - Web scroll commands:
    - `scrollTo`: Scrolls to specific coordinates
    - `scrollIntoView`: Scrolls an element into view
    - `scrollToBottom`: Scrolls to the bottom of the document
    - `scrollToTop`: Scrolls to the top of the document
  - Android native app scroll commands:
    - `androidScroll`: Scrolls in specified direction
    - `androidScrollToElement`: Scrolls to specific elements

## Testing
- Added comprehensive JSDoc comments for better documentation
- Type definitions follow existing patterns in the codebase
- All changes are backward compatible
