### PR TITLE
add node version 24 and 22

### DIFF
--- a/.github/workflows/build-node.yaml
+++ b/.github/workflows/build-node.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x, 22.x, 24.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
This PR extends the GitHub Actions test matrix to include **Node.js 22.x and 24.x**, ensuring Nightwatch is continuously tested against the latest active and upcoming Node.js releases.
