### PR TITLE
Fix `.debug()` command not working.

### DIFF
--- a/lib/api/client-commands/debug.js
+++ b/lib/api/client-commands/debug.js
@@ -47,7 +47,7 @@ class Debug extends EventEmitter {
     };
 
     // set the user provided context
-    if (config.context) {
+    if (config?.context) {
       Object.assign(context, config.context);
       delete config.context;
     }


### PR DESCRIPTION
The `.debug()` command has not been working since the last change made to the command in PR #4299. The command is getting resolved immediately after being executed without ever displaying the REPL interface to debug.