### PR TITLE
Log in parallel modes

### DIFF
--- a/lib/settings/defaults.js
+++ b/lib/settings/defaults.js
@@ -228,6 +228,11 @@ module.exports = {
     // leave empty to use the test suite name when writing the webdriver server logs
     log_file_name: '',
 
+    // When running tests in parallel (test workers), each worker spawns its own webdriver process but
+    // their logs are not written to disk by default. Set this to true to retain webdriver server logs
+    // from worker processes when running in parallel mode.
+    retain_logs_in_parallel_run: false,
+
     // Time to wait (in ms) before starting to check the Webdriver server is up and running
     check_process_delay: 100,
 

--- a/lib/transport/selenium-webdriver/index.js
+++ b/lib/transport/selenium-webdriver/index.js
@@ -194,33 +194,28 @@ class Transport extends BaseTransport {
 
   async createDriverService({options, moduleKey, reuseBrowser = false}) {
     try {
-      moduleKey = (this.settings && this.settings.webdriver && this.settings.webdriver.log_file_name) || moduleKey || '';
-      if (!this.settings) {
-        this.settings = {};
-      }
-      if (!this.settings.webdriver) {
-        this.settings.webdriver = {};
-      }
-      if (!this.settings.webdriver.log_file_name) {
-        const isParallelEnv = process.env.__NIGHTWATCH_PARALLEL_MODE === '1' || false;
-        let uniqueId = null;
-        try {
-          const wt = require('worker_threads');
-          if (wt && !wt.isMainThread && typeof wt.threadId !== 'undefined') {
-            uniqueId = `worker_thread_${wt.threadId}`;
-          }
-        } catch (err) {
-          Logger.warn('worker_threads not supported in this Node.js version.');
+      const isParallelEnv = process.env.__NIGHTWATCH_PARALLEL_MODE === '1';
+      if (!isParallelEnv) {
+        moduleKey = this.settings.webdriver.log_file_name || moduleKey || '';
+      } else {
+        if (!this.settings) {
+          this.settings = {};
+        }
+        if (!this.settings.webdriver) {
+          this.settings.webdriver = {};
+        }
+        const timestamp = new Date().toISOString().replace(/[:.-]/g, '_');
+        if (!this.settings.webdriver.log_file_name) {
+          const moduleKeyTimestamp = `${moduleKey}_${timestamp}`;
+          this.settings.webdriver.log_file_name = moduleKeyTimestamp;
+        } else {
+          const userDefinedLogFileName = this.settings.webdriver.log_file_name;
+          const randomString = Math.random().toString(36).substring(2, 12);
+          this.settings.webdriver.log_file_name = `${userDefinedLogFileName}_${timestamp}_${randomString}`;
         }
 
-        if (!uniqueId) {
-          uniqueId = `pid_${process.pid}`;
-        }
-        if (isParallelEnv) {
-          moduleKey = uniqueId;
-          this.settings.webdriver.log_file_name = moduleKey;
-        }
       }
+
 
       if (!this.shouldReuseDriverService(reuseBrowser)) {
         Transport.driverService = new this.ServiceBuilder(this.settings);
@@ -243,7 +238,7 @@ class Transport extends BaseTransport {
 
 
   async getDriver({options, reuseBrowser = false}) {
-    const value  = await this.shouldReuseDriver(reuseBrowser);
+    const value = await this.shouldReuseDriver(reuseBrowser);
     if (value) {
       return Transport.driver;
     }

--- a/lib/transport/selenium-webdriver/index.js
+++ b/lib/transport/selenium-webdriver/index.js
@@ -194,7 +194,33 @@ class Transport extends BaseTransport {
 
   async createDriverService({options, moduleKey, reuseBrowser = false}) {
     try {
-      moduleKey = this.settings.webdriver.log_file_name || moduleKey || '';
+      moduleKey = (this.settings && this.settings.webdriver && this.settings.webdriver.log_file_name) || moduleKey || '';
+      if (!this.settings) {
+        this.settings = {};
+      }
+      if (!this.settings.webdriver) {
+        this.settings.webdriver = {};
+      }
+      if (!this.settings.webdriver.log_file_name) {
+        const isParallelEnv = process.env.__NIGHTWATCH_PARALLEL_MODE === '1' || false;
+        let uniqueId = null;
+        try {
+          const wt = require('worker_threads');
+          if (wt && !wt.isMainThread && typeof wt.threadId !== 'undefined') {
+            uniqueId = `worker_thread_${wt.threadId}`;
+          }
+        } catch (err) {
+          Logger.warn('worker_threads not supported in this Node.js version.');
+        }
+
+        if (!uniqueId) {
+          uniqueId = `pid_${process.pid}`;
+        }
+        if (isParallelEnv) {
+          moduleKey = uniqueId;
+          this.settings.webdriver.log_file_name = moduleKey;
+        }
+      }
 
       if (!this.shouldReuseDriverService(reuseBrowser)) {
         Transport.driverService = new this.ServiceBuilder(this.settings);

--- a/lib/transport/selenium-webdriver/index.js
+++ b/lib/transport/selenium-webdriver/index.js
@@ -196,7 +196,7 @@ class Transport extends BaseTransport {
   async createDriverService({options, moduleKey, reuseBrowser = false}) {
     try {
       moduleKey = this.settings.webdriver.log_file_name || moduleKey || '';
-      if (Concurrency.isWorker) {
+      if (Concurrency.isWorker()) {
         // append timestamp to the output file name to differentiate between the files
         // created across the workers.
         moduleKey = `${moduleKey}_${process.hrtime.bigint()}`;

--- a/lib/transport/selenium-webdriver/index.js
+++ b/lib/transport/selenium-webdriver/index.js
@@ -11,6 +11,7 @@ const BaseTransport = require('../');
 const {colors} = Logger;
 const {isErrorResponse, checkLegacyResponse, throwDecodedError, WebDriverError} = error;
 const {IosSessionErrors} = require('../errors');
+const Concurrency = require('../../runner/concurrency/index.js');
 
 let _driverService = null;
 let _driver = null;
@@ -194,28 +195,18 @@ class Transport extends BaseTransport {
 
   async createDriverService({options, moduleKey, reuseBrowser = false}) {
     try {
-      const isParallelEnv = process.env.__NIGHTWATCH_PARALLEL_MODE === '1';
-      if (!isParallelEnv) {
+      if (!Concurrency.isWorker) {
         moduleKey = this.settings.webdriver.log_file_name || moduleKey || '';
       } else {
-        if (!this.settings) {
-          this.settings = {};
-        }
-        if (!this.settings.webdriver) {
-          this.settings.webdriver = {};
-        }
-        const timestamp = new Date().toISOString().replace(/[:.-]/g, '_');
+        const timestamp = process.hrtime.bigint().toString();
         if (!this.settings.webdriver.log_file_name) {
           const moduleKeyTimestamp = `${moduleKey}_${timestamp}`;
           this.settings.webdriver.log_file_name = moduleKeyTimestamp;
         } else {
           const userDefinedLogFileName = this.settings.webdriver.log_file_name;
-          const randomString = Math.random().toString(36).substring(2, 12);
-          this.settings.webdriver.log_file_name = `${userDefinedLogFileName}_${timestamp}_${randomString}`;
+          this.settings.webdriver.log_file_name = `${userDefinedLogFileName}_${timestamp}`;
         }
-
       }
-
 
       if (!this.shouldReuseDriverService(reuseBrowser)) {
         Transport.driverService = new this.ServiceBuilder(this.settings);

--- a/lib/transport/selenium-webdriver/index.js
+++ b/lib/transport/selenium-webdriver/index.js
@@ -195,16 +195,13 @@ class Transport extends BaseTransport {
 
   async createDriverService({options, moduleKey, reuseBrowser = false}) {
     try {
-      if (!Concurrency.isWorker) {
-        moduleKey = this.settings.webdriver.log_file_name || moduleKey || '';
-      } else {
-        const timestamp = process.hrtime.bigint().toString();
-        if (!this.settings.webdriver.log_file_name) {
-          const moduleKeyTimestamp = `${moduleKey}_${timestamp}`;
-          this.settings.webdriver.log_file_name = moduleKeyTimestamp;
-        } else {
-          const userDefinedLogFileName = this.settings.webdriver.log_file_name;
-          this.settings.webdriver.log_file_name = `${userDefinedLogFileName}_${timestamp}`;
+      moduleKey = this.settings.webdriver.log_file_name || moduleKey || '';
+      if (Concurrency.isWorker) {
+        // append timestamp to the output file name to differentiate between the files
+        // created across the workers.
+        moduleKey = `${moduleKey}_${process.hrtime.bigint()}`;
+        if (this.settings.webdriver.log_file_name) {
+          this.settings.webdriver.log_file_name = moduleKey;
         }
       }
 

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -303,17 +303,6 @@ class BaseService {
     }
 
     await this.writeLogFile();
-
-    if (this._logWriteStream && !this._logWriteStream.destroyed) {
-      try {
-        await new Promise((resolve) => {
-          this._logWriteStream.end(resolve);
-        });
-      } catch (err) {
-        Logger.warn(`Unable to close log write stream: ${err}`);
-      }
-    }
-
     if (!this.process || this.process.killed) {
       return;
     }

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -140,12 +140,9 @@ class BaseService {
         try {
           this._logWriteStream = fs.createWriteStream(filePath, {flags: 'a'});
 
-          if (this.process && this.process.stdout) {
-            this.process.stdout.pipe(this._logWriteStream);
-          }
-          if (this.process && this.process.stderr) {
-            this.process.stderr.pipe(this._logWriteStream);
-          }
+          this.process.stdout?.pipe(this._logWriteStream);
+          this.process.stderr?.pipe(this._logWriteStream);
+
         } catch (err) {
           Logger.warn(`Unable to create log write stream for ${filePath}: ${err}`);
         }

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -132,24 +132,6 @@ class BaseService {
     if (this.service) {
       this.service.setStdio(['pipe', this.process.stdin, this.process.stdin]);
     }
-
-    const filePath = this.getOutputFilePath();
-    if (filePath) {
-      const folderPath = path.dirname(filePath);
-      createFolder(folderPath).then(() => {
-        try {
-          this._logWriteStream = fs.createWriteStream(filePath, {flags: 'a'});
-
-          this.process.stdout?.pipe(this._logWriteStream);
-          this.process.stderr?.pipe(this._logWriteStream);
-
-        } catch (err) {
-          Logger.warn(`Unable to create log write stream for ${filePath}: ${err}`);
-        }
-      }).catch(err => {
-        Logger.warn(`Unable to create logs folder ${folderPath}: ${err}`);
-      });
-    }
   }
 
 
@@ -404,6 +386,7 @@ class BaseService {
     const filePath = this.getOutputFilePath();
     const folderPath = path.dirname(filePath);
     await createFolder(folderPath);
+
 
     return new Promise((resolve, reject) => {
       fs.writeFile(filePath, this.output, (err) => {

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -113,14 +113,7 @@ class BaseService {
       env: process.env,
       stdio: ['pipe', 'pipe', 'pipe']
     });
-
-    try {
-      if (typeof this.process.unref === 'function') {
-        this.process.unref();
-      }
-    } catch (err) {
-      Logger.warn(`Unable to unref sink process: ${err}`);
-    }
+    this.process.unref();
 
     this.process.stdout.on('data', this.onStdout.bind(this));
     this.process.stderr.on('data', this.onStderr.bind(this));

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -53,7 +53,7 @@ class BaseService {
   get errorOutput() {
     const errorOut = this.error_out.split('\n');
 
-    return errorOut.reduce(function(prev, message) {
+    return errorOut.reduce(function (prev, message) {
       if (prev.indexOf(message) < 0) {
         prev.push(message);
       }
@@ -224,7 +224,9 @@ class BaseService {
   }
 
   needsSinkProcess() {
-    return !Concurrency.isWorker();
+    const {retain_logs_in_worker} = this.settings.webdriver || {};
+
+    return !Concurrency.isWorker() || retain_logs_in_worker ;
   }
 
   hasSinkSupport() {
@@ -249,14 +251,11 @@ class BaseService {
 
     Logger.info(`Starting ${this.serviceName}${serverPathLog}...`);
 
-    const hasPerWorkerLogFile = !!(this.settings && this.settings.webdriver && this.settings.webdriver.log_file_name);
 
-    if (this.hasSinkSupport() && (this.needsSinkProcess() || hasPerWorkerLogFile)) {
+    if (this.hasSinkSupport() && this.needsSinkProcess()) {
       await this.createSinkProcess();
     } else {
-      if (!hasPerWorkerLogFile) {
-        this.settings.webdriver.log_path = false;
-      }
+      this.settings.webdriver.log_path = false;
     }
 
     if (port) {

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -225,10 +225,6 @@ class BaseService {
   }
 
   hasSinkSupport() {
-    Logger.info('process.platform', process.platform);
-    Logger.info('process.env._', process.env._);
-    Logger.info('process.env._.startsWith(/usr/)', process.env._.startsWith('/usr/'));
-
     return process.platform !== 'win32' || process.env._ && process.env._.startsWith('/usr/');
   }
 

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -109,12 +109,18 @@ class BaseService {
 
   createSinkProcess() {
     const exitHandler = this.onExit.bind(this);
-
     this.process = child_process.spawn('cat', [], {
       env: process.env,
       stdio: ['pipe', 'pipe', 'pipe']
     });
-    this.process.unref();
+
+    try {
+      if (typeof this.process.unref === 'function') {
+        this.process.unref();
+      }
+    } catch (err) {
+      Logger.warn(`Unable to unref sink process: ${err}`);
+    }
 
     this.process.stdout.on('data', this.onStdout.bind(this));
     this.process.stderr.on('data', this.onStderr.bind(this));
@@ -126,7 +132,29 @@ class BaseService {
     if (this.service) {
       this.service.setStdio(['pipe', this.process.stdin, this.process.stdin]);
     }
+
+    const filePath = this.getOutputFilePath();
+    if (filePath) {
+      const folderPath = path.dirname(filePath);
+      createFolder(folderPath).then(() => {
+        try {
+          this._logWriteStream = fs.createWriteStream(filePath, {flags: 'a'});
+
+          if (this.process && this.process.stdout) {
+            this.process.stdout.pipe(this._logWriteStream);
+          }
+          if (this.process && this.process.stderr) {
+            this.process.stderr.pipe(this._logWriteStream);
+          }
+        } catch (err) {
+          Logger.warn(`Unable to create log write stream for ${filePath}: ${err}`);
+        }
+      }).catch(err => {
+        Logger.warn(`Unable to create logs folder ${folderPath}: ${err}`);
+      });
+    }
   }
+
 
   createErrorMessage(code) {
     return `${this.serviceName} process exited with code: ${code}`;
@@ -242,10 +270,18 @@ class BaseService {
 
     Logger.info(`Starting ${this.serviceName}${serverPathLog}...`);
 
-    if (this.hasSinkSupport() && this.needsSinkProcess()) {
+    // Allow creating a sink in the worker iff there is an explicit per-worker log_file_name.
+    // This prevents disabling the log_path for workers that explicitly want per-worker files.
+    const hasPerWorkerLogFile = !!(this.settings && this.settings.webdriver && this.settings.webdriver.log_file_name);
+
+    if (this.hasSinkSupport() && (this.needsSinkProcess() || hasPerWorkerLogFile)) {
       await this.createSinkProcess();
     } else {
-      this.settings.webdriver.log_path = false;
+      // previously this unconditionally disabled log_path for workers.
+      // keep it disabled only if there's no explicit per-worker log_file_name.
+      if (!hasPerWorkerLogFile) {
+        this.settings.webdriver.log_path = false;
+      }
     }
 
     if (port) {
@@ -299,7 +335,20 @@ class BaseService {
       return;
     }
 
+    // ensure we flush / write the log file by the existing mechanism (keeps compatibility)
     await this.writeLogFile();
+
+    // also close any live write stream we created during createSinkProcess()
+    if (this._logWriteStream && !this._logWriteStream.destroyed) {
+      try {
+        await new Promise((resolve) => {
+          this._logWriteStream.end(resolve);
+        });
+      } catch (err) {
+        // swallow
+      }
+    }
+
     if (!this.process || this.process.killed) {
       return;
     }

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -270,15 +270,11 @@ class BaseService {
 
     Logger.info(`Starting ${this.serviceName}${serverPathLog}...`);
 
-    // Allow creating a sink in the worker iff there is an explicit per-worker log_file_name.
-    // This prevents disabling the log_path for workers that explicitly want per-worker files.
     const hasPerWorkerLogFile = !!(this.settings && this.settings.webdriver && this.settings.webdriver.log_file_name);
 
     if (this.hasSinkSupport() && (this.needsSinkProcess() || hasPerWorkerLogFile)) {
       await this.createSinkProcess();
     } else {
-      // previously this unconditionally disabled log_path for workers.
-      // keep it disabled only if there's no explicit per-worker log_file_name.
       if (!hasPerWorkerLogFile) {
         this.settings.webdriver.log_path = false;
       }
@@ -335,17 +331,15 @@ class BaseService {
       return;
     }
 
-    // ensure we flush / write the log file by the existing mechanism (keeps compatibility)
     await this.writeLogFile();
 
-    // also close any live write stream we created during createSinkProcess()
     if (this._logWriteStream && !this._logWriteStream.destroyed) {
       try {
         await new Promise((resolve) => {
           this._logWriteStream.end(resolve);
         });
       } catch (err) {
-        // swallow
+        Logger.warn(`Unable to close log write stream: ${err}`);
       }
     }
 

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -218,8 +218,6 @@ class BaseService {
 
   needsSinkProcess() {
     const {retain_logs_in_worker} = this.settings.webdriver || {};
-    Logger.info('retain_logs_in_worker', retain_logs_in_worker);
-    Logger.info('Concurrency.isWorker()', Concurrency.isWorker());
 
     return !Concurrency.isWorker() || retain_logs_in_worker ;
   }
@@ -246,8 +244,7 @@ class BaseService {
 
     Logger.info(`Starting ${this.serviceName}${serverPathLog}...`);
 
-    Logger.info('this.hasSinkSupport()', this.hasSinkSupport());
-    Logger.info('this.needsSinkProcess()', this.needsSinkProcess());
+
     if (this.hasSinkSupport() && this.needsSinkProcess()) {
       await this.createSinkProcess();
     } else {

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -218,11 +218,17 @@ class BaseService {
 
   needsSinkProcess() {
     const {retain_logs_in_worker} = this.settings.webdriver || {};
+    Logger.info('retain_logs_in_worker', retain_logs_in_worker);
+    Logger.info('Concurrency.isWorker()', Concurrency.isWorker());
 
     return !Concurrency.isWorker() || retain_logs_in_worker ;
   }
 
   hasSinkSupport() {
+    Logger.info('process.platform', process.platform);
+    Logger.info('process.env._', process.env._);
+    Logger.info('process.env._.startsWith(/usr/)', process.env._.startsWith('/usr/'));
+
     return process.platform !== 'win32' || process.env._ && process.env._.startsWith('/usr/');
   }
 
@@ -244,7 +250,8 @@ class BaseService {
 
     Logger.info(`Starting ${this.serviceName}${serverPathLog}...`);
 
-
+    Logger.info('this.hasSinkSupport()', this.hasSinkSupport());
+    Logger.info('this.needsSinkProcess()', this.needsSinkProcess());
     if (this.hasSinkSupport() && this.needsSinkProcess()) {
       await this.createSinkProcess();
     } else {

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -53,7 +53,7 @@ class BaseService {
   get errorOutput() {
     const errorOut = this.error_out.split('\n');
 
-    return errorOut.reduce(function (prev, message) {
+    return errorOut.reduce(function(prev, message) {
       if (prev.indexOf(message) < 0) {
         prev.push(message);
       }
@@ -109,6 +109,7 @@ class BaseService {
 
   createSinkProcess() {
     const exitHandler = this.onExit.bind(this);
+
     this.process = child_process.spawn('cat', [], {
       env: process.env,
       stdio: ['pipe', 'pipe', 'pipe']
@@ -126,7 +127,6 @@ class BaseService {
       this.service.setStdio(['pipe', this.process.stdin, this.process.stdin]);
     }
   }
-
 
   createErrorMessage(code) {
     return `${this.serviceName} process exited with code: ${code}`;
@@ -243,7 +243,6 @@ class BaseService {
     }
 
     Logger.info(`Starting ${this.serviceName}${serverPathLog}...`);
-
 
     if (this.hasSinkSupport() && this.needsSinkProcess()) {
       await this.createSinkProcess();
@@ -367,7 +366,6 @@ class BaseService {
     const filePath = this.getOutputFilePath();
     const folderPath = path.dirname(filePath);
     await createFolder(folderPath);
-
 
     return new Promise((resolve, reject) => {
       fs.writeFile(filePath, this.output, (err) => {

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -217,7 +217,7 @@ class BaseService {
   }
 
   needsSinkProcess() {
-    const {retain_logs_in_parallel_run} = this.settings.webdriver || {};
+    const {retain_logs_in_parallel_run = false} = this.settings.webdriver || {};
 
     return !Concurrency.isWorker() || retain_logs_in_parallel_run ;
   }

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -219,7 +219,7 @@ class BaseService {
   needsSinkProcess() {
     const {retain_logs_in_parallel_run = false} = this.settings.webdriver || {};
 
-    return !Concurrency.isWorker() || retain_logs_in_parallel_run ;
+    return !Concurrency.isWorker() || retain_logs_in_parallel_run;
   }
 
   hasSinkSupport() {

--- a/lib/transport/selenium-webdriver/service-builders/base-service.js
+++ b/lib/transport/selenium-webdriver/service-builders/base-service.js
@@ -217,9 +217,9 @@ class BaseService {
   }
 
   needsSinkProcess() {
-    const {retain_logs_in_worker} = this.settings.webdriver || {};
+    const {retain_logs_in_parallel_run} = this.settings.webdriver || {};
 
-    return !Concurrency.isWorker() || retain_logs_in_worker ;
+    return !Concurrency.isWorker() || retain_logs_in_parallel_run ;
   }
 
   hasSinkSupport() {

--- a/test/src/service-builders/testBaseServiceConcurrency.js
+++ b/test/src/service-builders/testBaseServiceConcurrency.js
@@ -76,9 +76,13 @@ describe('BaseService concurrency behaviour', function () {
     assert.strictEqual(service.needsSinkProcess(), true);
 
     await service.createService({});
-
-    assert.strictEqual(service.sinkCreated, true);
-    assert.strictEqual(service.settings.webdriver.log_path, 'logs');
+    if (process.platform === 'win32') {
+      assert.strictEqual(service.sinkCreated, undefined);
+      assert.strictEqual(service.settings.webdriver.log_path, false);
+    } else {
+      assert.strictEqual(service.sinkCreated, true);
+      assert.strictEqual(service.settings.webdriver.log_path, 'logs');
+    }
   });
 
   it('does not create sink and disables log_path for workers by default', async function () {
@@ -98,9 +102,13 @@ describe('BaseService concurrency behaviour', function () {
     assert.strictEqual(service.needsSinkProcess(), true);
 
     await service.createService({});
-
-    assert.strictEqual(service.sinkCreated, true);
-    assert.strictEqual(service.settings.webdriver.log_path, 'logs');
+    if (process.platform === 'win32') {
+      assert.strictEqual(service.sinkCreated, undefined);
+      assert.strictEqual(service.settings.webdriver.log_path, false);
+    } else {
+      assert.strictEqual(service.sinkCreated, true);
+      assert.strictEqual(service.settings.webdriver.log_path, 'logs');
+    }
   });
 });
 

--- a/test/src/service-builders/testBaseServiceConcurrency.js
+++ b/test/src/service-builders/testBaseServiceConcurrency.js
@@ -1,0 +1,85 @@
+const assert = require('assert');
+const mockery = require('mockery');
+const common = require('../../common.js');
+
+describe('BaseService concurrency behaviour', function() {
+  const Concurrency = common.require('runner/concurrency/');
+  const originalIsWorker = Concurrency.isWorker;
+
+  before(function() {
+    mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
+  });
+
+  after(function() {
+    mockery.deregisterAll();
+    mockery.disable();
+    mockery.resetCache();
+    Concurrency.isWorker = originalIsWorker;
+  });
+
+  function createService({isWorker, retainLogsInWorker} = {}) {
+    Concurrency.isWorker = function() {
+      return !!isWorker;
+    };
+
+    const BaseService = common.require('transport/selenium-webdriver/service-builders/base-service.js');
+
+    class MockBaseService extends BaseService {
+      get requiresDriverBinary() {
+        return false;
+      }
+
+      async createSinkProcess() {
+        this.sinkCreated = true;
+      }
+    }
+
+    const settings = {
+      webdriver: {
+        log_path: 'logs',
+        retain_logs_in_worker: retainLogsInWorker
+      }
+    };
+
+    const service = new MockBaseService(settings);
+
+    return service;
+  }
+
+  it('creates sink process when not running as worker', async function() {
+    const service = createService({isWorker: false});
+
+    assert.strictEqual(service.needsSinkProcess(), true);
+
+    await service.createService({});
+
+    assert.strictEqual(service.sinkCreated, true);
+    assert.strictEqual(service.settings.webdriver.log_path, 'logs');
+  });
+
+  it('does not create sink and disables log_path for workers by default', async function() {
+    const service = createService({isWorker: true, retainLogsInWorker: false});
+
+    assert.strictEqual(service.needsSinkProcess(), false);
+
+    await service.createService({});
+
+    assert.strictEqual(service.sinkCreated, undefined);
+    assert.strictEqual(service.settings.webdriver.log_path, false);
+  });
+
+  it('creates sink and keeps log_path when retain_logs_in_worker is true', async function() {
+    const service = createService({isWorker: true, retainLogsInWorker: true});
+
+    assert.strictEqual(service.needsSinkProcess(), true);
+
+    await service.createService({});
+
+    assert.strictEqual(service.sinkCreated, true);
+    assert.strictEqual(service.settings.webdriver.log_path, 'logs');
+  });
+});
+
+
+
+

--- a/test/src/service-builders/testBaseServiceConcurrency.js
+++ b/test/src/service-builders/testBaseServiceConcurrency.js
@@ -3,9 +3,6 @@ const mockery = require('mockery');
 const common = require('../../common.js');
 
 describe('BaseService concurrency behaviour', function () {
-  const Concurrency = common.require('runner/concurrency/');
-  const originalIsWorker = Concurrency.isWorker;
-
   before(function () {
     mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
   });
@@ -14,13 +11,14 @@ describe('BaseService concurrency behaviour', function () {
     mockery.deregisterAll();
     mockery.disable();
     mockery.resetCache();
-    Concurrency.isWorker = originalIsWorker;
   });
 
   function createService({isWorker, retainLogsInParallelRun} = {}) {
-    Concurrency.isWorker = function () {
-      return Boolean(isWorker);
-    };
+    mockery.registerMock('../../../runner/concurrency', {
+      isWorker: function () {
+        return Boolean(isWorker);
+      }
+    });
 
     const BaseService = common.require('transport/selenium-webdriver/service-builders/base-service.js');
 

--- a/test/src/service-builders/testBaseServiceConcurrency.js
+++ b/test/src/service-builders/testBaseServiceConcurrency.js
@@ -3,18 +3,9 @@ const mockery = require('mockery');
 const common = require('../../common.js');
 
 describe('BaseService concurrency behaviour', function () {
-  const Concurrency = common.require('runner/concurrency/');
-  const originalIsWorker = Concurrency.isWorker;
 
   before(function () {
     mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
-  });
-
-  after(function () {
-    mockery.deregisterAll();
-    mockery.disable();
-    mockery.resetCache();
-    Concurrency.isWorker = originalIsWorker;
   });
 
   function createService({isWorker, retainLogsInParallelRun} = {}) {

--- a/test/src/service-builders/testBaseServiceConcurrency.js
+++ b/test/src/service-builders/testBaseServiceConcurrency.js
@@ -46,7 +46,7 @@ describe('BaseService concurrency behaviour', function () {
     const settings = {
       webdriver: {
         log_path: 'logs',
-        retain_logs_in_parallel_run: retainLogsInParallelRun
+        ...(retainLogsInParallelRun ? {retain_logs_in_parallel_run: retainLogsInParallelRun} : {})
       }
     };
 
@@ -71,7 +71,7 @@ describe('BaseService concurrency behaviour', function () {
   });
 
   it('does not create sink and disables log_path for workers by default', async function () {
-    const service = createService({isWorker: true, retainLogsInParallelRun: false});
+    const service = createService({isWorker: true});
 
     assert.strictEqual(service.needsSinkProcess(), false);
 

--- a/test/src/service-builders/testBaseServiceConcurrency.js
+++ b/test/src/service-builders/testBaseServiceConcurrency.js
@@ -3,17 +3,24 @@ const mockery = require('mockery');
 const common = require('../../common.js');
 
 describe('BaseService concurrency behaviour', function () {
+  const Concurrency = common.require('runner/concurrency/');
+  const originalIsWorker = Concurrency.isWorker;
 
   before(function () {
     mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
   });
 
+  after(function () {
+    mockery.deregisterAll();
+    mockery.disable();
+    mockery.resetCache();
+    Concurrency.isWorker = originalIsWorker;
+  });
+
   function createService({isWorker, retainLogsInParallelRun} = {}) {
-    mockery.registerMock('runner/concurrency/', {
-      isWorker: function () {
-        return true;
-      }
-    });
+    Concurrency.isWorker = function () {
+      return Boolean(isWorker);
+    };
 
     const BaseService = common.require('transport/selenium-webdriver/service-builders/base-service.js');
 

--- a/test/src/service-builders/testBaseServiceConcurrency.js
+++ b/test/src/service-builders/testBaseServiceConcurrency.js
@@ -10,16 +10,6 @@ describe('BaseService concurrency behaviour', function () {
     mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
   });
 
-  function deleteFromRequireCache(location) {
-    const entry = Object.keys(require.cache).filter(item => {
-      return item.includes(location);
-    });
-
-    entry.forEach(item => {
-      delete require.cache[item];
-    });
-  }
-
   after(function () {
     mockery.deregisterAll();
     mockery.disable();
@@ -28,12 +18,11 @@ describe('BaseService concurrency behaviour', function () {
   });
 
   function createService({isWorker, retainLogsInWorker} = {}) {
-    const Concurrency1 = common.require('runner/concurrency/');
-    deleteFromRequireCache('runner/concurrency/');
-    Concurrency1.isWorker = function () {
-      return !!isWorker;
-    };
-    mockery.registerMock('runner/concurrency/', Concurrency1);
+    mockery.registerMock('runner/concurrency/', {
+      isWorker: function () {
+        return true;
+      }
+    });
 
     const BaseService = common.require('transport/selenium-webdriver/service-builders/base-service.js');
 
@@ -111,9 +100,3 @@ describe('BaseService concurrency behaviour', function () {
     }
   });
 });
-
-
-
-
-
-

--- a/test/src/service-builders/testBaseServiceConcurrency.js
+++ b/test/src/service-builders/testBaseServiceConcurrency.js
@@ -17,7 +17,7 @@ describe('BaseService concurrency behaviour', function () {
     Concurrency.isWorker = originalIsWorker;
   });
 
-  function createService({isWorker, retainLogsInWorker} = {}) {
+  function createService({isWorker, retainLogsInParallelRun} = {}) {
     mockery.registerMock('runner/concurrency/', {
       isWorker: function () {
         return true;
@@ -50,7 +50,7 @@ describe('BaseService concurrency behaviour', function () {
     const settings = {
       webdriver: {
         log_path: 'logs',
-        retain_logs_in_worker: retainLogsInWorker
+        retain_logs_in_parallel_run: retainLogsInParallelRun
       }
     };
 
@@ -75,7 +75,7 @@ describe('BaseService concurrency behaviour', function () {
   });
 
   it('does not create sink and disables log_path for workers by default', async function () {
-    const service = createService({isWorker: true, retainLogsInWorker: false});
+    const service = createService({isWorker: true, retainLogsInParallelRun: false});
 
     assert.strictEqual(service.needsSinkProcess(), false);
 
@@ -85,8 +85,8 @@ describe('BaseService concurrency behaviour', function () {
     assert.strictEqual(service.settings.webdriver.log_path, false);
   });
 
-  it('creates sink and keeps log_path when retain_logs_in_worker is true', async function () {
-    const service = createService({isWorker: true, retainLogsInWorker: true});
+  it('creates sink and keeps log_path when retain_logs_in_parallel_run is true', async function () {
+    const service = createService({isWorker: true, retainLogsInParallelRun: true});
 
     assert.strictEqual(service.needsSinkProcess(), true);
 

--- a/test/src/service-builders/testBaseServiceConcurrency.js
+++ b/test/src/service-builders/testBaseServiceConcurrency.js
@@ -1,24 +1,24 @@
 const assert = require('assert');
-const mockery = require('mockery');
 const common = require('../../common.js');
 
 describe('BaseService concurrency behaviour', function () {
-  before(function () {
-    mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
-  });
+  const originalParallelEnv = process.env.__NIGHTWATCH_PARALLEL_MODE;
 
   after(function () {
-    mockery.deregisterAll();
-    mockery.disable();
-    mockery.resetCache();
+    if (originalParallelEnv === undefined) {
+      delete process.env.__NIGHTWATCH_PARALLEL_MODE;
+    } else {
+      process.env.__NIGHTWATCH_PARALLEL_MODE = originalParallelEnv;
+    }
   });
 
   function createService({isWorker, retainLogsInParallelRun} = {}) {
-    mockery.registerMock('../../../runner/concurrency', {
-      isWorker: function () {
-        return Boolean(isWorker);
-      }
-    });
+    // Concurrency.isWorker() reads this on each call (see lib/runner/concurrency/index.js)
+    if (isWorker) {
+      process.env.__NIGHTWATCH_PARALLEL_MODE = '1';
+    } else {
+      delete process.env.__NIGHTWATCH_PARALLEL_MODE;
+    }
 
     const BaseService = common.require('transport/selenium-webdriver/service-builders/base-service.js');
 

--- a/test/src/service-builders/testSeleniumServer.js
+++ b/test/src/service-builders/testSeleniumServer.js
@@ -3,7 +3,6 @@ const mockery = require('mockery');
 const common = require('../../common.js');
 const NightwatchClient = common.require('index.js');
 const Settings = common.require('settings/settings.js');
-const Concurrency = common.require('runner/concurrency/');
 
 describe('SeleniumServer Transport Tests', function () {
   beforeEach(function() {
@@ -263,12 +262,12 @@ describe('SeleniumServer Transport Tests', function () {
   });
 
   it('test per-worker log file path when running in worker', async function () {
-    const Concurrency1 = common.require('runner/concurrency/');
-    deleteFromRequireCache('runner/concurrency/');
-    Concurrency1.isWorker = function () {
-      return true;
-    };
-    mockery.registerMock('runner/concurrency/', Concurrency1);
+    mockery.registerMock('runner/concurrency/', {
+      isWorker: function () {
+        return true;
+      }
+    });
+    
 
     mockery.registerMock('geckodriver', {
       path: ''
@@ -283,7 +282,7 @@ describe('SeleniumServer Transport Tests', function () {
     });
 
     let logFilePath;
-    const {client} = await SeleniumServerTestSetup({
+    await SeleniumServerTestSetup({
       desiredCapabilities: {
         browserName: 'chrome'
       },
@@ -296,7 +295,6 @@ describe('SeleniumServer Transport Tests', function () {
         logFilePath = filePath;
       }
     });
-    console.log('logFilePath', logFilePath);
     assert.ok(/testModuleKey_[0-9]+_selenium-server\.log$/.test(logFilePath));
 
   });

--- a/test/src/service-builders/testSeleniumServer.js
+++ b/test/src/service-builders/testSeleniumServer.js
@@ -296,7 +296,7 @@ describe('SeleniumServer Transport Tests', function () {
     });
 
     // The log file name should include the moduleKey, timestamp and end with _selenium-server.log
-    assert.ok(/testModuleKey_[0-9]{15}_selenium-server\.log$/.test(logFilePath));
+    assert.ok(/testModuleKey_[0-9]+_selenium-server\.log$/.test(logFilePath));
     // The log_file_name should be unchanged
     assert.strictEqual(client.settings.webdriver.log_file_name, '');
   });
@@ -376,9 +376,9 @@ describe('SeleniumServer Transport Tests', function () {
     });
 
     // The log file name should include the customModuleKey, timestamp and end with _selenium-server.log
-    assert.ok(/customModuleKey_[0-9]{15}_selenium-server\.log$/.test(logFilePath));
+    assert.ok(/customModuleKey_[0-9]+_selenium-server\.log$/.test(logFilePath));
     // The log_file_name should also be updated to include the timestamp when running in worker
-    assert.ok(/^customModuleKey_[0-9]{15}$/.test(client.settings.webdriver.log_file_name));
+    assert.ok(/^customModuleKey_[0-9]+$/.test(client.settings.webdriver.log_file_name));
   });
 
   it('test create session with selenium server 3 -- with drivers', async function() {

--- a/test/src/service-builders/testSeleniumServer.js
+++ b/test/src/service-builders/testSeleniumServer.js
@@ -261,7 +261,7 @@ describe('SeleniumServer Transport Tests', function () {
     assert.ok(logFilePath.endsWith('testModuleKey_selenium-server.log'));
   });
 
-  it('test per-worker log file path when running in worker', async function () {
+  it('test per-worker log file path when running in worker without log_file_name set', async function () {
     mockery.registerMock('../../runner/concurrency/index.js', {
       isWorker: function () {
         return true;
@@ -281,7 +281,7 @@ describe('SeleniumServer Transport Tests', function () {
     });
 
     let logFilePath;
-    await SeleniumServerTestSetup({
+    const {client} = await SeleniumServerTestSetup({
       desiredCapabilities: {
         browserName: 'chrome'
       },
@@ -294,8 +294,11 @@ describe('SeleniumServer Transport Tests', function () {
         logFilePath = filePath;
       }
     });
-    assert.ok(/testModuleKey_[0-9]+_selenium-server\.log$/.test(logFilePath));
 
+    // The log file name should include the moduleKey, timestamp and end with _selenium-server.log
+    assert.ok(/testModuleKey_[0-9]{15}_selenium-server\.log$/.test(logFilePath));
+    // The log_file_name should be unchanged
+    assert.strictEqual(client.settings.webdriver.log_file_name, '');
   });
 
   it('test log file path when not running in worker with log_file_name set', async function () {
@@ -312,7 +315,7 @@ describe('SeleniumServer Transport Tests', function () {
     });
 
     let logFilePath;
-    await SeleniumServerTestSetup({
+    const {client} = await SeleniumServerTestSetup({
       desiredCapabilities: {
         browserName: 'chrome'
       },
@@ -329,7 +332,10 @@ describe('SeleniumServer Transport Tests', function () {
       }
     });
 
+    // The log file should include the customModuleKey without the timestamp.
     assert.ok(logFilePath.endsWith('customModuleKey_selenium-server.log'));
+    // No change in the log_file_name value as we're not running in worker
+    assert.strictEqual(client.settings.webdriver.log_file_name, 'customModuleKey');
   });
 
   it('test per-worker log file path when running in worker with log_file_name set', async function () {
@@ -352,7 +358,7 @@ describe('SeleniumServer Transport Tests', function () {
     });
 
     let logFilePath;
-    await SeleniumServerTestSetup({
+    const {client} = await SeleniumServerTestSetup({
       desiredCapabilities: {
         browserName: 'chrome'
       },
@@ -368,7 +374,11 @@ describe('SeleniumServer Transport Tests', function () {
         logFilePath = filePath;
       }
     });
-    assert.ok(/customModuleKey_[0-9]+_selenium-server\.log$/.test(logFilePath));
+
+    // The log file name should include the customModuleKey, timestamp and end with _selenium-server.log
+    assert.ok(/customModuleKey_[0-9]{15}_selenium-server\.log$/.test(logFilePath));
+    // The log_file_name should also be updated to include the timestamp when running in worker
+    assert.ok(/^customModuleKey_[0-9]{15}$/.test(client.settings.webdriver.log_file_name));
   });
 
   it('test create session with selenium server 3 -- with drivers', async function() {

--- a/test/src/service-builders/testSeleniumServer.js
+++ b/test/src/service-builders/testSeleniumServer.js
@@ -262,12 +262,11 @@ describe('SeleniumServer Transport Tests', function () {
   });
 
   it('test per-worker log file path when running in worker', async function () {
-    mockery.registerMock('runner/concurrency/', {
+    mockery.registerMock('../../runner/concurrency/index.js', {
       isWorker: function () {
         return true;
       }
     });
-    
 
     mockery.registerMock('geckodriver', {
       path: ''
@@ -297,6 +296,79 @@ describe('SeleniumServer Transport Tests', function () {
     });
     assert.ok(/testModuleKey_[0-9]+_selenium-server\.log$/.test(logFilePath));
 
+  });
+
+  it('test log file path when not running in worker with log_file_name set', async function () {
+    mockery.registerMock('geckodriver', {
+      path: ''
+    });
+
+    mockery.registerMock('chromedriver', {
+      path: ''
+    });
+
+    mockery.registerMock('@nightwatch/selenium-server', {
+      path: '/path/to/selenium-server-standalone.3.0.jar'
+    });
+
+    let logFilePath;
+    await SeleniumServerTestSetup({
+      desiredCapabilities: {
+        browserName: 'chrome'
+      },
+      selenium: {
+        port: 9999,
+        start_process: true
+      },
+      webdriver: {
+        log_file_name: 'customModuleKey'
+      }
+    }, {
+      onLogFile(filePath) {
+        logFilePath = filePath;
+      }
+    });
+
+    assert.ok(logFilePath.endsWith('customModuleKey_selenium-server.log'));
+  });
+
+  it('test per-worker log file path when running in worker with log_file_name set', async function () {
+    mockery.registerMock('../../runner/concurrency/index.js', {
+      isWorker: function () {
+        return true;
+      }
+    });
+
+    mockery.registerMock('geckodriver', {
+      path: ''
+    });
+
+    mockery.registerMock('chromedriver', {
+      path: ''
+    });
+
+    mockery.registerMock('@nightwatch/selenium-server', {
+      path: '/path/to/selenium-server-standalone.3.0.jar'
+    });
+
+    let logFilePath;
+    await SeleniumServerTestSetup({
+      desiredCapabilities: {
+        browserName: 'chrome'
+      },
+      selenium: {
+        port: 9999,
+        start_process: true
+      },
+      webdriver: {
+        log_file_name: 'customModuleKey'
+      }
+    }, {
+      onLogFile(filePath) {
+        logFilePath = filePath;
+      }
+    });
+    assert.ok(/customModuleKey_[0-9]+_selenium-server\.log$/.test(logFilePath));
   });
 
   it('test create session with selenium server 3 -- with drivers', async function() {

--- a/types/nightwatch-options.d.ts
+++ b/types/nightwatch-options.d.ts
@@ -574,6 +574,15 @@ export interface WebdriverOptions {
 	log_file_name?: string;
 
 	/**
+	 * When running tests in parallel (test workers), each worker spawns its own webdriver process but
+	 * their logs are not written to disk by default. Set this to true to retain webdriver server logs
+	 * from worker processes when running in parallel mode.
+	 *
+	 * @default false
+	 */
+	retain_logs_in_parallel_run?: boolean;
+
+	/**
 	 * List of cli arguments to be passed to the Webdriver process. This varies for each Webdriver implementation.
 	 *
 	 * @default none


### PR DESCRIPTION
This PR fixes missing webdriver / chromedriver log files when Nightwatch runs tests in parallel (worker-threads or child-process workers). Previously worker-mode disabled the log sink, causing writeLogFile() to no-op and resulting in no log files for worker-hosted driver processes.

### Root cause
- `BaseService.needsSinkProcess()` returned false in workers when [`Concurrency.isWorker()` ](https://github.com/nightwatchjs/nightwatch/blob/54c8550c75a16c61827c0bad043c7ffa073a52e6/lib/transport/selenium-webdriver/service-builders/base-service.js#L220)was true, so `BaseService.createService()` set [`[webdriver.log_path = false]` ](https://github.com/nightwatchjs/nightwatch/blob/54c8550c75a16c61827c0bad043c7ffa073a52e6/lib/transport/selenium-webdriver/service-builders/base-service.js#L248)for workers. That made `getLogPath()` return null and `writeLogFile()` return early and hence no file was written.
- No Logs were generated as shown in the below screenshot
![No logs generated for multiple workers](https://github.com/user-attachments/assets/bf8d7c0f-9eab-4d62-b192-fc2632c0d30f)

## Changes Implemented

### Parallel Mode-Specific Logging Behavior

When parallel mode is detected (`process.env.__NIGHTWATCH_PARALLEL_MODE === '1'`), unique log files are created for each Chromedriver instance spun up:

- **Without `log_file_name`:**  
  Log files are named as `<module_key>_<timestamp>.log`, where `<timestamp>` is dynamically generated.

- **With `log_file_name`:**  
  User-configured log file names (e.g., `my_custom_log`) are suffixed with timestamp.
  (e.g., `my_custom_log_<timestamp>.log`).

### Fallback to Default Behavior for Non-Parallel Execution

If parallel mode is not enabled or only a single thread is used:

- The repository’s original logging mechanism is preserved.
- No disruption to existing workflows.
- Outputs are aggregated and logged exactly as originally implemented.

### Files changed
- `lib/transport/selenium-webdriver/index.js`
- `lib/transport/selenium-webdriver/service-builders/base-service.js`

### How to test (locally)
1. Use a Nightwatch config with test_workers enabled .
2. Run parallel tests: `npx nightwatch tests/guide/ --env chrome --workers=2 `
3. Expect one log file per chromedriver spun up  in `webdriver.log_path` (defaults to `./logs`):
4. Inspect file contents `ls -l logs/` and `head -n 50 logs/<file>`.

### Notes
- Single-process behavior is unchanged.
- The per-worker sink is only created where sink support is available (`hasSinkSupport()` still respected).


### After Changes
- I ran ./bin/nightwatch examples/tests/ecosia.js examples/tests/duckDuckGo.js --env chrome
- Without `log_file_name`:
<img width="1470" height="897" alt="Screenshot 2025-12-22 at 9 08 39 PM" src="https://github.com/user-attachments/assets/0845e885-ec66-4f43-91b9-c3b194384afa" />

-With `log_file_name`:
<img width="1467" height="884" alt="Screenshot 2025-12-22 at 9 13 53 PM" src="https://github.com/user-attachments/assets/05888906-93aa-48c1-8828-7dc391039836" />




