### PR TITLE
Fix #4256 : write webdriver/chromedriver logs per worker in parallel mode

### DIFF
--- a/lib/transport/selenium-webdriver/index.js
+++ b/lib/transport/selenium-webdriver/index.js
@@ -194,33 +194,28 @@ class Transport extends BaseTransport {
 
   async createDriverService({options, moduleKey, reuseBrowser = false}) {
     try {
-      moduleKey = (this.settings && this.settings.webdriver && this.settings.webdriver.log_file_name) || moduleKey || '';
-      if (!this.settings) {
-        this.settings = {};
-      }
-      if (!this.settings.webdriver) {
-        this.settings.webdriver = {};
-      }
-      if (!this.settings.webdriver.log_file_name) {
-        const isParallelEnv = process.env.__NIGHTWATCH_PARALLEL_MODE === '1' || false;
-        let uniqueId = null;
-        try {
-          const wt = require('worker_threads');
-          if (wt && !wt.isMainThread && typeof wt.threadId !== 'undefined') {
-            uniqueId = `worker_thread_${wt.threadId}`;
-          }
-        } catch (err) {
-          Logger.warn('worker_threads not supported in this Node.js version.');
+      const isParallelEnv = process.env.__NIGHTWATCH_PARALLEL_MODE === '1';
+      if (!isParallelEnv) {
+        moduleKey = this.settings.webdriver.log_file_name || moduleKey || '';
+      } else {
+        if (!this.settings) {
+          this.settings = {};
+        }
+        if (!this.settings.webdriver) {
+          this.settings.webdriver = {};
+        }
+        const timestamp = new Date().toISOString().replace(/[:.-]/g, '_');
+        if (!this.settings.webdriver.log_file_name) {
+          const moduleKeyTimestamp = `${moduleKey}_${timestamp}`;
+          this.settings.webdriver.log_file_name = moduleKeyTimestamp;
+        } else {
+          const userDefinedLogFileName = this.settings.webdriver.log_file_name;
+          const randomString = Math.random().toString(36).substring(2, 12);
+          this.settings.webdriver.log_file_name = `${userDefinedLogFileName}_${timestamp}_${randomString}`;
         }
 
-        if (!uniqueId) {
-          uniqueId = `pid_${process.pid}`;
-        }
-        if (isParallelEnv) {
-          moduleKey = uniqueId;
-          this.settings.webdriver.log_file_name = moduleKey;
-        }
       }
+
 
       if (!this.shouldReuseDriverService(reuseBrowser)) {
         Transport.driverService = new this.ServiceBuilder(this.settings);
@@ -243,7 +238,7 @@ class Transport extends BaseTransport {
 
 
   async getDriver({options, reuseBrowser = false}) {
-    const value  = await this.shouldReuseDriver(reuseBrowser);
+    const value = await this.shouldReuseDriver(reuseBrowser);
     if (value) {
       return Transport.driver;
     }

--- a/lib/transport/selenium-webdriver/index.js
+++ b/lib/transport/selenium-webdriver/index.js
@@ -194,7 +194,33 @@ class Transport extends BaseTransport {
 
   async createDriverService({options, moduleKey, reuseBrowser = false}) {
     try {
-      moduleKey = this.settings.webdriver.log_file_name || moduleKey || '';
+      moduleKey = (this.settings && this.settings.webdriver && this.settings.webdriver.log_file_name) || moduleKey || '';
+      if (!this.settings) {
+        this.settings = {};
+      }
+      if (!this.settings.webdriver) {
+        this.settings.webdriver = {};
+      }
+      if (!this.settings.webdriver.log_file_name) {
+        const isParallelEnv = process.env.__NIGHTWATCH_PARALLEL_MODE === '1' || false;
+        let uniqueId = null;
+        try {
+          const wt = require('worker_threads');
+          if (wt && !wt.isMainThread && typeof wt.threadId !== 'undefined') {
+            uniqueId = `worker_thread_${wt.threadId}`;
+          }
+        } catch (err) {
+          Logger.warn('worker_threads not supported in this Node.js version.');
+        }
+
+        if (!uniqueId) {
+          uniqueId = `pid_${process.pid}`;
+        }
+        if (isParallelEnv) {
+          moduleKey = uniqueId;
+          this.settings.webdriver.log_file_name = moduleKey;
+        }
+      }
 
       if (!this.shouldReuseDriverService(reuseBrowser)) {
         Transport.driverService = new this.ServiceBuilder(this.settings);

--- a/lib/transport/selenium-webdriver/index.js
+++ b/lib/transport/selenium-webdriver/index.js
@@ -11,6 +11,7 @@ const BaseTransport = require('../');
 const {colors} = Logger;
 const {isErrorResponse, checkLegacyResponse, throwDecodedError, WebDriverError} = error;
 const {IosSessionErrors} = require('../errors');
+const Concurrency = require('../../runner/concurrency/index.js');
 
 let _driverService = null;
 let _driver = null;
@@ -194,28 +195,18 @@ class Transport extends BaseTransport {
 
   async createDriverService({options, moduleKey, reuseBrowser = false}) {
     try {
-      const isParallelEnv = process.env.__NIGHTWATCH_PARALLEL_MODE === '1';
-      if (!isParallelEnv) {
+      if (!Concurrency.isWorker) {
         moduleKey = this.settings.webdriver.log_file_name || moduleKey || '';
       } else {
-        if (!this.settings) {
-          this.settings = {};
-        }
-        if (!this.settings.webdriver) {
-          this.settings.webdriver = {};
-        }
-        const timestamp = new Date().toISOString().replace(/[:.-]/g, '_');
+        const timestamp = process.hrtime.bigint().toString();
         if (!this.settings.webdriver.log_file_name) {
           const moduleKeyTimestamp = `${moduleKey}_${timestamp}`;
           this.settings.webdriver.log_file_name = moduleKeyTimestamp;
         } else {
           const userDefinedLogFileName = this.settings.webdriver.log_file_name;
-          const randomString = Math.random().toString(36).substring(2, 12);
-          this.settings.webdriver.log_file_name = `${userDefinedLogFileName}_${timestamp}_${randomString}`;
+          this.settings.webdriver.log_file_name = `${userDefinedLogFileName}_${timestamp}`;
         }
-
       }
-
 
       if (!this.shouldReuseDriverService(reuseBrowser)) {
         Transport.driverService = new this.ServiceBuilder(this.settings);

--- a/lib/transport/selenium-webdriver/index.js
+++ b/lib/transport/selenium-webdriver/index.js
@@ -195,16 +195,13 @@ class Transport extends BaseTransport {
 
   async createDriverService({options, moduleKey, reuseBrowser = false}) {
     try {
-      if (!Concurrency.isWorker) {
-        moduleKey = this.settings.webdriver.log_file_name || moduleKey || '';
-      } else {
-        const timestamp = process.hrtime.bigint().toString();
-        if (!this.settings.webdriver.log_file_name) {
-          const moduleKeyTimestamp = `${moduleKey}_${timestamp}`;
-          this.settings.webdriver.log_file_name = moduleKeyTimestamp;
-        } else {
-          const userDefinedLogFileName = this.settings.webdriver.log_file_name;
-          this.settings.webdriver.log_file_name = `${userDefinedLogFileName}_${timestamp}`;
+      moduleKey = this.settings.webdriver.log_file_name || moduleKey || '';
+      if (Concurrency.isWorker) {
+        // append timestamp to the output file name to differentiate between the files
+        // created across the workers.
+        moduleKey = `${moduleKey}_${process.hrtime.bigint()}`;
+        if (this.settings.webdriver.log_file_name) {
+          this.settings.webdriver.log_file_name = moduleKey;
         }
       }
 

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -303,17 +303,6 @@ class BaseService {
     }
 
     await this.writeLogFile();
-
-    if (this._logWriteStream && !this._logWriteStream.destroyed) {
-      try {
-        await new Promise((resolve) => {
-          this._logWriteStream.end(resolve);
-        });
-      } catch (err) {
-        Logger.warn(`Unable to close log write stream: ${err}`);
-      }
-    }
-
     if (!this.process || this.process.killed) {
       return;
     }

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -140,12 +140,9 @@ class BaseService {
         try {
           this._logWriteStream = fs.createWriteStream(filePath, {flags: 'a'});
 
-          if (this.process && this.process.stdout) {
-            this.process.stdout.pipe(this._logWriteStream);
-          }
-          if (this.process && this.process.stderr) {
-            this.process.stderr.pipe(this._logWriteStream);
-          }
+          this.process.stdout?.pipe(this._logWriteStream);
+          this.process.stderr?.pipe(this._logWriteStream);
+
         } catch (err) {
           Logger.warn(`Unable to create log write stream for ${filePath}: ${err}`);
         }

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -132,24 +132,6 @@ class BaseService {
     if (this.service) {
       this.service.setStdio(['pipe', this.process.stdin, this.process.stdin]);
     }
-
-    const filePath = this.getOutputFilePath();
-    if (filePath) {
-      const folderPath = path.dirname(filePath);
-      createFolder(folderPath).then(() => {
-        try {
-          this._logWriteStream = fs.createWriteStream(filePath, {flags: 'a'});
-
-          this.process.stdout?.pipe(this._logWriteStream);
-          this.process.stderr?.pipe(this._logWriteStream);
-
-        } catch (err) {
-          Logger.warn(`Unable to create log write stream for ${filePath}: ${err}`);
-        }
-      }).catch(err => {
-        Logger.warn(`Unable to create logs folder ${folderPath}: ${err}`);
-      });
-    }
   }
 
 
@@ -404,6 +386,7 @@ class BaseService {
     const filePath = this.getOutputFilePath();
     const folderPath = path.dirname(filePath);
     await createFolder(folderPath);
+
 
     return new Promise((resolve, reject) => {
       fs.writeFile(filePath, this.output, (err) => {

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -113,14 +113,7 @@ class BaseService {
       env: process.env,
       stdio: ['pipe', 'pipe', 'pipe']
     });
-
-    try {
-      if (typeof this.process.unref === 'function') {
-        this.process.unref();
-      }
-    } catch (err) {
-      Logger.warn(`Unable to unref sink process: ${err}`);
-    }
+    this.process.unref();
 
     this.process.stdout.on('data', this.onStdout.bind(this));
     this.process.stderr.on('data', this.onStderr.bind(this));

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -53,7 +53,7 @@ class BaseService {
   get errorOutput() {
     const errorOut = this.error_out.split('\n');
 
-    return errorOut.reduce(function(prev, message) {
+    return errorOut.reduce(function (prev, message) {
       if (prev.indexOf(message) < 0) {
         prev.push(message);
       }
@@ -224,7 +224,9 @@ class BaseService {
   }
 
   needsSinkProcess() {
-    return !Concurrency.isWorker();
+    const {retain_logs_in_worker} = this.settings.webdriver || {};
+
+    return !Concurrency.isWorker() || retain_logs_in_worker ;
   }
 
   hasSinkSupport() {
@@ -249,14 +251,11 @@ class BaseService {
 
     Logger.info(`Starting ${this.serviceName}${serverPathLog}...`);
 
-    const hasPerWorkerLogFile = !!(this.settings && this.settings.webdriver && this.settings.webdriver.log_file_name);
 
-    if (this.hasSinkSupport() && (this.needsSinkProcess() || hasPerWorkerLogFile)) {
+    if (this.hasSinkSupport() && this.needsSinkProcess()) {
       await this.createSinkProcess();
     } else {
-      if (!hasPerWorkerLogFile) {
-        this.settings.webdriver.log_path = false;
-      }
+      this.settings.webdriver.log_path = false;
     }
 
     if (port) {

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -109,12 +109,18 @@ class BaseService {
 
   createSinkProcess() {
     const exitHandler = this.onExit.bind(this);
-
     this.process = child_process.spawn('cat', [], {
       env: process.env,
       stdio: ['pipe', 'pipe', 'pipe']
     });
-    this.process.unref();
+
+    try {
+      if (typeof this.process.unref === 'function') {
+        this.process.unref();
+      }
+    } catch (err) {
+      Logger.warn(`Unable to unref sink process: ${err}`);
+    }
 
     this.process.stdout.on('data', this.onStdout.bind(this));
     this.process.stderr.on('data', this.onStderr.bind(this));
@@ -126,7 +132,29 @@ class BaseService {
     if (this.service) {
       this.service.setStdio(['pipe', this.process.stdin, this.process.stdin]);
     }
+
+    const filePath = this.getOutputFilePath();
+    if (filePath) {
+      const folderPath = path.dirname(filePath);
+      createFolder(folderPath).then(() => {
+        try {
+          this._logWriteStream = fs.createWriteStream(filePath, {flags: 'a'});
+
+          if (this.process && this.process.stdout) {
+            this.process.stdout.pipe(this._logWriteStream);
+          }
+          if (this.process && this.process.stderr) {
+            this.process.stderr.pipe(this._logWriteStream);
+          }
+        } catch (err) {
+          Logger.warn(`Unable to create log write stream for ${filePath}: ${err}`);
+        }
+      }).catch(err => {
+        Logger.warn(`Unable to create logs folder ${folderPath}: ${err}`);
+      });
+    }
   }
+
 
   createErrorMessage(code) {
     return `${this.serviceName} process exited with code: ${code}`;
@@ -242,10 +270,18 @@ class BaseService {
 
     Logger.info(`Starting ${this.serviceName}${serverPathLog}...`);
 
-    if (this.hasSinkSupport() && this.needsSinkProcess()) {
+    // Allow creating a sink in the worker iff there is an explicit per-worker log_file_name.
+    // This prevents disabling the log_path for workers that explicitly want per-worker files.
+    const hasPerWorkerLogFile = !!(this.settings && this.settings.webdriver && this.settings.webdriver.log_file_name);
+
+    if (this.hasSinkSupport() && (this.needsSinkProcess() || hasPerWorkerLogFile)) {
       await this.createSinkProcess();
     } else {
-      this.settings.webdriver.log_path = false;
+      // previously this unconditionally disabled log_path for workers.
+      // keep it disabled only if there's no explicit per-worker log_file_name.
+      if (!hasPerWorkerLogFile) {
+        this.settings.webdriver.log_path = false;
+      }
     }
 
     if (port) {
@@ -299,7 +335,20 @@ class BaseService {
       return;
     }
 
+    // ensure we flush / write the log file by the existing mechanism (keeps compatibility)
     await this.writeLogFile();
+
+    // also close any live write stream we created during createSinkProcess()
+    if (this._logWriteStream && !this._logWriteStream.destroyed) {
+      try {
+        await new Promise((resolve) => {
+          this._logWriteStream.end(resolve);
+        });
+      } catch (err) {
+        // swallow
+      }
+    }
+
     if (!this.process || this.process.killed) {
       return;
     }

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -270,15 +270,11 @@ class BaseService {
 
     Logger.info(`Starting ${this.serviceName}${serverPathLog}...`);
 
-    // Allow creating a sink in the worker iff there is an explicit per-worker log_file_name.
-    // This prevents disabling the log_path for workers that explicitly want per-worker files.
     const hasPerWorkerLogFile = !!(this.settings && this.settings.webdriver && this.settings.webdriver.log_file_name);
 
     if (this.hasSinkSupport() && (this.needsSinkProcess() || hasPerWorkerLogFile)) {
       await this.createSinkProcess();
     } else {
-      // previously this unconditionally disabled log_path for workers.
-      // keep it disabled only if there's no explicit per-worker log_file_name.
       if (!hasPerWorkerLogFile) {
         this.settings.webdriver.log_path = false;
       }
@@ -335,17 +331,15 @@ class BaseService {
       return;
     }
 
-    // ensure we flush / write the log file by the existing mechanism (keeps compatibility)
     await this.writeLogFile();
 
-    // also close any live write stream we created during createSinkProcess()
     if (this._logWriteStream && !this._logWriteStream.destroyed) {
       try {
         await new Promise((resolve) => {
           this._logWriteStream.end(resolve);
         });
       } catch (err) {
-        // swallow
+        Logger.warn(`Unable to close log write stream: ${err}`);
       }
     }
 


### PR DESCRIPTION
This PR fixes missing webdriver / chromedriver log files when Nightwatch runs tests in parallel (worker-threads or child-process workers). Previously worker-mode disabled the log sink, causing writeLogFile() to no-op and resulting in no log files for worker-hosted driver processes.

### Root cause
- `BaseService.needsSinkProcess()` returned false in workers when [`Concurrency.isWorker()` ](https://github.com/nightwatchjs/nightwatch/blob/54c8550c75a16c61827c0bad043c7ffa073a52e6/lib/transport/selenium-webdriver/service-builders/base-service.js#L220)was true, so `BaseService.createService()` set [`[webdriver.log_path = false]` ](https://github.com/nightwatchjs/nightwatch/blob/54c8550c75a16c61827c0bad043c7ffa073a52e6/lib/transport/selenium-webdriver/service-builders/base-service.js#L248)for workers. That made `getLogPath()` return null and `writeLogFile()` return early and hence no file was written.
- No Logs were generated as shown in the below screenshot
![No logs generated for multiple workers](https://github.com/user-attachments/assets/bf8d7c0f-9eab-4d62-b192-fc2632c0d30f)

## Changes Implemented

### Parallel Mode-Specific Logging Behavior

When parallel mode is detected (`process.env.__NIGHTWATCH_PARALLEL_MODE === '1'`), unique log files are created for each Chromedriver instance spun up:

- **Without `log_file_name`:**  
  Log files are named as `<module_key>_<timestamp>.log`, where `<timestamp>` is dynamically generated.

- **With `log_file_name`:**  
  User-configured log file names (e.g., `my_custom_log`) are suffixed with timestamp and a generated random string of length 10  
  (e.g., `my_custom_log_<timestamp>_abcd1234ef.log`).

### Fallback to Default Behavior for Non-Parallel Execution

If parallel mode is not enabled or only a single thread is used:

- The repository’s original logging mechanism is preserved.
- No disruption to existing workflows.
- Outputs are aggregated and logged exactly as originally implemented.

### Files changed
- `lib/transport/selenium-webdriver/index.js`
- `lib/transport/selenium-webdriver/service-builders/base-service.js`

### How to test (locally)
1. Use a Nightwatch config with test_workers enabled .
2. Run parallel tests: `npx nightwatch tests/guide/ --env chrome --workers=2 `
3. Expect one log file per chromedriver spun up  in `webdriver.log_path` (defaults to `./logs`):
4. Inspect file contents `ls -l logs/` and `head -n 50 logs/<file>`.

### Notes
- Single-process behavior is unchanged.
- The per-worker sink is only created where sink support is available (`hasSinkSupport()` still respected).


### After Changes
- I ran ./bin/nightwatch examples/tests/ecosia.js examples/tests/duckDuckGo.js --env chrome
- Without `log_file_name`:
<img width="1470" height="897" alt="Screenshot 2025-12-22 at 9 08 39 PM" src="https://github.com/user-attachments/assets/0845e885-ec66-4f43-91b9-c3b194384afa" />

-With `log_file_name`:
<img width="1467" height="884" alt="Screenshot 2025-12-22 at 9 13 53 PM" src="https://github.com/user-attachments/assets/05888906-93aa-48c1-8828-7dc391039836" />




